### PR TITLE
Move article back to Data Forwarding section

### DIFF
--- a/blog-collector/2018/12-31.md
+++ b/blog-collector/2018/12-31.md
@@ -42,7 +42,7 @@ If you upgrade from version 19.209 to 19.216 or 19.227 on Mac OS X, you must man
 ### May 1, 2018 (19.216-33)
 * Enhanced metadata allowing you to customize `sourceCategory` and `sourceHost` with environment variables, labels, and tags. Docker tags welcome, For more information, see [Collect Logs and Stats from Docker](/docs/integrations/containers-orchestration/docker-community-edition#configure-sourcecategory-and-sourcehost-using-variables).
 * Metrics support for Carbon 2.0 format has arrived with a new Source, Streaming Metrics. This will support Graphite format as well so our Graphite Source has been renamed. For more information, see [Streaming Metrics Source](/docs/send-data/installed-collectors/sources/streaming-metrics-source).
-* Data Forwarding is now more reliable for HTTP and Syslog destinations. Data is queued on disk when in-memory fills instead of causing your system to run out of memory. To configure your data forwarding queue limits see [Archive Log Data to other destinations](/docs/manage/data-archiving/installed-collectors#Configure-data-forwarding-queue-size).
+* Data Forwarding is now more reliable for HTTP and Syslog destinations. Data is queued on disk when in-memory fills instead of causing your system to run out of memory. To configure your data forwarding queue limits see [Forward Data from an Installed Collector](/docs/manage/data-forwarding/installed-collectors/#configure-data-forwarding-queue-size).
 * SystemD is now the default init system on Linux distributions that support SystemD.
 * Simplified installation for the Linux binary package as a result of an updated Tanuki wrapper. For more information, see [Install a Collector on Linux](/docs/send-data/installed-collectors/linux#Install_using_the_binary_package).
 

--- a/blog-service/2022/12-31.md
+++ b/blog-service/2022/12-31.md
@@ -168,7 +168,7 @@ Update - We’ve released an improved, re-organized UI for Data Forwarding. Ther
 * Destinations that receive data forwarded from Sumo Logic partitions or scheduled views are still managed on the **Manage Data > Logs > Data Forwarding** page.
 * Destinations that receive data from Installed Collectors are managed on a new page: **Manage Data > Collection > Data Archiving** page.
 
-For more information, see [Forward Data from Sumo Logic to S3](/docs/manage/data-forwarding/amazon-s3-bucket) and [Archive Log Data to other destinations](/docs/manage/data-archiving/installed-collectors).
+For more information, see [Forward Data from Sumo Logic to S3](/docs/manage/data-forwarding/amazon-s3-bucket).
 
 ---
 ## October 3, 2022 (Search)

--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -2929,7 +2929,7 @@
   "/Manage/Content_Sharing/Share-Content": "/docs/manage/content-sharing",
   "/Manage/Data-Forwarding": "/docs/manage/data-forwarding",
   "/Manage/Data-Forwarding/Configure-Data-Forwarding-for-Installed-Collectors": "/docs/manage/data-archiving/installed-collectors",
-  "/docs/manage/data-forwarding/installed-collectors": "/docs/manage/data-archiving/installed-collectors",
+  "/docs/manage/data-archiving/installed-collectors": "/docs/manage/data-forwarding/installed-collectors",
   "/Manage/Data-Forwarding/Configure-Data-Forwarding-from-Sumo-Logic-to-S3/02File-Format-for-Data-Forwarding-to-an-Amazon-S3-Bucket": "/docs/manage/data-forwarding/amazon-s3-bucket",
   "/Manage/Data-Forwarding/Configure-Data-Forwarding-from-Sumo-Logic-to-S3": "/docs/manage/data-forwarding/amazon-s3-bucket",
   "/Manage/Data-Forwarding/Manage_Data_Forwarding": "/docs/manage/data-forwarding/manage",

--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -2928,7 +2928,7 @@
   "/Manage/Content_Sharing/Content_Sharing_FAQ": "/docs/manage/content-sharing/content-sharing-faq",
   "/Manage/Content_Sharing/Share-Content": "/docs/manage/content-sharing",
   "/Manage/Data-Forwarding": "/docs/manage/data-forwarding",
-  "/Manage/Data-Forwarding/Configure-Data-Forwarding-for-Installed-Collectors": "/docs/manage/data-archiving/installed-collectors",
+  "/Manage/Data-Forwarding/Configure-Data-Forwarding-for-Installed-Collectors": "/docs/manage/data-forwarding/installed-collectors",
   "/docs/manage/data-archiving/installed-collectors": "/docs/manage/data-forwarding/installed-collectors",
   "/Manage/Data-Forwarding/Configure-Data-Forwarding-from-Sumo-Logic-to-S3/02File-Format-for-Data-Forwarding-to-an-Amazon-S3-Bucket": "/docs/manage/data-forwarding/amazon-s3-bucket",
   "/Manage/Data-Forwarding/Configure-Data-Forwarding-from-Sumo-Logic-to-S3": "/docs/manage/data-forwarding/amazon-s3-bucket",

--- a/docs/manage/data-archiving/index.md
+++ b/docs/manage/data-archiving/index.md
@@ -27,13 +27,4 @@ In this section, we'll introduce the following concepts:
       <p>Learn to archive data to S3 for future ingestion and retrieval.</p>
     </div>
   </div>
-  <div className="box smallbox card">
-    <div className="container">
-      <a href="/docs/manage/data-archiving/installed-collectors">
-        <img src={useBaseUrl('img/icons/operations/send-data.png')} alt="Thumbnail icon" width="45" />
-        <h4>Archive Log Data to other destinations</h4>
-      </a>
-      <p>Learn how to set up Data Archiving destinations.</p>
-    </div>
-  </div>
 </div>

--- a/docs/manage/data-forwarding/index.md
+++ b/docs/manage/data-forwarding/index.md
@@ -48,7 +48,7 @@ In this section, we'll introduce the following concepts:
         <img src={useBaseUrl('img/icons/operations/send-data.png')} alt="Thumbnail icon" width="45" />
         <h4>View Information About Data Forwarding</h4>
       </a>
-      <p>Learn how to view a list of data forwarding configured for your organization, and to view the basic info and details of data forwarding.</p>
+      <p>Learn how to view data forwarding configuration information for your organization.</p>
     </div>
   </div>
   </div>

--- a/docs/manage/data-forwarding/index.md
+++ b/docs/manage/data-forwarding/index.md
@@ -17,6 +17,15 @@ In this section, we'll introduce the following concepts:
 <div className="box-wrapper">
   <div className="box smallbox card">
     <div className="container">
+      <a href="/docs/manage/data-forwarding/installed-collectors">
+        <img src={useBaseUrl('img/icons/operations/send-data.png')} alt="Thumbnail icon" width="45" />
+        <h4>Forward Data from an Installed Collector</h4>
+      </a>
+      <p>Learn how to set up Data Forwarding destinations for Installed Collectors.</p>
+    </div>
+  </div>
+  <div className="box smallbox card">
+    <div className="container">
       <a href="/docs/manage/data-forwarding/amazon-s3-bucket">
         <img src={useBaseUrl('img/icons/operations/send-data.png')} alt="Thumbnail icon" width="45" />
         <h4>Forward Data from Sumo Logic to S3</h4>
@@ -31,6 +40,15 @@ In this section, we'll introduce the following concepts:
         <h4>Manage Data Forwarding</h4>
       </a>
       <p>View, edit, delete, activate, and deactivate data forwarding destinations.</p>
+    </div>
+  </div>
+  <div className="box smallbox card">
+    <div className="container">
+      <a href="/docs/manage/data-forwarding/view-list-data-forwarding/">
+        <img src={useBaseUrl('img/icons/operations/send-data.png')} alt="Thumbnail icon" width="45" />
+        <h4>View Information About Data Forwarding</h4>
+      </a>
+      <p>Learn how to view a list of data forwarding configured for your organization, and to view the basic info and details of data forwarding.</p>
     </div>
   </div>
   </div>

--- a/docs/manage/data-forwarding/installed-collectors.md
+++ b/docs/manage/data-forwarding/installed-collectors.md
@@ -1,15 +1,15 @@
 ---
 id: installed-collectors
-title: Archive Log Data to Other Destinations
-description: Learn how to set up Data Archiving destinations.
+title: Forward Data from an Installed Collector
+description: Learn how to set up Data Forwarding destinations for Installed Collectors.
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-You can set up one or more data archiving destinations and configure an Installed Collector to send raw log data from specified Sources to those destinations. The Collector will send the raw data to external destinations at the same time it sends data to Sumo.
+You can set up one or more data forwarding destinations and configure an Installed Collector to send raw log data from specified Sources to those destinations. The Collector will send the raw data to external destinations at the same time it sends data to Sumo.
 
-You can archive raw log data using the following protocols.
+You can forward raw log data using the following protocols.
 
 * Syslog (TCP and UDP)—Send log data to a syslog server.
 * Generic REST API—Send log data to a web services endpoint.
@@ -17,17 +17,17 @@ You can archive raw log data using the following protocols.
 
 Follow the steps below to set up a Collector to forward raw log data to an external destination.
 
-You can set up Installed Collector data archiving when you first configure Sources or at a later time. If you apply rules at a later time, keep in mind that they are not applied retroactively.
+You can set up Installed Collector data forwarding when you first configure Sources or at a later time. If you apply rules at a later time, keep in mind that they are not applied retroactively.
 
 :::note
 Data forwarding processing rules are processed after all other [processing rules](/docs/send-data/collection/processing-rules).
 :::
 
-## Step 1: Configure data archiving destination
+## Step 1: Configure data forwarding destination
 
 You need the [Manage Collectors role capability](../users-roles/roles/role-capabilities.md) to create a data forwarding destination.
 
-To set up a data archiving destination:
+To set up a data forwarding destination:
 
 1. Choose **Manage Data > Collection > Data Archiving**.
 1. Click **+ Destination** to add a new destination.

--- a/docs/send-data/collection/processing-rules/create-processing-rule.md
+++ b/docs/send-data/collection/processing-rules/create-processing-rule.md
@@ -81,7 +81,7 @@ You can add a processing rule to an existing Source or create a processing rule 
     * [Include messages that match](include-and-exclude-rules.md). Send only the data you'd like in your Sumo Logic account, think of it as an "allowlist" filter. This type of filter can be very useful when the list of log data you want to send to Sumo Logic is easier to filter than setting up exclude filters for all of the types of messages you'd like to exclude, for example, if you only want to include only messages coming from a firewall.
     * [Hash messages that match](hash-rules.md). Replace a message with a unique, randomly-generated code to protect sensitive or proprietary information. You may want to hash unique identifiers, such as credit card numbers or user names. By hashing this type of data, you can still track it, even though it is fully hidden.
     * [Mask messages that match](mask-rules.md). Replace an expression with a mask string that you can customize—another option to protect data, such as passwords, that you'dn't normally track.
-    * Forward messages that match. Send data from an Installed Collector Source to a selected non-Sumo location. This option is only available if you have configured a data forwarding destination. For more information, see [Archive Log Data to other destinations](/docs/manage/data-archiving/installed-collectors.md).
+    * Forward messages that match. Send data from an Installed Collector Source to a selected non-Sumo location. This option is only available if you have configured a data forwarding destination. For more information, see [Forward Data from an Installed Collector](/docs/manage/data-forwarding/installed-collectors).
 
 1. Click **Apply** to add the rule. Continue to add rules as needed.
 

--- a/docs/send-data/use-json-configure-sources/index.md
+++ b/docs/send-data/use-json-configure-sources/index.md
@@ -336,7 +336,7 @@ To determine the sinkId for a data forwarding destination, you use the Sumo web 
 
 These instruction assume you have already created a data forwarding destination.
 
-1. Follow the instructions in [Configure processing rules for data forwarding](/docs/manage/data-archiving/installed-collectors.md#configure-processing-rules-for-data-forwarding) to add a data forwarding rule to a source on an installed collector. As part of this process, you will select the data forwarding destination to which you want to forward data.
+1. Follow the instructions in [Configure processing rules for data forwarding](/docs/manage/data-forwarding/installed-collectors#step-2-configure-processing-rules-for-data-forwarding) to add a data forwarding rule to a source on an installed collector. As part of this process, you will select the data forwarding destination to which you want to forward data.
 1. To view the JSON configuration for the source you updated in the previous step:
    1. Select **Manage Data** > **Collection** > **Collection**. 
    1. Click the icon to the right of the source. The API usage information panel appears. Make a note of the sinkId in the filter section of the JSON.<br/>  ![sink id](/img/send-data/sinkId.png)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -740,6 +740,7 @@ module.exports = {
       collapsed: true,
       link: {type: 'doc', id: 'manage/data-forwarding/index'},
       items: [
+        'manage/data-forwarding/installed-collectors',
         'manage/data-forwarding/amazon-s3-bucket',
         'manage/data-forwarding/manage',
         'manage/data-forwarding/view-list-data-forwarding',
@@ -753,7 +754,6 @@ module.exports = {
       link: {type: 'doc', id: 'manage/data-archiving/index'},
       items: [
         'manage/data-archiving/archive',
-        'manage/data-archiving/installed-collectors',
       ]
     },
     {


### PR DESCRIPTION


## Purpose of this pull request

This pull request undoes work done by PR [#2294](https://github.com/SumoLogic/sumologic-documentation/pull/2294) and moves this article back under [Data Forwarding](https://help.sumologic.com/docs/manage/data-forwarding/):
https://help.sumologic.com/docs/manage/data-archiving/installed-collectors/

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

Per Issue #3338 

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me
