### PR TITLE
Add sumo-drew to clabot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -136,7 +136,8 @@
     "c-kruse",
     "psyanite",
     "arkhitektor",
-    "mandrearczyk"
+    "mandrearczyk",
+    "sumo-drew"
   ],
   "message": "Thank you for your contribution! As this is an open source project, we require contributors to sign our Contributor License Agreement and do not have yours on file. To proceed with your PR, please [sign your name here](https://forms.gle/YgLddrckeJaCdZYA6) and we'll add you to our approved list of contributors.",
   "label": "cla-signed",


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request adds @sumo-drew to the [.clabot](https://github.com/SumoLogic/sumologic-documentation/blob/main/.clabot) file for PR #3349. 

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->


## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
