### PR TITLE
TRIDENT-17594 - CSE comments syntax

### DIFF
--- a/docs/cse/rules/cse-rules-syntax.md
+++ b/docs/cse/rules/cse-rules-syntax.md
@@ -45,6 +45,20 @@ The following expression divides `error_count` by `user_count`.
 
 `error_count / user_count`
 
+## /*  */
+
+The forward slash and asterisk characters (/*  */) comment out lines. 
+
+For CSE rules, two forward slashes (//) are *not* supported for commenting out lines. Two forward slashes are allowed in CIP, however, for [comments in search queries](/docs/search/get-started-with-search/search-basics/comments-search-queries/).
+
+**Syntax**
+
+`/*  */`
+
+**Example**
+
+`/* This is a comment. */`
+
 ## <
 
 The less than (<) character returns “true” if the expression is less than the other expression.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a description of the comments syntax (/* */) to the following article:
[https://help.sumologic.com/docs/cse/rules/cse-rules-syntax](https://help.sumologic.com/docs/cse/rules/cse-rules-syntax)

Issue number: 
[TRIDENT-17594 ](https://jasklabs.atlassian.net/browse/TRIDENT-17594)

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->
- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
