### PR TITLE
Remove comments from examples in rules syntax article

### DIFF
--- a/docs/cse/rules/cse-rules-syntax.md
+++ b/docs/cse/rules/cse-rules-syntax.md
@@ -21,13 +21,21 @@ The exclamation point (!) function is equivalent to a logical NOT operator.
 
 **Examples**
 
-`device_ip != '0.0.0.0'   //  true if the value of the device_ip  is not “0.0.0.0”`
+* The following expression returns "true" if the value of the `device_ip`  is not `0.0.0.0`:
 
-`!(null)   // true`
+    `device_ip != '0.0.0.0'`
+
+* The following expression returns "true":
+
+   `!(null)`
 
 ## -
 
-The dash (-) function is a subtraction operator. The following expression returns the difference between the length of the `dns_query` and the `dns_queryDomain` field values. 
+The dash (-) function is a subtraction operator. 
+
+**Example**
+
+The following expression returns the difference between the length of the `dns_query` and the `dns_queryDomain` field values:
 
 `(length(dns_query) - length(dns_queryDomain)) `
 
@@ -41,7 +49,7 @@ The forward slash (/) operator performs floating-point division between two expr
 
 **Example**
 
-The following expression divides `error_count` by `user_count`.
+The following expression divides `error_count` by `user_count`:
 
 `error_count / user_count`
 
@@ -69,13 +77,21 @@ The less than (`<`) character returns “true” if the expression is less than 
 
 **Examples**
 
-`srcPort < dstPort  // true if the value of srcPort is less than the value of dstPort `
+* The following expression returns "true" if the value of `srcPort` is less than the value of `dstPort`:
 
-`null < 10  // false`
+   `srcPort < dstPort`
 
-`10 < null  // false`
+* The following expression returns "false":
 
-`null < null  // false`
+   `null < 10`
+
+* The following expression returns "false":
+
+   `10 < null`
+
+* The following expression returns "false":
+
+   `null < null`
 
 ## `<=`
 
@@ -87,15 +103,21 @@ The is less than or equal to (`<=`) character returns true if the expression is 
 
 **Example**
 
-This expression is:
+* The following expression returns "true" if the value of `dstPort` is less than or equal to `6669`:
 
-`dstPort <= 6669  //  true if the value of dstPort is less or equal to  than “6669”`
+   `dstPort <= 6669`
 
-`null <= 10   // false`
+* The following expression returns "false":
 
-`10 <= null   // false`
+   `null <= 10`
 
-`null <= null   // false`
+* The following expression returns "false":
+
+   `10 <= null`
+
+* The following expression returns "false":
+
+   `null <= null`
 
 ## =
 
@@ -107,16 +129,21 @@ The equal to (=) function returns “true” if the expressions are equal, or 
 
 **Examples**
 
-`"foo" = "foo" // true`  
- 
+* The following expression returns "true":
 
-`null = "foo" // false`  
+   `"foo" = "foo"`  
  
+* The following expression returns "false":
 
-`"foo" = null // false`  
+   `null = "foo"`  
  
+* The following expression returns "false":
 
-`null = null // false`
+   `"foo" = null`  
+ 
+* The following expression returns "false":
+
+   `null = null`
 
 ## ==
 
@@ -136,15 +163,22 @@ The greater than (>) function returns “true” if one expression is greater th
 
 **Examples**
 
-`severity > '6'  //  true if the value of the severity field is greater than 6`
+* The following expression returns "true" if the value of the `severity` field is greater than `6`:
 
-`null > 10   // false`
+   `severity > '6'`
 
-`10 > null   // false`
+* The following expression returns "false":
 
-`null > null   // false`  
+   `null > 10`
+
+* The following expression returns "false":
+
+   `10 > null`
+
+* The following expression returns "false":
+
+   `null > null`  
  
-
 ## >=
 
 The greater than or equal to (>=) function returns “true” if one expression is greater than or equal to another expression.
@@ -155,13 +189,21 @@ The greater than or equal to (>=) function returns “true” if one expression 
 
 **Examples**
 
-`srcPort >= dstPort  // true if the  srcPort is greater than or equal to dstPort`
+* The following expression returns "true" if the  `srcPort` is greater than or equal to `dstPort`:
 
