### PR TITLE
Add role capabilities for the Automation Service

### DIFF
--- a/docs/cse/automation/about-automation-service-and-cloud-siem.md
+++ b/docs/cse/automation/about-automation-service-and-cloud-siem.md
@@ -98,7 +98,7 @@ Access to the Automation Service is controlled by [role capabilities](/docs/mana
        * View Automations
        * Manage Automations
        * Execute Automations
-1. Add Automation Service capabilities. See [Configure role capabilities](/docs/platform-services/automation-service/about-automation-service/#configure-role-capabilities) in [About the Automation Service](/docs/platform-services/automation-service/about-automation-service/). 
+1. [Add Automation Service role capabilities](/docs/platform-services/automation-service/about-automation-service/#configure-role-capabilities). 
 1. Follow the directions to [access the Automation Service](#access-the-automation-service-from-cloud-siem) to verify that you can see the **Automation** option in the **Configuration** menu.
 
 ## Support and compliance

--- a/docs/cse/automation/about-automation-service-and-cloud-siem.md
+++ b/docs/cse/automation/about-automation-service-and-cloud-siem.md
@@ -98,7 +98,7 @@ Access to the Automation Service is controlled by [role capabilities](/docs/mana
        * View Automations
        * Manage Automations
        * Execute Automations
-1. Add Automation Service capabilities. See [Configure role capabilites](/docs/platform-services/automation-service/about-automation-service/#configure-role-capabilities) in [About the Automation Service](/docs/platform-services/automation-service/about-automation-service/). 
+1. Add Automation Service capabilities. See [Configure role capabilities](/docs/platform-services/automation-service/about-automation-service/#configure-role-capabilities) in [About the Automation Service](/docs/platform-services/automation-service/about-automation-service/). 
 1. Follow the directions to [access the Automation Service](#access-the-automation-service-from-cloud-siem) to verify that you can see the **Automation** option in the **Configuration** menu.
 
 ## Support and compliance

--- a/docs/cse/automation/about-automation-service-and-cloud-siem.md
+++ b/docs/cse/automation/about-automation-service-and-cloud-siem.md
@@ -88,26 +88,18 @@ To learn how to create automations in Cloud SIEM that run playbooks from the Aut
 
 ### Configure role capabilities for Cloud SIEM automation
 
-Access to the Automation Service is controlled by [role capabilities](/docs/manage/users-roles/roles/role-capabilities) in the Sumo Logic platform. To get access to the Automation Service:
+Access to the Automation Service is controlled by [role capabilities](/docs/manage/users-roles/roles/role-capabilities) in the Sumo Logic platform. 
 1. In the left navigation bar of Sumo Logic, select **Administration > Users and Roles**.
 1. Click the **Roles** tab. 
-1. Click **Add Role** to create a new role for users of the Automation Service. Alternatively, you can select an existing role in the **Roles** tab and click **Edit**.
+1. Click **Add Role** to create a new role for users of Cloud SIEM automation. Alternatively, you can select an existing role in the **Roles** tab and click **Edit**.
 1. Add the following capabilities:
    * Cloud SIEM
      * Configuration
        * View Automations
        * Manage Automations
        * Execute Automations
-   * Cloud SOAR
-     * View Cloud SOAR
-     * Automation Playbooks
-       * Access
-       * Configure
+1. Add Automation Service capabilities. See [Configure role capabilites](/docs/platform-services/automation-service/about-automation-service/#configure-role-capabilities) in [About the Automation Service](/docs/platform-services/automation-service/about-automation-service/). 
 1. Follow the directions to [access the Automation Service](#access-the-automation-service-from-cloud-siem) to verify that you can see the **Automation** option in the **Configuration** menu.
-
-:::note
-To interact with most of the Automation Service features, you must have at least View Automations, View Cloud SOAR, and Access Playbooks permissions.
-:::
 
 ## Support and compliance
 

--- a/docs/platform-services/automation-service/about-automation-service.md
+++ b/docs/platform-services/automation-service/about-automation-service.md
@@ -54,21 +54,20 @@ Access to the Automation Service is controlled by [role capabilities](/docs/mana
 1. Click the **Roles** tab. 
 1. Click **Add Role** to create a new role for users of the Automation Service. Alternatively, you can select an existing role in the **Roles** tab and click **Edit**.
 1. Add the following capabilities:
-   * Cloud SIEM
-     * Configuration
-       * View Automations
-       * Manage Automations
-       * Execute Automations
-   * Cloud SOAR
-     * View Cloud SOAR
-     * Automation Playbooks
-       * Access
-       * Configure
-
-:::note
-To interact with most of the Automation Service features, you must have at least View Automations, View Cloud SOAR, and Access Playbooks permissions.
-:::
-
+   * Automation Service
+      * Task Access
+      * Task Access all
+      * Task Edit
+      * Task Reassign
+      * App Central Access
+      * App Central Export
+      * Integrations Access
+      * Integrations Configure
+      * Playbooks Access
+      * Playbooks Configure
+      * Bridge Monitoring Access
+      * Observability Access
+      * Observability Configure
 
 ### Configure the connection for an integration resource
 


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request updates the following article sections with new role capabilities for the Automation Service:
- https://help.sumologic.com/docs/platform-services/automation-service/about-automation-service/#configure-role-capabilities
- https://help.sumologic.com/docs/cse/automation/about-automation-service-and-cloud-siem/#configure-role-capabilities-for-cloud-siem-automation

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

Issue: [CSOAR-936](https://sumologic.atlassian.net/browse/CSOAR-936)

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
