### PR TITLE
Fix "Manage Organization Settings" article

### DIFF
--- a/docs/manage/manage-subscription/manage-org-settings.md
+++ b/docs/manage/manage-subscription/manage-org-settings.md
@@ -31,8 +31,8 @@ For Cloud Flex:
 
 1. In the left navigation bar of the UI, select **Administration** > **Account**. 
 1. Access the appropriate menu for your [account type](#availability):
-     * Cloud Flex Credits: At the top select **Manage Organization > Change Organization Name**.
-     * Cloud Flex: From the kebob menu at the top select **Change Organization Name**.
+     * Cloud Flex Credits: From the kebob menu at the top select **Change Organization Name**.
+     * Cloud Flex: At the top select **Manage Organization > Change Organization Name**.
 1. At the prompt, enter a new organization name in the text field.
 1. Click **Change Organization Name.** <br/><img src={useBaseUrl('img/subscriptions/Change_Organization_Name_prompt.png')} alt="Change_Organization_Name_prompt.png" width="450"/>
 
@@ -44,8 +44,8 @@ After you make this change, you will not be able to edit the account owner.
 
 1. In the left navigation bar of the UI, select **Administration** > **Account**.
 1. Access the appropriate menu for your [account type](#availability):
-     * Cloud Flex Credits: At the top select **Manage Organization > Change Account Owner**.
-     * Cloud Flex: From the kebob menu at the top select **Change Account Owner**.
+     * Cloud Flex Credits: From the kebob menu at the top select **Change Account Owner**.
+     * Cloud Flex: At the top select **Manage Organization > Change Account Owner**.
 1. In the prompt dialog, enter a new account owner in the text field.
 1. click **Change Account Owner**. <br/><img src={useBaseUrl('img/subscriptions/Change_account_owner_prompt.png')} alt="Change_account_owner_prompt.png" width="450"/>
 
@@ -102,8 +102,8 @@ You must be the account owner of the Sumo Logic account to change the account su
 
 1. Go to **Administration** > **Account** and select the details icon at the top.
 1. Access the appropriate menu for your [account type](#availability):
-     * Cloud Flex Credits: At the top select **Manage Organization > Change Account Owner**.
-     * Cloud Flex: From the kebob menu at the top select **Change Account Subdomain**.
+     * Cloud Flex Credits: From the kebob menu at the top select **Change Account Subdomain**.
+     * Cloud Flex: At the top select **Manage Organization > Change Account Owner**.
 1. Enter a new subdomain name. The name must be between 4 and 63 characters in length at least four characters in length, and can contain lower case letters, numbers, and dashes only. <br/><img src={useBaseUrl('img/subscriptions/change-subdomain-name.png')} alt="change-subdomain-name.png"/>
 1. Click **Change Subdomain** Name to update the name.
 1. You will be automatically logged out and redirected to the new subdomain login page. 

--- a/docs/manage/manage-subscription/manage-org-settings.md
+++ b/docs/manage/manage-subscription/manage-org-settings.md
@@ -32,7 +32,7 @@ For Cloud Flex:
 1. In the left navigation bar of the UI, select **Administration** > **Account**. 
 1. Access the appropriate menu for your [account type](#availability):
      * Cloud Flex Credits: From the kebab menu at the top, select **Change Organization Name**.
-     * Cloud Flex: At the top select **Manage Organization > Change Organization Name**.
+     * Cloud Flex: At the top, select **Manage Organization > Change Organization Name**.
 1. At the prompt, enter a new organization name in the text field.
 1. Click **Change Organization Name.** <br/><img src={useBaseUrl('img/subscriptions/Change_Organization_Name_prompt.png')} alt="Change_Organization_Name_prompt.png" width="450"/>
 

--- a/docs/manage/manage-subscription/manage-org-settings.md
+++ b/docs/manage/manage-subscription/manage-org-settings.md
@@ -102,8 +102,8 @@ You must be the account owner of the Sumo Logic account to change the account su
 
 1. Go to **Administration** > **Account** and select the details icon at the top.
 1. Access the appropriate menu for your [account type](#availability):
-     * Cloud Flex Credits: From the kebob menu at the top select **Change Account Subdomain**.
-     * Cloud Flex: At the top select **Manage Organization > Change Account Owner**.
+     * Cloud Flex Credits: From the kebab menu at the top, select **Change Account Subdomain**.
+     * Cloud Flex: At the top, select **Manage Organization > Change Account Owner**.
 1. Enter a new subdomain name. The name must be between 4 and 63 characters in length at least four characters in length, and can contain lower case letters, numbers, and dashes only. <br/><img src={useBaseUrl('img/subscriptions/change-subdomain-name.png')} alt="change-subdomain-name.png"/>
 1. Click **Change Subdomain** Name to update the name.
 1. You will be automatically logged out and redirected to the new subdomain login page. 

--- a/docs/manage/manage-subscription/manage-org-settings.md
+++ b/docs/manage/manage-subscription/manage-org-settings.md
@@ -44,8 +44,8 @@ After you make this change, you will not be able to edit the account owner.
 
 1. In the left navigation bar of the UI, select **Administration** > **Account**.
 1. Access the appropriate menu for your [account type](#availability):
-     * Cloud Flex Credits: From the kebob menu at the top select **Change Account Owner**.
-     * Cloud Flex: At the top select **Manage Organization > Change Account Owner**.
+     * Cloud Flex Credits: From the kebab menu at the top, select **Change Account Owner**.
+     * Cloud Flex: At the top, select **Manage Organization > Change Account Owner**.
 1. In the prompt dialog, enter a new account owner in the text field.
 1. click **Change Account Owner**. <br/><img src={useBaseUrl('img/subscriptions/Change_account_owner_prompt.png')} alt="Change_account_owner_prompt.png" width="450"/>
 

--- a/docs/manage/manage-subscription/manage-org-settings.md
+++ b/docs/manage/manage-subscription/manage-org-settings.md
@@ -31,7 +31,7 @@ For Cloud Flex:
 
 1. In the left navigation bar of the UI, select **Administration** > **Account**. 
 1. Access the appropriate menu for your [account type](#availability):
-     * Cloud Flex Credits: From the kebob menu at the top select **Change Organization Name**.
+     * Cloud Flex Credits: From the kebab menu at the top, select **Change Organization Name**.
      * Cloud Flex: At the top select **Manage Organization > Change Organization Name**.
 1. At the prompt, enter a new organization name in the text field.
 1. Click **Change Organization Name.** <br/><img src={useBaseUrl('img/subscriptions/Change_Organization_Name_prompt.png')} alt="Change_Organization_Name_prompt.png" width="450"/>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes an error I introduced with PR #3086 in this article:
https://help.sumologic.com/docs/manage/manage-subscription/manage-org-settings/

I needed to flip the "Cloud Flex Credits" and "Cloud Flex" instructions. The kebob menu is used for Cloud Flex Credits! 🤦 

Issue number: Original issue was #3084 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
