### PR TITLE
Add Cloud SIEM release notes for 2024-01-30 and 2024-02-02

### DIFF
--- a/blog-cse/2024-01-30-content.md
+++ b/blog-cse/2024-01-30-content.md
@@ -1,0 +1,18 @@
+---
+title: January 30, 2024 - Content Release
+hide_table_of_contents: true
+keywords:
+  - log mappers
+image: https://help.sumologic.com/img/sumo-square.png
+authors:
+  - url: https://help.sumologic.com/release-notes-cse/rss.xml
+    image_url: /img/release-notes/rss-orange.png
+---
+
+This content release includes updates to log mappers for Zeek fixing several bugs that were preventing fields from mapping properly.
+
+#### Log Mappers
+
+* [Updated] Zeek DNS Activity
+* [Updated] Zeek HTTP Activity
+* [Updated] Zeek conn Activity

--- a/blog-cse/2024-02-02-content.md
+++ b/blog-cse/2024-02-02-content.md
@@ -1,0 +1,27 @@
+---
+title: February 2, 2024 - Content Release
+hide_table_of_contents: true
+keywords:
+  - log mappers
+image: https://help.sumologic.com/img/sumo-square.png
+authors:
+  - url: https://help.sumologic.com/release-notes-cse/rss.xml
+    image_url: /img/release-notes/rss-orange.png
+---
+
+This release includes minor mapping adjustments to Duo and MS Graph Identify Protection Risk logs. Specific changes are enumerated below.
+
+#### Log Mappers
+
+* [Updated] Duo Security Admin API - Audit
+   * Added mappings for source host and source IP
+* [Updated] Duo Security Admin API - Authentication
+   * Added mappings for source host and source IP
+* [Updated] Duo Security Admin API - Non-User Audit Changes
+   * Added mappings for source host and source IP
+* [Updated] Duo Security Admin API - Targeted User Audit Changes
+   * Added mappings for source host and source IP
+* [Updated] Microsoft Graph Identity Protection API C2C - riskDetections
+   * Added principal as primary `user_username` key
+* [Updated] Microsoft Graph Identity Protection API C2C - riskyUsers
+   * Added principal as primary `user_username` key


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds release notes here for Jan. 30 and Feb. 2 per [discussion in the #sbu-threat-labs Slack channel](https://sumologic.slack.com/archives/C03ASV6SJV8/p1706890183710159):
https://help.sumologic.com/release-notes-cse/

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
- [ ] 
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me
