### PR TITLE
jmw-isreservedip-syntax

### DIFF
--- a/docs/search/search-query-language/search-operators/isreservedip.md
+++ b/docs/search/search-query-language/search-operators/isreservedip.md
@@ -9,8 +9,12 @@ The isReservedIP operator checks if an IPv4 address is reserved as defined by <a
 
 ## Syntax
 
-* `isReservedIP(\<IPv4_strin\>") as\<fiel\>`
-* `isReservedIP\<IPv4_string_fiel\>) [as\<fiel\>]`
+```sql
+isReservedIP("<IPv4_string>") as <field>
+```
+```sql
+isReservedIP(<IPv4_string_field>) [as <field>]
+```
 
 **Rules**
 


### PR DESCRIPTION
Correct isReservedIP syntax, and make formatting consistent with other is*IP operators

## Purpose of this pull request

This pull request (PR) ...

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
