### PR TITLE
Add missing verb to metrics operators parse tip

### DIFF
--- a/docs/metrics/metrics-operators/parse.md
+++ b/docs/metrics/metrics-operators/parse.md
@@ -7,7 +7,7 @@ sidebar_label: parse
 The parse operator parses the specified field to create new fields to use in the metrics query.
 
 :::tip
-If you are querying Graphite metrics, and do not specify the field to be parsed, then the metric name is parsed.
+If you are querying Graphite metrics, and do not specify the field to be parsed, then the metric name will be parsed.
 :::
 
 Each wildcard in the pattern corresponds to a specified field. The parse operator supports both lazy (shortest match) and greedy (longest match wildcard matches.  Use '\*' for a lazy match, or '\*\*' for a greedy match.

--- a/docs/metrics/metrics-operators/parse.md
+++ b/docs/metrics/metrics-operators/parse.md
@@ -7,7 +7,7 @@ sidebar_label: parse
 The parse operator parses the specified field to create new fields to use in the metrics query.
 
 :::tip
-If you are querying Graphite metrics, and do not specify the field to be parsed, the metric name parsed.
+If you are querying Graphite metrics, and do not specify the field to be parsed, then the metric name is parsed.
 :::
 
 Each wildcard in the pattern corresponds to a specified field. The parse operator supports both lazy (shortest match) and greedy (longest match wildcard matches.  Use '\*' for a lazy match, or '\*\*' for a greedy match.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a missing verb (most likely a typoo) in one of metrics operators `parse` tip boxes.

Issue number:  none

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
