### PR TITLE
Update mysql.md

### DIFF
--- a/docs/integrations/databases/mysql.md
+++ b/docs/integrations/databases/mysql.md
@@ -468,7 +468,6 @@ Sumo Logic supports collecting logs via a local log file. Local log files can be
        slow_query_log=1
        slow_query_log_file = /var/log/mysql/mysql-slow.log
        long_query_time=2
-       long_query_time=2
    ```
      * [Error Logs](https://dev.mysql.com/doc/refman/5.7/en/slow-query-log.html). By default, error logs are enabled and are logged at file specified by the `log_error` key.
      * [Slow Query Logs](https://dev.mysql.com/doc/refman/5.7/en/slow-query-log.html). `slow_query_log=1` enables logging of slow queries to the file specified by `slow_query_log_file`. Setting `long_query_time=2` will cause queries that take more than two seconds to execute to be logged. The default value of `long_query_time` is 10 seconds.


### PR DESCRIPTION
long_query_time = 2 is written twice, which is redundant, a prospect recently had to troubleshoot for an hour since mysql conf file kept giving an error because of this.

## Purpose of this pull request

This pull request (PR) ...

Issue number: 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
