### PR TITLE
Add Cloud SIEM content release notes for August 22, 2023

### DIFF
--- a/blog-cse/2023-08-22-content.md
+++ b/blog-cse/2023-08-22-content.md
@@ -1,0 +1,31 @@
+---
+title: August 22, 2023 - Content Release
+hide_table_of_contents: true
+keywords:
+  - rules
+  - log mappers
+image: https://help.sumologic.com/img/sumo-square.png
+authors:
+  - url: https://help.sumologic.com/release-notes-cse/rss.xml
+    image_url: /img/release-notes/rss-orange.png
+---
+
+This release contains updates to MITRE tags used in several rules that have been deprecated, removed, or were otherwise invalid. Other changes are enumerated below.
+
+#### Rules
+
+* [New] MATCH-S00886 Suspicious chmod Execution
+   * This alert looks for a "chmod" execution on a file that is found on the `/tmp` directory of a Linux or macOS host. Threat actors may download and copy files to this directory and add execution bits or change permissions on these files.
+* [Updated] MATCH-S00516 Antivirus Ransomware Detection
+* [Updated] MATCH-S00534 MacOS - Re-Opened Applications
+* [Updated] MATCH-S00149 PowerShell File Download
+* [Updated] MATCH-S00342 Suspicious use of Dev-Tools-Launcher
+
+#### Log Mappers
+
+* [Updated] Microsoft Defender for Cloud - Security Alerts
+   * Adds support for Security Alerts via Azure Activity Log
+* [Updated] Zscaler - Nanolog Streaming Service - JSON
+   * Adds alternate values for NSS mappers to ensure proper normalization
+* [Updated] Zscaler Firewall
+   * Adds alternate values for ZScaler Firewall mappers to ensure proper normalization


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds Cloud SIEM content release notes here:
https://help.sumologic.com/release-notes-cse/2023/08/22/content/

Issue number: None. Request made by @jc-sumo. See [#sbu-threat-labs](https://sumologic.slack.com/archives/C03ASV6SJV8/p1692738696597539) Slack channel for the internal release notes announcement.

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
