### PR TITLE
Change "Cloud SIEM/SOAR" to "Security" in guides list

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -346,7 +346,7 @@ module.exports = {
               {
                 type: 'docSidebar',
                 sidebarId: 'security',
-                label: 'Cloud SIEM/SOAR',
+                label: 'Security',
                 icon: 'security',
               },
               {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes "Cloud SIEM/SOAR" to "Security" in the Guides dropdown list:
<img width="201" alt="Cloud SIEM:SOAR in guides dropdown" src="https://github.com/SumoLogic/sumologic-documentation/assets/127961815/76b5a5b4-55c4-49c2-8153-0ffc7aacb022">

Issue number: None

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
