### PR TITLE
Remove data retention section

### DIFF
--- a/docs/cse/administration/cse-data-retention.md
+++ b/docs/cse/administration/cse-data-retention.md
@@ -26,3 +26,10 @@ This table lists where, and for how long, different types of CSE data are retain
 * Signals that are not attached to Insights are retained in CSE:
     * For 90 days if suppressed. (As of October 1, 2022, this will change to 30 days.)
     * For 365 days if unsuppressed.
+* Playbook and action executions are retained in CSE for 2 years. For those that need to ensure HIPAA compliance, we delete the data after 7 years.
+
+### Custom retention periods
+
+You can request retention periods different from those declared in the tables above, as long as the retention period requested is greater than 1 day and less than 5000 days.
+
+In order to do that, open a [Support ticket](/docs/get-started/help#support) with your request.

--- a/docs/cse/automation-service/about-automation-service.md
+++ b/docs/cse/automation-service/about-automation-service.md
@@ -174,40 +174,6 @@ The [CSE API](/docs/cse/administration/cse-apis/) supports automations. Endpoint
 
 The Sumo Logic Terraform provider also supports automations. For more information, see the [Sumo Logic Terraform documentation](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs).
 
-:::tip
+:::note
 The Automation Service uses the [Cloud SOAR API](/docs/cloud-soar/cloud-soar-apis). 
 :::
-
-
-### Data retention
-
-This section lists the retention period for each type of data generated. 
-
-#### Default retention periods by data type
-
-We automatically delete the following customer data according to the table retention period below, except for those that need to ensure HIPAA compliance.
-
-| Data type | Retention period |
-| :-- | :-- |
-| Incidents | 2 years |
-| Triage | 2 years |
-| Entities | 2 years |
-| Playbook and action executions | 2 years |
-
-For those that need to ensure HIPAA compliance, we delete data following the retention periods below. Please keep in mind that if a customer needs to follow HIPAA compliance, it is important to explicitly communicate this when requesting Automation Service activation.
-
-| Data type | Retention period |
-| :-- | :-- |
-| Incidents | 7 years |
-| Triage | 7 years |
-| Entities | 7 years |
-| Playbook and action executions | 7 years |
-| CSE Records | Records (normalized logs) are stored in the partitions whose names begin with the string `sec_records`. There is one partition for each Record type. <br/><br/>There is no additional charge for storage of Records.| 90 days |
-| CSE Signals | Stored in the `sec_signal` partition.<br/><br/>There is no additional charge for storage of Signals. | 2 years |   
-| CSE Insights | The `sumologic_system_events` partition contains Insights and Insight-related events that result from system actions. <br/><br/>The `sumologic_audit_events` partition contains Insights and Insight-related events that result from user actions.<br/><br/>There is a charge for storage of Insight-related data in the audit indexes. Note however the volume of data is typically very low compared to log ingestion levels. | By default, these partitions have a retention period of 30 days. This period is [customer-configurable](/docs/get-started/help#support). |
-
-#### Custom retention periods
-
-You can request retention periods different from those declared in the tables above, as long as the retention period requested is greater than 1 day and less than 5000 days.
-
-In order to do that, please open a [Support ticket](/docs/get-started/help#support) with your request.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the "Data retention" section from "About the Automation Service" article:
https://help.sumologic.com/docs/cse/automation-service/about-automation-service/#data-retention

Issue number: 
GitHub issue #2572 

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