-`null >= 10  // false`
+   `srcPort >= dstPort`
 
-`10>= null  // false`
+* The following expression returns "false":
 
-`null >= null  // false`
+   `null >= 10`
+
+* The following expression returns "false":
+
+   `10>= null`
+
+* The following expression returns "false":
+
+   `null >= null`
 
 ## +
 
@@ -173,7 +215,7 @@ The plus sign (+) function adds the value of two or more expressions.
 
 **Example**
 
-The following example adds the value of the `errorCount_x`  field to the value of the `errorCount_y`  field.
+The following example adds the value of the `errorCount_x`  field to the value of the `errorCount_y`  field:
 
 `errorCount_x + errorCount_y`
 
@@ -195,7 +237,9 @@ Calculates the absolute value of the supplied argument.
 
 **Example**
 
-`abs(-1.5) // 1.5`
+The following expression returns "1.5":
+
+`abs(-1.5)`
 
 ## acos
 
@@ -207,7 +251,9 @@ Returns the inverse cosine of the supplied argument.
 
 **Example**
 
-`acos(1) // 0`
+The following expression returns "0":
+
+`acos(1`
 
 ## anyHttpHeaderMatches
 
@@ -240,7 +286,9 @@ Returns the inverse sine of the supplied argument.
 
 **Example**
 
-`asin(1) // 1.5707963267948966`
+The following example returns "1.5707963267948966":
+
+`asin(1)`
 
 ## atan
 
@@ -252,9 +300,9 @@ Returns the inverse tangent of the supplied argument.
 
 **Example**
 
-The following example returns the inverse tangent of 1, which is 
+The following expression returns the inverse tangent of 1, which is "0.78540":
 
-`atan(1) // 0.78540`
+`atan(1)`
 
 ## atan2
 
@@ -266,7 +314,9 @@ Returns the four-quadrant inverse tangent of the two arguments supplied.
 
 **Example**
 
-`atan2(0, -1) // 3.141592653589793 (pi)`
+The following expression returns "3.141592653589793" (pi):
+
+`atan2(0, -1)`
 
 ## array_contains
 
@@ -347,15 +397,21 @@ Returns “true” if the value of an expression falls within a specified range.
 
 **Example**
 
-This example returns “true” if the value of the  `metadata_deviceEventId` is between “2000000” and “2999999”:
+* The following expression returns "true" if the value of `metadata_deviceEventId` is between “2000000” and “2999999”:
 
-`metadata_deviceEventId between '2000000' and '2999999' // true if metadata_deviceEventId is between “2000000” and “2999999”`
+   `metadata_deviceEventId between '2000000' and '2999999'`
 
-`null BETWEEN 1 and 10   // false`
+* The following expression returns "false":
 
-`1 BETWEEN null and 10   // false`
+   `null BETWEEN 1 and 10`
 
-`10 BETWEEN 1 and null   // false`
+* The following expression returns "false":
+
+   `1 BETWEEN null and 10`
+
+* The following expression returns "false":
+
+   `10 BETWEEN 1 and null`
 
 ## cbrt
 
@@ -367,7 +423,9 @@ Returns the cube root value of the argument.
 
 **Example**
 
-`cbrt(8) // 2`
+The following expression returns "2":
+
+`cbrt(8)`
 
 ## ceil
 
@@ -379,9 +437,13 @@ The ceil operator rounds up a field value to the nearest integer value.
 
 **Examples**
 
-`ceil(1.5) // 2`
+* The following expression returns "2":
 
-`ceil(-1.5) // -1`
+   `ceil(1.5)`
+
+* The following expression returns "-1":
+
+   `ceil(-1.5)`
 
 ## compareCIDRPrefix
 
@@ -393,7 +455,9 @@ Compares two IPv4 addresses and returns true if the network prefixes match.
 
 **Example**
 
-`compareCIDRPprefix("10.10.1.35", "10.10.1.100", "24") // true`
+The following expression returns "true":
+
+`compareCIDRPprefix("10.10.1.35", "10.10.1.100", "24")`
 
 ## concat
 
