### PR TITLE
Remove Gigamon ThreatInsight

### DIFF
--- a/docs/cse/ingestion/products-with-log-mappings.md
+++ b/docs/cse/ingestion/products-with-log-mappings.md
@@ -199,10 +199,6 @@ which CSE provides built-in log mapping and parsing support. 
 
 * Fortigate
 
-## Gigamon
-
-* ThreatInsight
-
 ## GitHub
 
 * GitHub

--- a/docs/integrations/partner-ecosystem-apps.md
+++ b/docs/integrations/partner-ecosystem-apps.md
@@ -20,7 +20,6 @@ Sumo Logic Partner Ecosystem Apps are provided and supported by our partner netw
 * [Code42](https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Integrate_Code42_with_Sumo_Logic)
 * [Cybereason](https://github.com/SumoLogic/sumologic-public-partner-apps/tree/master/Cybereason)
 * [Cyral](https://github.com/SumoLogic/sumologic-public-partner-apps/tree/master/Cyral)
-* [Gigamon ThreatINSIGHT](https://github.com/SumoLogic/sumologic-public-partner-apps/tree/master/Gigamon_ThreatINSIGHT)
 * [Gigamon HAWK](https://github.com/SumoLogic/sumologic-public-partner-apps/tree/master/Gigamon_HAWK)
 * [LambdaTest](https://github.com/SumoLogic/sumologic-public-partner-apps/tree/master/LambdaTest)
 * [Lucidum](https://github.com/SumoLogic/sumologic-public-partner-apps/tree/master/Lucidum)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes Gigamon ThreatInsight from these articles:
- https://help.sumologic.com/docs/cse/ingestion/products-with-log-mappings/
- https://help.sumologic.com/docs/integrations/partner-ecosystem-apps/

Issue number: #3117 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
