### PR TITLE
Adding requirement of credits account for tracing data

### DIFF
--- a/docs/send-data/hosted-collectors/http-source/otlp.md
+++ b/docs/send-data/hosted-collectors/http-source/otlp.md
@@ -8,7 +8,16 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 <img src={useBaseUrl('img/send-data/otel-color.svg')} alt="Thumbnail icon" width="45"/>
 
-An OTLP/HTTP Source is an endpoint for receiving OTLP-formatted Logs, Metrics, and Traces. This is an alternative option to installing an OpenTelemetry Collector for sending OTLP data to Sumo Logic. 
+An OTLP/HTTP Source is an endpoint for receiving OTLP-formatted Logs, Metrics, and Traces. This is an alternative option to installing an OpenTelemetry Collector for sending OTLP data to Sumo Logic.
+
+## Tracing Prerequisites
+
+As indictated [here](/docs/apm/traces/quickstart.md#prerequisites) the following preprequisites apply before Sumo Logic can accept tracing data:
+
+| Account Type | Account Level |
+|:--|:--|
+| Credits | Enterprise Operations and Enterprise Suite. Essentials get up to 5 GB a day. |
+
 
 ## Create an OTLP/HTTP Source
 

--- a/docs/send-data/hosted-collectors/http-source/otlp.md
+++ b/docs/send-data/hosted-collectors/http-source/otlp.md
@@ -12,7 +12,7 @@ An OTLP/HTTP Source is an endpoint for receiving OTLP-formatted Logs, Metrics, 
 
 ## Tracing Prerequisites
 
-As indictated [here](/docs/apm/traces/quickstart.md#prerequisites) the following preprequisites apply before Sumo Logic can accept tracing data:
+As indicated [here](/docs/apm/traces/quickstart/#prerequisites), the following prerequisites apply before Sumo Logic can accept tracing data:
 
 | Account Type | Account Level |
 |:--|:--|


### PR DESCRIPTION
As indicated here https://help.sumologic.com/docs/apm/traces/quickstart/#prerequisites tracing requires credit plan and specific account type. Tracing data is not ingested trough OTLP source for other accounts (where tracing data limit in Zuora is 0)

## Purpose of this pull request

This pull request (PR) ...

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
