### PR TITLE
Fix broken link in AWS Lambda Python article

### DIFF
--- a/docs/apm/traces/get-started-transaction-tracing/opentelemetry-instrumentation/aws-lambda/python.md
+++ b/docs/apm/traces/get-started-transaction-tracing/opentelemetry-instrumentation/aws-lambda/python.md
@@ -7,7 +7,7 @@ description: Learn how to install and configure OpenTelemetry distributed tracin
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-This document covers how to install and configure OpenTelemetry distributed tracing for AWS Lambda functions written in Python and send data to Sumo Logic. To obtain telemetry data from AWS Lambda functions developed in Python language you can use the [Sumo Logic Distribution for OpenTelemetry Python Lambda](https://github.com/SumoLogic-Labs/sumo-opentelemetry-lambda/tree/main/python).
+This document covers how to install and configure OpenTelemetry distributed tracing for AWS Lambda functions written in Python and send data to Sumo Logic. To obtain telemetry data from AWS Lambda functions developed in Python language you can use the [Sumo Logic Distribution for OpenTelemetry Python Lambda](https://github.com/SumoLogic/sumologic-otel-lambda/tree/main/python).
 
 Sumo Logic OTel Python Lambda layer supports:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes a broken link in this article:
https://help.sumologic.com/docs/apm/traces/get-started-transaction-tracing/opentelemetry-instrumentation/aws-lambda/python/

Issue: GitHub issue #3194

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

