### PR TITLE
Fix reuse for Cloud SOAR API article

### DIFF
--- a/docs/api/cloud-soar.md
+++ b/docs/api/cloud-soar.md
@@ -14,4 +14,4 @@ The Cloud SOAR APIs allow you to manage incidents, triage, and other Cloud SOAR 
 
 {@import ../reuse/api-intro.md}
 
-{@import ../reuse/cse-api-table.md}
+{@import ../reuse/csoar-api-table.md}

--- a/docs/cloud-soar/cloud-soar-apis.md
+++ b/docs/cloud-soar/cloud-soar-apis.md
@@ -13,5 +13,5 @@ The Cloud SOAR APIs allow you to manage incidents, triage, and other Cloud SOAR 
 
 {@import ../reuse/api-intro.md}
 
-{@import ../reuse/cse-api-table.md}
+{@import ../reuse/csoar-api-table.md}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a reuse call in this article:
https://help.sumologic.com/docs/api/cloud-soar/

It erroneously called "/reuse/cse-api-table" instead of "/reuse/csoar-api-table".

Issue number: None

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
