### PR TITLE
Fix link to old docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,7 +179,7 @@ module.exports = {
     metadata: [{name: 'keywords', content: 'sumo logic, documentation, tutorials, quickstarts'}],
     announcementBar: {
       id: 'announcementBar',
-      content: `⭐️ Welcome to the new Sumo Logic Doc Site! If you want the old site go to https//helpstaging.sumologic.com ⭐️`,
+      content: `⭐️ Welcome to the new Sumo Logic Doc Site! If you want the old site go to https://helpstaging.sumologic.com ⭐️`,
     },
     imageZoom: {
       selector: '.markdown :not(a) > img',


### PR DESCRIPTION
## Purpose of this pull request

Fixes the link to old docs site in the top banner by adding the missing colon `:`. 

## Select the type of change:

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
