### PR TITLE
Add Role Based Search Index article to beta section

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -2797,6 +2797,7 @@ integrations: [
       items: [
         'manage/manage-subscription/beta-opt-in',
         'api/beta',
+        'manage/users-roles/roles/rbac-for-indexes'
       ],
     },
   ],


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request adds the "[Index Based and Advanced Search Filters](https://help.sumologic.com/docs/manage/users-roles/roles/rbac-for-indexes/)" article to the beta section:
https://help.sumologic.com/docs/beta/

I forgot to add it. @sukhhanda1 reminded me in the [#rbac-for-indexes](https://sumologic.slack.com/archives/C03AZ4AF9S6/p1698734007631519?thread_ts=1698073698.675599&cid=C03AZ4AF9S6) Slack channel.

<!-- Enter the GitHub Issue number or the Jira project and number (ABC-123) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions and updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site, Gatsby, React, etc
