### PR TITLE
Remove "/blob" from examples in AWS traces article

### DIFF
--- a/docs/apm/traces/get-started-transaction-tracing/set-up-traces-collection-aws-environments.md
+++ b/docs/apm/traces/get-started-transaction-tracing/set-up-traces-collection-aws-environments.md
@@ -39,13 +39,13 @@ You'll need an ECS Cluster where the Sumo Logic Distribution for OpenTelemetry C
 1. Download the CloudFormation template file which will be used later to install the Collector:
 
     ```bash
-    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/blob/main/examples/aws/ecs-ec2-deployment.yaml
+    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/examples/aws/ecs-ec2-deployment.yaml
     ```
 
 1. Download the Sumo Logic Distribution for OpenTelemetry Collector configuration file:
 
     ```bash
-    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/blob/main/examples/aws/config.yaml
+    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/examples/aws/config.yaml
     ```
 
 1. Set up the following environment variables that are needed to perform the Collector deployment.
@@ -86,13 +86,13 @@ You'll need an ECS Cluster where the Sumo Logic Distribution for OpenTelemetry C
 1. Download the CloudFormation template file which will be used later to install the Collector:
 
     ```bash
-    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/blob/main/examples/aws/ecs-fargate-deployment.yaml
+    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/examples/aws/ecs-fargate-deployment.yaml
     ```
 
 1. Download the configuration file.
 
     ```bash
-    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/blob/main/examples/aws/config.yaml
+    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/examples/aws/config.yaml
     ```
 
 1. Set up the following environment variables that are needed to perform the Collector deployment:
@@ -131,7 +131,7 @@ You'll need an ECS Cluster where the Sumo Logic Distribution for OpenTelemetry C
 1. Download the CloudFormation template file which will be used later to install the Collector on your EC2 instance.
 
     ```bash
-    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/blob/main/examples/aws/ec2-deployment.yaml
+    curl -O https://raw.githubusercontent.com/SumoLogic/sumologic-otel-collector/main/examples/aws/ec2-deployment.yaml
     ```
 
 1. Set up the following environment variables that are needed to perform a deployment.


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request removes "/blob" from code examples in this article:
https://help.sumologic.com/docs/apm/traces/get-started-transaction-tracing/set-up-traces-collection-aws-environments

Issue: Per a [request in #dochub Slack channel](https://sumologic.slack.com/archives/C0S86TM6K/p1701876838769219).

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
