### PR TITLE
Update mysql.md - Parsing error from sample telegraf.conf

### DIFF
--- a/docs/integrations/databases/mysql.md
+++ b/docs/integrations/databases/mysql.md
@@ -232,10 +232,10 @@ primary:
         gather_file_events_stats = true
         gather_perf_events_statements = true
         [inputs.mysql.tags]
-        environment: "ENV_TO_BE_CHANGED"
+        environment = "ENV_TO_BE_CHANGED"
         component = "database"
         db_system = "mysql"
-        db_cluster: "ENV_TO_BE_CHANGED"
+        db_cluster = "ENV_TO_BE_CHANGED"
         db_cluster_address = "ENV_TO_BE_CHANGED"
         db_cluster_port = "ENV_TO_BE_CHANGED"
     tailing-sidecar: sidecarconfig;slowlog:data:/bitnami/mysql/data/mysql-release-0-slow.log


### PR DESCRIPTION
Replaced the ":" in the telegraf.conf example to a "=". The ":" was resulting in a parsing error when starting telegraf.

## Purpose of this pull request

This pull request (PR) is to fix the sample telegraf.conf. It is currently formatted incorrectly and telegraf cannot be started.

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
