### PR TITLE
Remove Ideas Portal link

### DIFF
--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/index.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/index.md
@@ -43,7 +43,7 @@ For the Federal environments, a different set of Static IPs is available for eac
 
 ## Integrations
 
-The topics below are the available integrations. In Sumo Logic these are called Sources. Check out the Sources we have available in beta. You are invited to request new Sources for the Cloud-to-Cloud Integration Framework from our [Ideas Portal](https://ideas.sumologic.com/ideas).
+The topics below are the available integrations. In Sumo Logic these are called Sources. Check out the Sources we have available in beta. 
 
 ## Versions
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a link to the Ideas Portal from here:
https://help.sumologic.com/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/#integrations

Issue number: See [thread in #dochub](https://sumologic.slack.com/archives/C0S86TM6K/p1697147289196199)

<!-- Enter the GitHub issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
