### PR TITLE
Move cid redirects to a separate file

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -1,0 +1,3 @@
+{
+    "/cid/1234": "/docs/contributing/markdown-cheat-sheet"
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,8 +4,12 @@
 
 // Documentation page id for open source: sumo-logic-open-source-projects
 
+const fs = require('fs')
+
 const lightCodeTheme = require('prism-react-renderer/themes/vsLight');
 const darkCodeTheme = require('prism-react-renderer/themes/vsDark');
+
+const cidRedirects = JSON.parse(fs.readFileSync('cid-redirects.json').toString())
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
@@ -116,13 +120,9 @@ module.exports = {
     'react-iframe',
     ['@docusaurus/plugin-client-redirects',
       {
-        redirects: [
-          {
-            //CID REDIRECTS: Enter a from: of the /cid=##### with the path to the file for to: for each CID!
-            to: '/docs/contributing/markdown-cheat-sheet',
-            from: '/cid=1234',
-          },
-        ]
+        redirects: Object.entries(cidRedirects).map(
+          ([key, value]) => ({ from: key, to: value })
+        )
       },
     ],
   ],


### PR DESCRIPTION
## Purpose of this pull request

Move the CID redirects to a separate JSON file for easier maintenance.


## Select the type of change:

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [X] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
