### PR TITLE
fix(send-data/opentelemetry-collector): add missing `-InstallHostMetrics` flag for Windows installer

### DIFF
--- a/docs/send-data/opentelemetry-collector/install-collector-windows.md
+++ b/docs/send-data/opentelemetry-collector/install-collector-windows.md
@@ -57,7 +57,7 @@ The script is going to perform the following operations:
 |:---------------|:----------------|:-------------|
 | `-InstallationToken` | Installation token      | Yes       |
 | `-Tags`         | Sets tags for collector. This argument should be a map. | Yes, for example `@{"host.group" = "default"; "deployment.environment" = "default"}` |
-| `-InstallHostMetrics` | Install the hostmetrics configuration to collect host metrics. The default is `$False`. | Yes, for example `-InstallHostMetrics $True` or `-InstallHostMetrics $False` |
+| `-InstallHostMetrics` | Installs the hostmetrics configuration to collect host metrics. The default is `$False`. | Yes, for example: `-InstallHostMetrics $True` or `-InstallHostMetrics $False`. |
 
 ### UI Installation via App Catalog
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds missing `-InstallHostMetrics` flag description for the Windows installer of the Sumo OT distro.

Issue number: SUMO-222989

## Select the type of change:

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
