### PR TITLE
Add note about V1 ingest budgets

### DIFF
--- a/docs/manage/ingestion-volume/ingest-budgets/assign-collector-ingest-budget.md
+++ b/docs/manage/ingestion-volume/ingest-budgets/assign-collector-ingest-budget.md
@@ -20,7 +20,7 @@ Once you have created an ingest budget you can assign a Collector to it. You ca
 The UI installer for Installed Collectors does not support assigning ingest budgets, use another method.
 
 :::note
-Assigning an Ingest Budget to a Collector is only relavant for V1 Ingest Budgets. V2 Ingest Budgets assign budgets to your log data by **Fields** or built-in metadata fields, and do not use the reserved **`_budget`** field.
+Assigning an Ingest Budget to a Collector is only relevant for V1 Ingest Budgets. V2 Ingest Budgets assign budgets to your log data by **Fields** or built-in metadata fields, and do not use the reserved **`_budget`** field.
 :::
 
 ## Collection page

--- a/docs/manage/ingestion-volume/ingest-budgets/assign-collector-ingest-budget.md
+++ b/docs/manage/ingestion-volume/ingest-budgets/assign-collector-ingest-budget.md
@@ -19,6 +19,10 @@ Once you have created an ingest budget you can assign a Collector to it. You ca
 
 The UI installer for Installed Collectors does not support assigning ingest budgets, use another method.
 
+:::note
+Assigning an Ingest Budget to a Collector is only relavant for V1 Ingest Budgets. V2 Ingest Budgets assign budgets to your log data by **Fields** or built-in metadata fields, and do not use the reserved **`_budget`** field.
+:::
+
 ## Collection page
 
 On the **Manage Data** \> **Collection** \> **[Collection page](/docs/manage/collection)** when editing an existing Collector or creating a new Hosted Collector there is an option, **Assign to a Budget**, that allows you to assign an ingest budget to a Collector.


### PR DESCRIPTION
Assigning ingest budgets to a collector is for V1 budgets only. This does not apply to V2 budgets. This doc needs to be updated with a note to keep people from getting confused.

## Purpose of this pull request

This pull request (PR) ...

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
