### PR TITLE
Removed CSS rule for DocCardList that hid the top border on hover in dark theme.

### DIFF
--- a/src/css/sumo.scss
+++ b/src/css/sumo.scss
@@ -1085,7 +1085,6 @@ html[data-theme='dark'] .node polygon {
 }
 
 html[data-theme='dark'] .card:hover {
-  border-top: 4px solid var(--ds-blue-700);
   transition: none;
 }
 


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request...

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
