### PR TITLE
Add note about View Rules role capability

### DIFF
--- a/docs/cse/administration/mitre-coverage.md
+++ b/docs/cse/administration/mitre-coverage.md
@@ -17,6 +17,10 @@ The MITRE ATT&CK Coverage page shows the [MITRE ATT&CK](https://attack.mitre.org
 
 To determine your coverage, MITRE ATT&CK Coverage collects data from rules that have fired in the last 180 days. 
 
+:::note
+To view the MITRE ATT&CK Coverage page, you must be assigned the [**View Rules** role capability](/docs/manage/users-roles/roles/role-capabilities/#cloud-siem-enterprise). 
+:::
+
 Watch this micro lesson to learn about MITRE ATT&CK Coverage.
 
 <Iframe url="https://www.youtube.com/embed/O1SmpbL4gos?rel=0"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a note about needing the View Rules role capability in order to view the MITRE ATT&CK Coverage page in Cloud SIEM. The note is added here:
https://help.sumologic.com/docs/cse/administration/mitre-coverage/

Issue number: None. Created PR per Slack conversation in [#cse-project-mitre-dashboard](https://sumologic.slack.com/archives/C05GD60TFQ8/p1696354708635429). 

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
