### PR TITLE
App-2589 - Markdown link in rule description

### DIFF
--- a/docs/cse/rules/write-aggregation-rule.md
+++ b/docs/cse/rules/write-aggregation-rule.md
@@ -97,6 +97,9 @@ On the right side of the Rules Editor, in the **Then Create a Signal** section, 
 1. **On Entity**. Use the pull-down list to select one or more Entity fields, for example, an IP address, MAC address, hostname, and so on. When the rule is triggered, it will fire a Signal on each of the Entity fields you select.  
 1. **with the summary**. Enter a brief summary describing what causes the Rule to create a Signal.
 1. **with the description**. Enter a description for the Signal. The Signal description should be a good indication of what the rule looks for.
+:::note
+{@import ../../reuse/cse-rule-description-links.md}
+:::
 1. **with a severity of**. Severity is an estimate of the criticality of the detected activity, from 1 (lowest) to 10 (highest). There are two ways to specify Severity:
    * **Constant**. Every Signal that the rule fires will have the same severity,
    * **Dynamic**. Severity is based on the value of a field in the Record.

--- a/docs/cse/rules/write-chain-rule.md
+++ b/docs/cse/rules/write-chain-rule.md
@@ -66,6 +66,9 @@ If you use the Test Rule feature on a rule that has one or more [Rule Tuning Exp
 1. **On Entity**. Define the Entity field — for example, an IP address, hostname, and so on — in the Record that the resulting Signal should be associated with. (In CSE, an Insight is a set of Signals with the same Entity field.) Select a value from the pull-down list. 
 1. **with the summary.** Enter a brief summary describing what causes the Rule to create a Signal.
 1. **with the description**. Enter a description for the Signal. The Signal description should be a good indication of what the rule looks for.
+:::note
+{@import ../../reuse/cse-rule-description-links.md}
+:::
 1. **with a severity of**. Severity is an estimate of the criticality of the detected activity, from 1 (lowest) to 10 (highest).
 1. **with tags**. If desired, you can add metadata tags to your rule. Tags are useful for adding context to items like Rules, Insights, Signals, Entities. You can also search for and filter items by tag. For more information, see [Using Tags with Insights, Signals, Entities, and Rules](/docs/cse/records-signals-entities-insights/tags-insights-signals-entities-rules).
 

--- a/docs/cse/rules/write-match-rule.md
+++ b/docs/cse/rules/write-match-rule.md
@@ -60,6 +60,9 @@ import Iframe from 'react-iframe'; 
     :::
 1. **with the summary**. Enter a brief summary describing what causes the Rule to create a Signal.
 1. **with the description**. Define the description for the Signal the same way you did the Signal name, using text and Record fields. The Signal description should be a good indication of what the rule looks for.
+:::note
+{@import ../../reuse/cse-rule-description-links.md}
+:::
 1. **with a severity of**. Severity is an estimate of the criticality of the detected activity, from 1 (lowest) to 10 (highest). There are two ways to specify Severity:
    * **Constant**. Every Signal that the rule fires will have the same severity,
    * **Dynamic**. Severity is based on the value of a field in the Record.

--- a/docs/cse/rules/write-threshold-rule.md
+++ b/docs/cse/rules/write-threshold-rule.md
@@ -72,6 +72,9 @@ When you're configuring a Threshold and Chain rule, you don't supply a Signal na
 1. **On Entity**. Select the Entity field—for example, an IP address, MAC address, hostname, and so on—in the Record that the resulting Signal should be associated with. (In CSE, an Insight is a set of Signals with the same Entity field.) Select a value from the pull-down list. 
 1. **with the summary**. Enter a brief summary describing what causes the Rule to create a Signal.
 1. **with the description**. Define the description for the Signal. You can use text and Record fields. The Signal description should be a good indication of what the rule looks for.
+:::note
+{@import ../../reuse/cse-rule-description-links.md}
+:::
 1. **with a severity of**. Severity is an estimate of the criticality of the detected activity, from 1 (lowest) to 10 (highest).
 1. **with tags**. If desired, you can add metadata tags to your rule. Tags are useful for adding context to items like Rules, Insights, Signals, and Entities. You can also search for and filter items by tag. For more information, see [Using Tags with Insights, Signals, Entities, and Rules](/docs/cse/records-signals-entities-insights/tags-insights-signals-entities-rules).
 

--- a/docs/reuse/cse-rule-description-links.md
+++ b/docs/reuse/cse-rule-description-links.md
@@ -1,0 +1,1 @@
+You can add a [markdown link](https://www.markdownguide.org/basic-syntax/#links) (for example, `[link](https://link-target)`) in the **with the description** field to add a link that will appear in the Signal that the rule fires. Then people viewing the Signal can click the link to access documentation about how to respond to the Signal. 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a note to the "with the description" field in Cloud SIEM rule articles describing how to add a markdown link. The note will appear here:
* https://help.sumologic.com/docs/cse/rules/write-match-rule/#configure-then-create-a-signal-settings
* https://help.sumologic.com/docs/cse/rules/write-chain-rule/#configure-then-create-a-signal-settings
* https://help.sumologic.com/docs/cse/rules/write-aggregation-rule/#configure-then-create-a-signal-settings
* https://help.sumologic.com/docs/cse/rules/write-threshold-rule/#configure-then-create-a-signal-settings

Issue number: [APP-2589](https://sumologic.atlassian.net/browse/APP-2589)

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
