### PR TITLE
Update link to v3 migration guide in important changes part

### DIFF
--- a/docs/send-data/kubernetes/v4/important-changes.md
+++ b/docs/send-data/kubernetes/v4/important-changes.md
@@ -27,5 +27,5 @@ By default, the OpenTelemetry Collector is now used for metrics collection inste
 
 This Helm Chart automatically creates the necessary Collector and Sources in Sumo. Up until this point, these were generic HTTP sources accepting data in different formats. As Sumo now has native support for the OTLP protocol used by OpenTelemetry, we've decided to switch to using these new sources by default. This is a completely transparent change **unless** you use the `_sourceName` or `_source` fields in your Sumo queries.
 
-[v3_migration_guide]: https://help.sumologic.com/docs/send-data/kubernetes/v3/important-changes/
+[v3_migration_guide]: https://help.sumologic.com/docs/send-data/kubernetes/v3/how-to-upgrade/
 [scraped_metrics_aggregations]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/scraped-metrics.md#aggregations-removed

--- a/docs/send-data/kubernetes/v4/important-changes.md
+++ b/docs/send-data/kubernetes/v4/important-changes.md
@@ -27,5 +27,5 @@ By default, the OpenTelemetry Collector is now used for metrics collection inste
 
 This Helm Chart automatically creates the necessary Collector and Sources in Sumo. Up until this point, these were generic HTTP sources accepting data in different formats. As Sumo now has native support for the OTLP protocol used by OpenTelemetry, we've decided to switch to using these new sources by default. This is a completely transparent change **unless** you use the `_sourceName` or `_source` fields in your Sumo queries.
 
-[v3_migration_guide]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/v3-migration-doc.md
+[v3_migration_guide]: https://help.sumologic.com/docs/send-data/kubernetes/v3/important-changes/
 [scraped_metrics_aggregations]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/scraped-metrics.md#aggregations-removed


### PR DESCRIPTION
v3 migration guide will be removed from github soon, so it is necessary to update the link to point to the document in help.sumologic.com

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
