### PR TITLE
MET-0: Remove false information about default quantization rollup selection

### DIFF
--- a/docs/metrics/introduction/metric-quantization.md
+++ b/docs/metrics/introduction/metric-quantization.md
@@ -106,7 +106,7 @@ Sumo Logic will never decrease the quantization interval that you specify. We’
 
 #### How Sumo chooses rollup table and quantization interval
 
-If you don't specify a rollup type in your query, Sumo Logic will run the query using the `avg` rollup, unless the query contains a `max` or `min` aggregation after the first pipe, in which case the query will run against the `max` or `min` rollup respectively.
+If you don't specify a rollup type in your query, Sumo Logic will run the query using the `avg` rollup.
 
 The table below shows how Sumo Logic selects a quantization interval based on query time range, in the case that you do not specify those options explicitly using the `quantize` operator.
 


### PR DESCRIPTION
## Purpose of this pull request
Removed part of the sentence is simply not true - we always use `avg` rollup by default, regardless of the rest of the query.

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
