### PR TITLE
Add information about using FIPS compliant OpenTelemetry Collector in the Sumo Logic Helm Chart

### DIFF
--- a/docs/send-data/kubernetes/install-helm-chart.md
+++ b/docs/send-data/kubernetes/install-helm-chart.md
@@ -147,8 +147,7 @@ An alternative would be to host Sumo Logic container images in one's container r
 
 ### Using FIPS compliant OpenTelemetry Collector
 
-Refer to [FIPS compliant binaries section](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/security-best-practices.md#fips-compliant-binaries) in
-[Advanced Configuration / Security Best Practices document](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/security-best-practices.md).
+Refer to the [FIPS compliant binaries](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/security-best-practices.md#fips-compliant-binaries) section in the [Advanced Configuration / Security Best Practices](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/security-best-practices.md) document.
 
 ### Proxy
 

--- a/docs/send-data/kubernetes/install-helm-chart.md
+++ b/docs/send-data/kubernetes/install-helm-chart.md
@@ -145,6 +145,11 @@ An alternative would be to host Sumo Logic container images in one's container r
 [aws-public-ecr-docs]: https://aws.amazon.com/blogs/aws/amazon-ecr-public-a-new-public-container-registry/
 [aws-ecr-pricing]: https://aws.amazon.com/ecr/pricing/
 
+### Using FIPS compliant OpenTelemetry Collector
+
+Refer to [FIPS compliant binaries section](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/security-best-practices.md#fips-compliant-binaries) in
+[Advanced Configuration / Security Best Practices document](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/security-best-practices.md).
+
 ### Proxy
 
 If you are installing the collection in a cluster that requires proxying outbound requests, please see the following


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

Add information about using FIPS compliant OpenTelemetry Collector in the Sumo Logic Helm Chart
https://sumologic.atlassian.net/browse/OSC-386

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
