### PR TITLE
Fix cards on the Audit Indexes page

### DIFF
--- a/docs/manage/security/audit-indexes/index.md
+++ b/docs/manage/security/audit-indexes/index.md
@@ -21,26 +21,26 @@ Availability of the indexes differs according to your account type. To enable ac
 
 In this section, we'll introduce the following concepts:
 
-<div className="box-wrapper" markdown="1">
-<div className="box smallbox1 card">
+<div className="box-wrapper">
+<div className="box smallbox card">
   <div className="container">
   <a href="/docs/manage/security/audit-indexes/audit-index"><img src={useBaseUrl('img/icons/security/security.png')} alt="icon" width="40"/><h4>Audit Index</h4></a>
   <p>Collect event logs in plain text on account activities, such as account management, user activity, scheduled searches, and alerting.</p>
   </div>
 </div>
-<div className="box smallbox2 card">
+<div className="box smallbox card">
   <div className="container">
   <a href="/docs/manage/security/audit-indexes/audit-event-index"><img src={useBaseUrl('img/icons/security/security.png')} alt="icon" width="40"/><h4>Audit Event Index</h4></a>
   <p>Collect event logs in JSON format on account activities for a wide range of actions.</p>
   </div>
 </div>
-<div className="box smallbox3 card">
+<div className="box smallbox card">
   <div className="container">
   <a href="/docs/manage/security/audit-indexes/search-audit-index"><img src={useBaseUrl('img/icons/security/security.png')} alt="icon" width="40"/><h4>Search Audit Index</h4></a>
   <p>Collect event logs on search activities in your account.</p>
   </div>
 </div>
-<div className="box smallbox4 card">
+<div className="box smallbox card">
   <div className="container">
   <a href="/docs/manage/security/audit-indexes/audit-index-access"><img src={useBaseUrl('img/icons/security/security.png')} alt="icon" width="40"/><h4>Grant Access to Data in Audit Indexes</h4></a>
   <p>Use role capabilities to grant access to data in audit indexes.</p>


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request fixes cards on the following page so they are three in a row:
https://help.sumologic.com/docs/manage/security/audit-indexes/

Issue: [Asana ticket to combine audit pages](https://app.asana.com/0/1183741177809740/1204636298843900/f)

<!-- Enter the GitHub Issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
