### PR TITLE
Added more SLO Beta URLs

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -1164,6 +1164,7 @@
   "/Beta/Cloud-to-Cloud_Integration_Framework": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework",
   "/Beta/Metrics-Rules": "/docs/metrics/metric-rules-editor",
   "/Beta/SLO_Reliability_Management": "/docs/observability/reliability-management-slo",
+  "/Beta/SLO_Reliability_Management/Access_and_Create_SLOs": "/docs/observability/reliability-management-slo",
   "/Dashboards-and-Alerts/Dashboards": "/docs/dashboards-new",
   "/Dashboards-and-Alerts/Dashboards/Chart-Panel-Types": "/docs/dashboards/chart-panel-types",
   "/Dashboards-and-Alerts/Dashboards/Get-Started-with-Dashboards-and-Panels/03Share-Dashboards": "/docs/manage/security/create-allowlist-ip-cidr-addresses",

--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -1163,6 +1163,7 @@
   "/Beta": "/docs/beta",
   "/Beta/Cloud-to-Cloud_Integration_Framework": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework",
   "/Beta/Metrics-Rules": "/docs/metrics/metric-rules-editor",
+  "/Beta/SLO_Reliability_Management": "/docs/observability/reliability-management-slo",
   "/Dashboards-and-Alerts/Dashboards": "/docs/dashboards-new",
   "/Dashboards-and-Alerts/Dashboards/Chart-Panel-Types": "/docs/dashboards/chart-panel-types",
   "/Dashboards-and-Alerts/Dashboards/Get-Started-with-Dashboards-and-Panels/03Share-Dashboards": "/docs/manage/security/create-allowlist-ip-cidr-addresses",


### PR DESCRIPTION
## Purpose of this pull request

Customer reported 404s [here](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/slo) that were linking to deprecated beta pages.

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
