### PR TITLE
Fixed code block highlighting in light mode

### DIFF
--- a/src/css/sumo.scss
+++ b/src/css/sumo.scss
@@ -172,6 +172,7 @@ html[data-theme='light'] {
   --ifm-table-stripe-background: rgb(241, 244, 247);
   --ifm-table-head-background: rgba(0, 139, 178, 0.397);
   --ifm-table-border-color: rgba(25, 43, 54, 0.35);
+  --docusaurus-highlighted-code-line-bg: rgba(0,0,0,.1);
   --docsearch-searchbox-background: transparent !important;
   --docsearch-searchbox-focus-background: #efefef !important;
   --docsearch-searchbox-shadow: #efefef !important;


### PR DESCRIPTION
## Purpose of this pull request

Before
<img width="350" alt="Screenshot 2023-01-27 at 11 10 46 PM" src="https://user-images.githubusercontent.com/56411016/215252512-7d9868ba-aa2f-450c-a263-c148b385e077.png">


After
<img width="350" alt="Screenshot 2023-01-27 at 11 10 08 PM" src="https://user-images.githubusercontent.com/56411016/215252518-eb89717d-a2b9-4e0e-8090-c6edc5472c00.png">

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
