### PR TITLE
Remove beta note from entity relationship graph section

### DIFF
--- a/docs/cse/records-signals-entities-insights/about-cse-insight-ui.md
+++ b/docs/cse/records-signals-entities-insights/about-cse-insight-ui.md
@@ -189,10 +189,6 @@ The cumulative severity value is color coded: cyan for less than 12, orange for 
 
 #### About the Entities tab graph view
 
-:::note
-This section describes a feature which is available to all customers but is currently in Beta. If you encounter any issues with this feature, please report them to Sumo Logic Support. Thank you!
-:::
-
 The screenshot below shows the **Entities** tab **graph** view for an Insight.
 
 ![related-entity-graph.png](/img/cse/related-entity-graph.jpg)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the beta note from this section:
https://help.sumologic.com/docs/cse/records-signals-entities-insights/about-cse-insight-ui/#about-the-entities-tab-graph-view

Issue number: 
Asana ticket - https://app.asana.com/0/1183741177809740/1204229287097769/f

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
