### PR TITLE
Add Scheduled action type

### DIFF
--- a/docs/platform-services/automation-service/automation-service-playbooks.md
+++ b/docs/platform-services/automation-service/automation-service-playbooks.md
@@ -82,9 +82,9 @@ Before you can add action nodes to a playbook, you must [configure the connectio
 1. Select the **Type** of action:
    * **Containment**. Performs some sort of response or remediation action, such as resetting a user's password or blocking a domain on your firewall. 
    * **Custom**. Performs an action defined in a custom action YAML file. For an example of a custom action created for Cloud SIEM, see [Advanced example: Configure a custom integration](/docs/cse/automation/cloud-siem-automation-examples/#advanced-example-configure-a-custom-integration).
-   * **Daemon**. Performs a daemon action. Uploading an action YAML file with the daemon type allows you to not only specify daemon actions, but also define rules associated with a daemon. For more information, see [Daemon action definitions](/docs/cloud-soar/cloud-soar-integration-framework/#daemon-action-definitions).
    * **Enrichment**. Enriches data with additional information, such as adding information about a known malicious IP address.
    * **Notification**. Sends a notification, for example, an email or a post in a messaging service.
+   * **Scheduled**. Runs an action on a schedule once the playbook starts. For example, the action regularly checks a condition, and once the condition is met, the next playbook actions are executed. 
    :::note
    The **Type** drop-down menu shows only the action types available in the selected integration.
    :::


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request adds the Scheduled action type to step 8 in this section at the request of @pkazmir-sumo:
https://help.sumologic.com/docs/platform-services/automation-service/automation-service-playbooks/#add-an-action-node-to-a-playbook

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
