### PR TITLE
Adding an important note for S3 SNS notifications

### DIFF
--- a/docs/send-data/hosted-collectors/amazon-aws/aws-s3-source.md
+++ b/docs/send-data/hosted-collectors/amazon-aws/aws-s3-source.md
@@ -189,7 +189,7 @@ The following steps use the AWS SNS Console. You may instead use AWS CloudForma
     :::important
     S3 Event Notifications do not allow you to have overlapping suffixes in two rules if the prefixes are overlapping for the same event type.
 
-    In this scenario, you will likely need to have a single Event Notification for the suffix that sends to an SNS Topic, and then have multiple SNS Subscriptions to the same Topic. This will allow you to have parallel data streams for the same Event Notifications (i.e. one that points to a Sumo Endpoint, and one that points elsewhere).
+    In this scenario, you will likely need to have a single Event Notification for the suffix that sends to an SNS Topic, and then have multiple SNS Subscriptions to the same Topic. This will allow you to have parallel data streams for the same Event Notifications (i.e., one that points to a Sumo Endpoint, and one that points elsewhere).
     :::
 
 When collecting from one AWS S3 bucket with multiple Sumo Sources you need to create a separate topic and subscription for each Source. Subscriptions and Sumo Sources should both map to only one endpoint. If you were to have multiple subscriptions Sumo would collect your objects multiple times.

--- a/docs/send-data/hosted-collectors/amazon-aws/aws-s3-source.md
+++ b/docs/send-data/hosted-collectors/amazon-aws/aws-s3-source.md
@@ -186,6 +186,12 @@ The following steps use the AWS SNS Console. You may instead use AWS CloudForma
 
 ### SNS with one bucket and multiple Sources
 
+    :::important
+    S3 Event Notifications do not allow you to have overlapping suffixes in two rules if the prefixes are overlapping for the same event type.
+
+    In this scenario, you will likely need to have a single Event Notification for the suffix that sends to an SNS Topic, and then have multiple SNS Subscriptions to the same Topic. This will allow you to have parallel data streams for the same Event Notifications (i.e. one that points to a Sumo Endpoint, and one that points elsewhere).
+    :::
+
 When collecting from one AWS S3 bucket with multiple Sumo Sources you need to create a separate topic and subscription for each Source. Subscriptions and Sumo Sources should both map to only one endpoint. If you were to have multiple subscriptions Sumo would collect your objects multiple times.
 
 Each topic needs a separate filter (prefix/suffix) so that collection does not overlap. For example, the following image shows a bucket configured with two notifications that have filters (prefix/suffix) set to notify Sumo separately about new objects in different folders.


### PR DESCRIPTION
S3 does not support overlapping suffixes for event notifications. I have provided a workaround for customers.

## Purpose of this pull request

This pull request (PR) ...

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
