### PR TITLE
Enable "See all ... Results" link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -248,7 +248,7 @@ module.exports = {
       // Optional: Algolia search parameters
       //searchParameters: {},
       // Optional: path for search page that enabled by default (`false` to disable it)
-      searchPagePath: false,
+      //searchPagePath: false,
       //... other Algolia params
     },
     prism: {


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes a setting from the Algolia block in the Dinosaurus config file that was preventing the "See all [n] results" link from appearing.

I reached this solution by removing settings and reloading the client. I wish I could link to a Docusaurus or DocSearch source to explain **why** this works, but I have yet to find one. Oddly enough, if you search either Docusaurus' or DocSearch's site for "searchPagePath," you get zero results in both.

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
