### PR TITLE
Issue 2180 - Add limited availability note

### DIFF
--- a/docs/cse/automation-service/about-automation-service.md
+++ b/docs/cse/automation-service/about-automation-service.md
@@ -13,6 +13,13 @@ The Automation Service for Cloud SIEM Enterprise (CSE) uses [Cloud SOAR automati
 
 You can interact with the service through [automations](/docs/cse/automation-service/automation-service-automations), which execute playbooks. [Playbooks](/docs/cse/automation-service/automation-service-playbooks)  are composed of one or more [actions](/docs/cse/automation-service/automation-service-playbooks#add-an-action-node-to-a-playbook) with a workflow that could include parallel actions and logic steps. Actions are included with [integrations](/docs/cse/automation-service/automation-service-integrations). Sumo Logic provides a number of integrations, actions, and playbooks with the service that you can customize. You can also create your own.
 
+
+:::info Limited availability
+The Automation Service is available on a limited availability (LA) basis. This means the feature is fully implemented and supported, and is available to all customers, but is only deployed in customer environments upon request. If you would like the Automation Service enabled in your Cloud SIEM Enterprise environment, contact your Sumo Logic account representative.
+
+Cloud SOAR automation [App Central](/docs/cloud-soar/automation/#app-central), where you can browse the full integration and playbook catalog, is not yet connected to the Automation Service. A selection of popular integrations have been added to your environment automatically, but the full list of [available integrations](/docs/cse/automation-service/automation-service-integrations#available-integrations) is included. Contact your Sumo Logic account representative if you would like to have one of these integrations added to your environment, if you would like documentation for a specific integration, or if you're interested in an integration that's not listed.
+:::
+
 ## Differences compared to Cloud SOAR
 
 The Automation Service differs from Cloud SOAR in the following ways:
@@ -22,11 +29,6 @@ The Automation Service differs from Cloud SOAR in the following ways:
 * The Automation Service does not include the incident and case management features from Cloud SOAR.
 * Playbooks, integrations, and actions in this version may differ from those in [Cloud SOAR automation](/docs/cloud-soar/automation/). 
 
-:::info Limited availability
-The Automation Service is available on a limited availability (LA) basis. This means the feature is fully implemented and supported, and is available to all customers, but is only deployed in customer environments upon request. If you would like the Automation Service enabled in your Cloud SIEM Enterprise environment, contact your Sumo Logic account representative.
-
-Cloud SOAR automation [App Central](/docs/cloud-soar/automation/#app-central), where you can browse the full integration and playbook catalog, is not yet connected to the Automation Service. A selection of popular integrations have been added to your environment automatically, but the full list of [available integrations](/docs/cse/automation-service/automation-service-integrations#available-integrations) is included. Contact your Sumo Logic account representative if you would like to have one of these integrations added to your environment, if you would like documentation for a specific integration, or if you're interested in an integration that's not listed.
-:::
 
 ## Benefits
 

--- a/docs/cse/automation-service/automation-service-automations.md
+++ b/docs/cse/automation-service/automation-service-automations.md
@@ -7,6 +7,7 @@ description: Learn how automations run playbooks to add enrichments and create n
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+{@import ../../reuse/automation-service-la-note.md}
 
 Automations run playbooks to add enrichments and create notifications for either Insights or Entities. You can set automations to run automatically when Insights are created or closed, or you can run them manually.
 

--- a/docs/cse/automation-service/automation-service-bridge.md
+++ b/docs/cse/automation-service/automation-service-bridge.md
@@ -7,7 +7,7 @@ description: Learn how to install a bridge to allow running custom actions or in
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-
+{@import ../../reuse/automation-service-la-note.md}
 
 You can only run custom actions or integrations outside of the Sumo Logic cloud in an "on-premise" environment. For on-premise environments, you need to install a bridge as described below.
 

--- a/docs/cse/automation-service/automation-service-integrations.md
+++ b/docs/cse/automation-service/automation-service-integrations.md
@@ -7,6 +7,7 @@ description: Learn how integrations are connectors to applications from industry
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+{@import ../../reuse/automation-service-la-note.md}
 
 Integrations are connectors to applications from industry-leading network and security vendors. Playbooks run actions provided by resources in integrations.      
 

--- a/docs/cse/automation-service/automation-service-playbooks.md
+++ b/docs/cse/automation-service/automation-service-playbooks.md
@@ -7,7 +7,7 @@ description: Learn about playbooks. A playbook is a predefined set of actions an
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-
+{@import ../../reuse/automation-service-la-note.md}
 
 A playbook is a predefined set of actions and conditional statements that run in an automated workflow to respond to a certain event or incident type. Playbooks can allow your organization's teams to respond to an incident in a consistent, focused, and repeatable fashion.
 

--- a/docs/reuse/automation-service-la-note.md
+++ b/docs/reuse/automation-service-la-note.md
@@ -1,0 +1,3 @@
+:::info Limited availability
+The Automation Service is available on a limited availability (LA) basis. This means the feature is fully implemented and supported, and is available to all customers, but is only deployed in customer environments upon request. For more information, see [About the Automation Service](/docs/cse/automation-service/about-automation-service/).
+:::


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR)
- Moves the limited availability note up in the "About Automation Service" article.
- Adds a reusable note about limited availability to the top of the other Automation Service articles.

Issue number: 
[GitHub issue #2180](https://github.com/SumoLogic/sumologic-documentation/issues/2180)

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->
- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