@@ -405,7 +469,9 @@ Allows you to concatenate or join multiple strings, numbers, and fields into a s
 
 **Example**
 
-`concat(1, "/", 1, "/", 2020) // "1/1/2020"`
+The following example returns "1/1/2020":
+
+`concat(1, "/", 1, "/", 2020)`
 
 ## contains
 
@@ -429,7 +495,9 @@ Returns the cosine of the argument in radians.
 
 **Example**
 
-`cos(1) // 0.5403023058681398`
+The following expression returns "0.5403023058681398":
+
+`cos(1)`
 
 ## cosh
 
@@ -441,7 +509,9 @@ Returns the hyperbolic cosine of the argument in radians.
 
 **Example**
 
-`cosh(1) // 1.54308`
+The following expression returns "1.54308":
+
+`cosh(1)`
 
 ## decToHex
 
@@ -453,7 +523,9 @@ Converts a long value of 16 or fewer digits to a hexadecimal string using Two's 
 
 **Example**
 
-`decToHex(“4919”) // "1337"`
+The following expression returns "1337":
+
+`decToHex(“4919”)`
 
 ## exp
 
@@ -465,7 +537,9 @@ Returns Euler's number e raised to the power of x.
 
 **Example**
 
-`exp(1) // 2.7182818284590455`
+The following expression returns "2.7182818284590455":
+
+`exp(1)`
 
 ## expm1
 
@@ -477,7 +551,9 @@ Returns value of x in exp(x)-1, compensating for the roundoff in exp(x).
 
 **Example**
 
-`expm1(0.1) // 0.10517091807564763`
+The following expression returns "0.10517091807564763":
+
+`expm1(0.1)`
 
 ## floor
 
@@ -502,7 +578,9 @@ Extracts the network prefix from an IPv4 address. 
 
 **Example**
 
-`getCIDRPrefix("10.10.1.35", "24") // "10.10.1.0"`
+The following expression returns "10.10.1.0":
+
+`getCIDRPrefix("10.10.1.35", "24")`
 
 ## haversine
 
@@ -514,7 +592,9 @@ Returns the distance between latitude and longitude values of two coordinates in
 
 **Example**
 
-`haversine(39.04380, -77.48790, 45.73723, -119.81143) // 3512.71`
+The following expression returns "3512.71":
+
+`haversine(39.04380, -77.48790, 45.73723, -119.81143)`
 
 ## hexToAscii 
 
@@ -535,7 +615,9 @@ Converts a hexadecimal string of 16 or fewer characters to a long data type usin
 
 **Example**
 
-`hexToDec("0000000000001337") // 4919`
+The following expression returns "4919":
+
+`hexToDec("0000000000001337")`
 
 ## hypot
 
@@ -547,7 +629,9 @@ Returns the square root of the sum of an array of squares.
 
 **Example**
 
-`hypot(3, 4) // 5`
+The following expression returns "5":
+
+`hypot(3, 4)`
 
 ## if
 
@@ -577,11 +661,17 @@ Returns “true” if the value of an expression exists within the specified lis
 
 **Examples**
 
-`srcDevice_ip IN ("1.2.3.4", "2.3.4.5", "3.4.5.6") // true if the value of srcDevice_ip is "1.2.3.4" or any of the other specified values`
+* The following expression returns "true" if the value of `srcDevice_ip` is "1.2.3.4" or any of the other specified values:
 
-`http_response_statusCode in (400, 500) // true if the value of http_response_code equals 400 or 500`
+   `srcDevice_ip IN ("1.2.3.4", "2.3.4.5", "3.4.5.6")`
 
-`null IN ("value1", "value2", "value3") // false`
+* The following expression returns "true" if the value of `http_response_code` equals "400" or "500"d:
+
+   `http_response_statusCode in (400, 500)`
+
+* The following expression returns "false":
+
+   `null IN ("value1", "value2", "value3")`
 
 ## ipv4ToNumber
 
@@ -593,7 +683,9 @@ Converts an Internet Protocol version 4 (IPv4) IP address from the octet dot-dec
 
 **Example**
 
