### PR TITLE
Fixing table layout

### DIFF
--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/duo-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/duo-source.md
@@ -123,7 +123,7 @@ The following table shows the **config** parameters for a Duo Source.
 | `fields` | JSON Object | No |  | JSON map of key-value fields (metadata) to apply to the Collector or Source. Use the boolean field _siemForward to enable forwarding to SIEM. | modifiable |
 | `domain` | String | Yes |  | Provide your API hostname, such as api-********.duosecurity.com.	modifiable
 | `integration_key` | String | Yes |  | Provide the Duo Integration Key you want to use to authenticate collection requests. | modifiable |
-| `secret_key`	String | Yes |  | Provide the Duo Secret Key you want to use to authenticate collection requests. | modifiable |
+| `secret_key` | String | Yes |  | Provide the Duo Secret Key you want to use to authenticate collection requests. | modifiable |
 | `polling_interval` | Integer | No | 300 | This sets how often the Source checks for new data. | modifiable |
 
 Duo Source JSON example:


### PR DESCRIPTION
Added a missing separator on the `secret_key` line of the fields table.

## Purpose of this pull request

Simple fix to a table formatting issue in the Collection Source documentation for integration with the Cisco Duo API. The row `secret_key` was missing a column separator between the first and second column.

Issue number: 

N/A

## Select the type of change:

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
