### PR TITLE
Added counter to show the total number of integrations in App Central

### DIFF
--- a/docs/platform-services/automation-service/app-central/integrations/index.md
+++ b/docs/platform-services/automation-service/app-central/integrations/index.md
@@ -13,9 +13,9 @@ Please refer to the individual integration documentation for detailed informatio
 Some integrations are tailor-made for Cloud SOAR and are indicated as such within their respective documentation entries. These integrations only appear in the [Cloud SOAR App Central](/docs/cloud-soar/automation/#app-central).
 :::
 
-## Integrations list
+## Integrations (321)
 
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<DocCardList items={useCurrentSidebarCategory().items} />


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

This pull request...

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
