### PR TITLE
Fix reference to Security Foundations app

### DIFF
--- a/docs/cloud-security-analytics/threat-detection-and-investigation.md
+++ b/docs/cloud-security-analytics/threat-detection-and-investigation.md
@@ -43,7 +43,7 @@ Attacks may persist without further investigation and patches, so it’s critica
 ## Pre-built apps for threat detection and investigation
 
 [Install](/docs/get-started/apps-integrations) the following apps to get dashboards, queries, and alerting for security monitoring and threat investigation. 
-* [**Security Foundations**](/docs/integrations/sumo-apps/security-analytics/). App for alert analysis and Entity risk assessment. 
+* [**Security Analytics**](/docs/integrations/sumo-apps/security-analytics/). App for alert analysis and Entity risk assessment. 
 * [**Security and threat detection**](/docs/integrations/security-threat-detection/). Apps for security products, such as firewall tools, endpoint protection applications, and security automation and orchestration programs. For ex ample, the [Threat Intel Quick Analysis](/docs/integrations/security-threat-detection/threat-intel-quick-analysis/) app comes preloaded with queries and dashboards that leverage CrowdStrike’s threat intelligence database. 
 * [**Cloud security monitoring and analytics**](/docs/integrations/cloud-security-monitoring-analytics/). Apps that provide security insights for data sources such as Windows, Linux, AWS CloudTrail, AWS VPC Flows, and Palo Alto Networks Firewalls. 
 * [**Global Intelligence Service**](/docs/integrations/global-intelligence/). Apps that provide real-time security intelligence for detection, prioritization, investigation, and workflow.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a reference to the Security Foundations app from the following article, because the app hasn't released yet:
https://help.sumologic.com/docs/cloud-security-analytics/threat-detection-and-investigation/#pre-built-apps-for-threat-detection-and-investigation

Issue number: None

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
