### PR TITLE
Fix link to Cloud SOAR on help home page

### DIFF
--- a/src/helper/features.js
+++ b/src/helper/features.js
@@ -179,7 +179,7 @@ export const features4 = [
       description='SOAR description'>
       Modernize and automate your SOC for faster response times.
     </Translate>),
-    link: 'https://www.sumologic.com/solutions/cloud-soar',
+    link: 'docs/cloud-soar',
   },
 ];
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a link to Cloud SOAR on our main help page:
https://help.sumologic.com/

Issue number: GitHub issue #2749 

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
