### PR TITLE
Revert "MET-0: Remove false information about default quantization rollup selection"

### DIFF
--- a/docs/metrics/introduction/metric-quantization.md
+++ b/docs/metrics/introduction/metric-quantization.md
@@ -106,7 +106,7 @@ Sumo Logic will never decrease the quantization interval that you specify. We’
 
 #### How Sumo chooses rollup table and quantization interval
 
-If you don't specify a rollup type in your query, Sumo Logic will run the query using the `avg` rollup.
+If you don't specify a rollup type in your query, Sumo Logic will run the query using the `avg` rollup, unless the query contains a `max` or `min` aggregation after the first pipe, in which case the query will run against the `max` or `min` rollup respectively.
 
 The table below shows how Sumo Logic selects a quantization interval based on query time range, in the case that you do not specify those options explicitly using the `quantize` operator.
 


### PR DESCRIPTION
Reverts SumoLogic/sumologic-documentation#3216 in an attempt to fix Search outage