### PR TITLE
Remove 'Preview Apps' - deprecated

### DIFF
--- a/docs/get-started/apps-integrations.md
+++ b/docs/get-started/apps-integrations.md
@@ -204,23 +204,8 @@ This Dashboard provides several ways to monitor your logs based on the metadata 
 
 ### Collectors and Source Monitoring
 
-The Panels in the Collector and Source Monitoring Dashboard help you
-keep an eye on the machines running Collectors and Sources. If a machine begins to have issues (such as no logs being uploaded to Sumo Logic) you'll know at a glance.
+The Panels in the Collector and Source Monitoring Dashboard help you keep an eye on the machines running Collectors and Sources. If a machine begins to have issues (such as no logs being uploaded to Sumo Logic) you'll know at a glance.
 
 * **Issues by Collector.** This Panel displays the number of log messages that contain error, exception, or failure terms by Collector.
 * **Issues by Source.** Shows the number of log messages that contain error, exception, or failure terms by each Collector's Source.
 * **Collector Issue Monitoring.** Displays warnings generated over time for each Collector in your deployment.
-
-
-
-## Preview Apps
-
-Preview Apps are Sumo Logic Apps that are currently under development, but are not yet released or officially supported. They appear in the Library under the **Preview** tab. You can install and use Preview Apps to test how well their use cases work for you, and provide feedback to Sumo Logic.
-
-Preview Apps that have the highest customer adoption rate will become the first in the queue to be adopted and moved to the Apps tab, where they will be officially supported by Sumo Logic.
-
-As Preview Apps are iterated, updated, and finally released, you will need to reinstall the App to get the latest version.
-
-:::sumo Sumo Logic Community
-Because Preview Apps are not fully developed, they are not officially supported by Sumo Logic Support, and documentation instructions are not final. To provide feedback, report a bug, or get help, log into the [Sumo Logic Community](https://community.sumologic.com/s/topic/0TOE0000000g6auOAA/Apps), and post to the topic for your Preview App. 
-:::


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes deprecated section (see Asana ticket for details)

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204008432606240