-`ipv4ToNumber("127.0.0.1") // 2130706433`
+The following expression returns "2130706433":
+
+`ipv4ToNumber("127.0.0.1")`
 
 ## isBlank
 
@@ -643,7 +735,9 @@ Checks if an IPv4 address is private and returns a boolean.
 
 **Example**
 
-`isPrivateIP("192.168.0.1") // true`
+The following expression returns "true":
+
+`isPrivateIP("192.168.0.1")`
 
 ## isPublicIP
 
@@ -655,7 +749,9 @@ Checks if an IPv4 address is public and returns a boolean.
 
 **Example**
 
-`isPublicIP("10.255.255.255") // false`
+The following expression returns "false":
+
+`isPublicIP("10.255.255.255")`
 
 ## isValidIP
 
@@ -667,9 +763,13 @@ Checks if the input string is a valid IPv4 or IPv6 address.
 
 **Examples**
 
-`isValidIP("10.255.255.255") // true`
+* The following expression returns "true":
 
-`isValidIP("127.0.500.1") // false`
+   `isValidIP("10.255.255.255")`
+
+* The following expression returns "false":
+
+   `isValidIP("127.0.500.1")`
 
 ## isValidIPv4
 
@@ -681,7 +781,9 @@ Checks if the input string is a valid IPv4 address.
 
 **Example**
 
-`isValidIPv4("10.10.10.10") // true`
+The following expression returns "true":
+
+`isValidIPv4("10.10.10.10")`
 
 ## isValidIPv6
 
@@ -693,7 +795,9 @@ Checks if the input string is a valid IPv6 address.
 
 **Example**
 
-`isValidIPv6("10.10.10.10") // false`
+The following expression returns "false":
+
+`isValidIPv6("10.10.10.10")`
 
 ## jsonArrayContains 
 
@@ -801,9 +905,13 @@ Returns the number of characters in a string. If the string is null, it returns 
 
 **Examples**
 
-`length("sumo logic") // 10`
+* The following expression returns "10":
 
-`length(null) // 0`
+   `length("sumo logic")`
+
+* The following expression returns "0":
+
+   `length(null)`
 
 ## like
 
@@ -813,31 +921,38 @@ Compares a string to a pattern, and returns “true” if the string matches the
 
 `str like pattern [ ESCAPE 'escape_character' ]`
 
-If `pattern` or `escape_character` is null, the expression evaluates to
-null.
-
-**Examples**
-
-`null LIKE “%foo%”   // false`
-
-`“foo” LIKE null   // false`
-
-`bro_rdp_cookie like '%admin%' // true if the value of bro_rdp_cookie matches %admin%`  
-
-In the following example, the string` '%SystemDrive%\Users\John'` has to match the pattern `'\%SystemDrive\%\\Users%'` to return “true”.
-
-`'%SystemDrive%\Users\John' like '\%SystemDrive\%\\Users%'`  
- 
-
 where:
 
 * `str` is a string expression
 * `pattern` is a string expression, which is matched literally, except for the following wildcard symbols:
 
     * `_` represents a single character 
-    * `%` Represents zero, one, or multiple characters    
+    * `%` Represents zero, one, or multiple characters  
 
-**Example log**
+If `pattern` or `escape_character` is null, the expression evaluates to
+null.
+
+**Examples**
+
+* The following expression returns "false":
+
+   `null LIKE “%foo%”`
+
+
+* The following expression returns "false":
+
+   `“foo” LIKE null`
+
+* The following expression returns "true" if the value of `bro_rdp_cookie` matches `%admin%`:
+
+   `bro_rdp_cookie like '%admin%'`  
+
+* In the following expression, the string `'%SystemDrive%\Users\John'` has to match the pattern `'\%SystemDrive\%\\Users%'` to return “true”.
+
+   `'%SystemDrive%\Users\John' like '\%SystemDrive\%\\Users%'`  
+ 
+
+## log
 
 Returns the natural logarithm of the argument.
 
@@ -847,7 +962,9 @@ Returns the natural logarithm of the argument.
 
 **Example**
 
-`log(2) // 0.6931471805599453`
+The following expression returns "0.6931471805599453":
+
+`log(2) `
 
 ## log10
 
