### PR TITLE
Update link to v3 migration guide

### DIFF
--- a/docs/send-data/kubernetes/v4/how-to-upgrade.md
+++ b/docs/send-data/kubernetes/v4/how-to-upgrade.md
@@ -169,4 +169,4 @@ After you're done, please review the [full list of changes](full-list-of-changes
 [application_metrics_annotation]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/collecting-application-metrics.md#application-metrics-are-exposed-one-endpoint-scenario
 [kubernetes_metrics_v3]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v3/docs/collecting-kubernetes-metrics.md#collecting-kubernetes-metrics
 [otel_metrics_filter]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/collecting-application-metrics.md#filtering-metrics
-[v3_migration_guide]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/v3-migration-doc.md
+[v3_migration_guide]: https://help.sumologic.com/docs/send-data/kubernetes/v3/important-changes/


### PR DESCRIPTION
As the v3 migration guide has been moved to Sumo docs, the link needs to be updated

## Select the type of change:

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
