### PR TITLE
Typo in line 15

### DIFF
--- a/docs/search/search-query-language/group-aggregate-operators/first-last.md
+++ b/docs/search/search-query-language/group-aggregate-operators/first-last.md
@@ -12,7 +12,7 @@ For example, the following image shows a few results in the default sort order. 
 ![new_to_old_default_result_order.png](/img/search/searchquerylanguage/group-aggregate-operators/new_to_old_default_result_order.png)
 
 * The `first` result is indicated with the `#` value of 1. This `first` result has the most recent `Time`.
-* The `last` result is indicated with the `#` value of 1. This `last` result has the oldest `Time`.
+* The `last` result is indicated with the `#` value of 5. This `last` result has the oldest `Time`.
 
 :::tip
 Using the [sort](/docs/search/search-query-language/search-operators/sort) operator allows you to change the default sort order.


### PR DESCRIPTION
## Purpose of this pull request

In line 15: 'last' result should return value of '5', not '1'. The initial doc showed '1' for both lines 14 and 15

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->
Not sure where to find this (#976?)

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [X] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
