### PR TITLE
Edit audit index note

### DIFF
--- a/docs/manage/security/audit-indexes/audit-index.md
+++ b/docs/manage/security/audit-indexes/audit-index.md
@@ -28,7 +28,7 @@ All users can access the data contained within the audit index, but only adminis
 1. Next to **Sumo Logic Auditing**, select the **Enable** check box.
 
 :::important
-Auditing typically adds a nominal amount of data to your overall volume (approximately one to two percent) when pre-aggregated. Depending on your Sumo Logic account type and subscription, this data will count against your data volume quota. For more information, see [Manage Ingestion](/docs/manage/ingestion-volume/log-ingestion).
+Auditing typically adds a nominal amount of data to your overall volume (approximately one to two percent) when pre-aggregated. In your Sumo Logic account, this data will count against your data volume quota. For more information, see [Manage Ingestion](/docs/manage/ingestion-volume/log-ingestion).
 :::
 
 ## Query the audit index


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request makes an update to a note here:
https://help.sumologic.com/docs/manage/security/audit-indexes/audit-index/#enable-the-audit-index

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

This update is made per a request from Chas Clawson in a direct Slack message:
>I spoke with leadership and we decided this last sentence should be removed as it’s charged regardless of “type and account type”.
>"Auditing typically adds a nominal amount of data to your overall volume (approximately one to two percent) when pre-aggregated. Depending on your Sumo Logic account type and subscription, this data will count against your data volume quota. "
I replied:
>I'll change "Depending on your Sumo Logic account type and subscription" to "In your Sumo Logic account" .

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