@@ -859,7 +976,9 @@ Returns the base-10 logarithm of the argument.
 
 **Example**
 
-`log10(2) // 0.3010299956639812`
+The following expression returns "0.3010299956639812":
+
+`log10(2)`
 
 ## log1p
 
@@ -871,7 +990,9 @@ Calculates log(1+x) accurately for small values of x.
 
 **Example**
 
-`log1p(0.1) // 0.09531017980432487`
+The following expression returns "0.09531017980432487":
+
+`log1p(0.1)`
 
 ## luhn
 
@@ -883,9 +1004,13 @@ Uses Luhn’s algorithm to check message logs for strings of numbers that may be
 
 **Example**
 
-`luhn("6666-7777-6666-8888") // true`
+* The following expression returns "true":
 
-`luhn("0000000000000131") // false`
+   `luhn("6666-7777-6666-8888")`
+
+* The following expression returns "false":
+
+   `luhn("0000000000000131")`
 
 ## maskFromCIDR
 
@@ -897,7 +1022,9 @@ A utility function that returns a subnet mask for boolean operations with IPv4 a
 
 **Example**
 
-`maskFromCIDR("30") // "255.255.255.252"`
+The following expression returns "255.255.255.252":
+
+`maskFromCIDR("30")`
 
 ## matches
 
@@ -936,9 +1063,9 @@ Casts string data to a number.
 
 ## rlike
 
-The `rlike` function returns “true” if a string matches a specified
-regular expression. If there is no match, the function returns “false”,
-The syntax is:
+The `rlike` function returns “true” if a string matches a specified regular expression. If there is no match, the function returns “false”,
+
+**Syntax**
 
 `str rlike regexp`
 
@@ -949,14 +1076,18 @@ where:
 
 **Examples**
 
-`null RLIKE “.*foo.*”   // false`
+* The following expression returns "false":
 
-`“foo” RLIKE null   // false`
+   `null RLIKE “.*foo.*”`
 
-This example returns “true” of the value of the `dns_query` field
-matches the regular expression `[A-Za-z2-7]{60,}`.
+* The following expression returns "false":
 
-`dns_query rlike '[A-Za-z2-7]{60,}' `
+   `“foo” RLIKE null`
+
+* The following expression returns "true" if the value of the `dns_query` field
+matches the regular expression `[A-Za-z2-7]{60,}`:
+
+   `dns_query rlike '[A-Za-z2-7]{60,}' `
 
 ## round
 
@@ -969,8 +1100,13 @@ provided, it will round to the nearest integer.
 
 **Examples**
 
-* `round(1.5) // 2`
-* `round(1.549, 2) // 1.55`
+* The following expression returns "2":
+
+   `round(1.5)`
+
+* The following expression returns "1.55":
+
+   `round(1.549, 2)`
 
 ## sin
 
@@ -982,7 +1118,9 @@ Returns the sine of the argument in radians.
 
 **Example**
 
-`sin(1) // 0.8414709848078965`
+The following expression returns "0.8414709848078965":
+
+`sin(1) `
 
 ## sinh
 
@@ -994,7 +1132,9 @@ Returns the hyperbolic sine of the argument in radians.
 
 **Example**
 
-`sinh(1) // 1.1752011936438014`
+The following expression returns "1.1752011936438014":
+
+`sinh(1)`
 
 ## size
 
@@ -1018,7 +1158,9 @@ Returns the square root of the argument.
 
 **Example**
 
-`sqrt(4) // 2`
+The following expression returns "2":
+
+`sqrt(4)`
 
 ## substring
 
@@ -1039,9 +1181,17 @@ Allows you to specify an offset that will output only part of a string, referred
 
 **Examples**
 
-* `substring("Hello world!", 6) // "world!"`
-* `substring("Sumo Logic", 0, 4) // "Sumo"`
-* `substring("Sumo Logic", 0, 100) // "Sumo Logic"`
+* The following expression returns "world!":
+
+   `substring("Hello world!", 6)`
+
+* The following expression returns "Sumo":
+
+   `substring("Sumo Logic", 0, 4)`
+
+* The following expression returns "Sumo Logic":
+
+   `substring("Sumo Logic", 0, 100)`
 
 ## tan
 
