### PR TITLE
docs: update telegraf install instructions

### DIFF
--- a/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
+++ b/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
@@ -47,7 +47,7 @@ This section has instructions for installing the latest stable version of Telegr
 If you want to install Telegraf using a .deb file, or on Windows see [Manually install Telegraf from a .deb file](#manually-install-telegraf-on-debian-from-a-deb-file) or [Install Telegraf on Windows](#install-telegraf-on-windows). Telegraf releases are available for all Operating Systems through the portal [downloads page](https://portal.influxdata.com/downloads/).
 :::
 
-1. Add the InfluxData repository on Ubuntu or Debian, run the following command in a terminal window.
+1. Add the InfluxData repository on Ubuntu or Debian, then run the following command in a terminal window:
 
     ```bash
     # influxdata-archive_compat.key GPG fingerprint:

--- a/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
+++ b/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
@@ -51,7 +51,7 @@ If you want to install Telegraf using a .deb file, or on Windows see [Manually i
 
     ```bash
     # influxdata-archive_compat.key GPG fingerprint:
-    #     9D53 9D90 D332 8DC7 D6C8 D3B9 D8FF 8E1F 7DF8 B07E
+    # 9D53 9D90 D332 8DC7 D6C8 D3B9 D8FF 8E1F 7DF8 B07E
     wget -q https://repos.influxdata.com/influxdata-archive_compat.key
     echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
     echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list

--- a/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
+++ b/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
@@ -62,8 +62,8 @@ If you want to install Telegraf using a .deb file, or on Windows see [Manually i
 
     ```bash
     sudo apt-get update && sudo apt-get install telegraf
-    # update /etc/telegraf/telegraf.conf with your specific config
-    # settings then start the service
+    # update /etc/telegraf/telegraf.conf with your
+    # specific config settings, then start the service
     sudo systemctl start telegraf
     ```
 

--- a/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
+++ b/docs/send-data/collect-from-other-data-sources/collect-metrics-telegraf/install-telegraf.md
@@ -47,43 +47,23 @@ This section has instructions for installing the latest stable version of Telegr
 If you want to install Telegraf using a .deb file, or on Windows see [Manually install Telegraf from a .deb file](#manually-install-telegraf-on-debian-from-a-deb-file) or [Install Telegraf on Windows](#install-telegraf-on-windows). Telegraf releases are available for all Operating Systems through the portal [downloads page](https://portal.influxdata.com/downloads/).
 :::
 
-1. Add the InfluxData repository.
+1. Add the InfluxData repository on Ubuntu or Debian, run the following command in a terminal window.
 
-   * To add the repository on Ubuntu, run the following command in a terminal window.
-
-        ```bash
-        wget -qO- https://repos.influxdata.com/influxdb.key | sudo apt-key add -
-        source /etc/lsb-release
-        echo "deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-        ```
-
-    * To add the repository on Debian, run the following commands in a terminal window, skipping the comment lines, which begin with #.
-
-        ```bash
-        # Before adding Influx repository, run this \
-        # so that apt will be able to read the repository.
-        sudo apt-get update && sudo apt-get install apt-transport-https
-
-        # Add the InfluxData key
-        wget -qO-https://repos.influxdata.com/influxdb.key | sudo apt-key add -
-        source /etc/os-release
-        test $VERSION_ID = "7" && echo "deb https://repos.influxdata.com/debian wheezy stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-        test $VERSION_ID = "8" && echo "deb https://repos.influxdata.com/debian jessie stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-        test $VERSION_ID = "9" && echo "deb https://repos.influxdata.com/debian stretch stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-        test $VERSION_ID = "10" && echo "deb https://repos.influxdata.com/debian buster stable" | sudo tee /etc/apt/sources.list.d/influxdb.list
-        ```
+    ```bash
+    # influxdata-archive_compat.key GPG fingerprint:
+    #     9D53 9D90 D332 8DC7 D6C8 D3B9 D8FF 8E1F 7DF8 B07E
+    wget -q https://repos.influxdata.com/influxdata-archive_compat.key
+    echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
+    echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
+    sudo apt-get update && sudo apt-get install telegraf
+    ```
 
 1. To install and start the Telegraf service, run the following commands in a terminal window:
 
     ```bash
     sudo apt-get update && sudo apt-get install telegraf
-    sudo service telegraf start
-    ```
-
-    Or, if your operating system uses systemd (Ubuntu 15.04+, Debian 8+):
-
-    ```bash
-    sudo apt-get update && sudo apt-get install telegraf
+    # update /etc/telegraf/telegraf.conf with your specific config
+    # settings then start the service
     sudo systemctl start telegraf
     ```
 


### PR DESCRIPTION
## Purpose of this pull request

The InfluxData repo updated their GPG key. This updates the instruction to use the new key. Additionally, this provides a single install instruction that works across all deb-based distros.

https://www.influxdata.com/blog/linux-package-signing-key-rotation/
https://github.com/influxdata/telegraf/commit/16744624c6ad2cbc7fe111cb6573518d8b4328ef

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
