### PR TITLE
Fix for issue 2654 - Provide certificate information in Trend Micro article

### DIFF
--- a/docs/integrations/security-threat-detection/trend-micro-deep-security.md
+++ b/docs/integrations/security-threat-detection/trend-micro-deep-security.md
@@ -126,7 +126,7 @@ Note the spaces with `Deep Security Manager`.
      ```
 1. **Server Name**. Enter the value that was shown in the **Host** field on the **Cloud Syslog Source Token** page when you configured the Cloud Syslog Source above.
 2. **Server Port**.  Enter the value that was shown in the **Port** field on the **Cloud Syslog Source Token** page when you configured the Cloud Syslog Source above.
-3. **Transport**. Leave "TLS" selected.
+3. **Transport**. Leave "TLS" selected. To check your connection for TLS, see [Troubleshooting](/docs/send-data/hosted-collectors/cloud-syslog-source#troubleshooting) in our Cloud Syslog Source article.
 4. Click **OK**.
 
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) provides a fix for Issue #2654 by adding a link to Step 2 substep 7 of this article:
https://help.sumologic.com/docs/integrations/security-threat-detection/trend-micro-deep-security/#step-2-configure-sumo-as-a-syslog-server-in-trend-micro-deep-security

Issue number: #2654 

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
