### PR TITLE
Add cpawar29 to .clabot file

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -107,7 +107,8 @@
     "gbertolinii",
     "msinghsumologic",
     "yzgyyang",
-    "sumo-ppatel"
+    "sumo-ppatel",
+    "cpawar29"
   ],
   "message": "Thank you for your contribution! As this is an open source project, we require contributors to sign our Contributor License Agreement and do not have yours on file. To proceed with your PR, please [sign your name here](https://forms.gle/YgLddrckeJaCdZYA6) and we'll add you to our approved list of contributors.",
   "label": "cla-signed",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds @cpawar29 to the .[clabot](https://github.com/SumoLogic/sumologic-documentation/blob/main/.clabot) file.

Issue number: Relates to PR #2754 

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