@@ -1053,7 +1203,9 @@ Returns the tangent of the argument in radians.
 
 **Example**
 
-`tan(1) // 1.5574077246549023`
+The following expression returns "1.5574077246549023":
+
+`tan(1)`
 
 ## tanh
 
@@ -1065,7 +1217,9 @@ Returns the hyperbolic tangent of the argument in radians.
 
 **Example**
 
-`tanh(1) // 0.76159`
+The following expression returns "0.76159":
+
+`tanh(1)`
 
 ## toDegrees
 
@@ -1077,7 +1231,9 @@ Converts angles from radians to degrees.
 
 **Example**
 
-`toDegrees(asin(1)) // 90 (asin(1) is pi / 2)`
+The following expression returns "90 (asin(1) is pi / 2)":
+
+`toDegrees(asin(1))`
 
 ## toDouble
 
@@ -1132,7 +1288,9 @@ Converts angles from radians to degrees.
 
 **Example**
 
-`toRadians(180) // 3.141592653589793 (pi)`
+The following expression returns "3.141592653589793" (pi):
+
+`toRadians(180)`
 
 ## toUpperCase 
 
@@ -1153,7 +1311,9 @@ Eliminates leading and trailing spaces from a string field.
 
 **Example**
 
-`trim("  Hello World  ") // "Hello World"`
+The following expression returns "Hello World":
+
+`trim("  Hello World  ")`
 
 ## urldecode
 
@@ -1166,7 +1326,9 @@ URL string.
 
 **Example**
 
-`urldecode("http%3A%2F%2Fyourmainserver-city55555.org%2Ffunctions%2Fmain.php%3Fgk%3DGk45MgHJhEYx8bPYvGfiWS7o3KLdfg90%26") // "http://yourmainserver-city55555.org/...iWS7o3KLdfg90&"`
+The following expression returns "http://yourmainserver-city55555.org/...iWS7o3KLdfg90&":
+
+`urldecode("http%3A%2F%2Fyourmainserver-city55555.org%2Ffunctions%2Fmain.php%3Fgk%3DGk45MgHJhEYx8bPYvGfiWS7o3KLdfg90%26")`
 
 ## urlencode
 
@@ -1178,7 +1340,9 @@ Encodes the URL into an ASCII character set.
 
 **Example**
 
-`urlencode("http://yourmainserver-city55555.org/...iWS7o3KLdfg90&") // "http%3A%2F%2Fyourmainserver-city55555.org%2Ffunctions%2Fmain.php%3Fgk%3DGk45MgHJhEYx8bPYvGfiWS7o3KLdfg90%26"`
+The following expression returns ""http%3A%2F%2Fyourmainserver-city55555.org%2Ffunctions%2Fmain.php%3Fgk%3DGk45MgHJhEYx8bPYvGfiWS7o3KLdfg90%26"
+
+`urlencode("http://yourmainserver-city55555.org/...iWS7o3KLdfg90&")`
 
 ## where
 

--- a/docs/cse/rules/cse-rules-syntax.md
+++ b/docs/cse/rules/cse-rules-syntax.md
@@ -1340,7 +1340,7 @@ Encodes the URL into an ASCII character set.
 
 **Example**
 
-The following expression returns ""http%3A%2F%2Fyourmainserver-city55555.org%2Ffunctions%2Fmain.php%3Fgk%3DGk45MgHJhEYx8bPYvGfiWS7o3KLdfg90%26"
+The following expression returns "http%3A%2F%2Fyourmainserver-city55555.org%2Ffunctions%2Fmain.php%3Fgk%3DGk45MgHJhEYx8bPYvGfiWS7o3KLdfg90%26"
 
 `urlencode("http://yourmainserver-city55555.org/...iWS7o3KLdfg90&")`
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes comments from examples in the following article:
https://help.sumologic.com/docs/cse/rules/cse-rules-syntax/

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

Asana ticket "[Remove // in examples](https://app.asana.com/0/1183741177809740/1206509376131544/f)".

Also see [APP-2852](https://sumologic.atlassian.net/browse/APP-2852).

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me
