### PR TITLE
ci: deploy to production on pushes to main

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,8 +2,8 @@ name: deploy-to-production
 
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
 
 jobs:
   deploy-to-staging:


### PR DESCRIPTION
## Purpose of this pull request

Deploy to production on pushes to main instead of on git tags.

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [X] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
