### PR TITLE
feat: replace Otelcol's deprecated Logging exporter with Debug exporter

### DIFF
--- a/docs/apm/traces/get-started-transaction-tracing/set-up-traces-collection-for-kubernetes-environments.md
+++ b/docs/apm/traces/get-started-transaction-tracing/set-up-traces-collection-for-kubernetes-environments.md
@@ -157,14 +157,14 @@ After enabling and installing tracing, you should have additional Kubernetes res
 * There are running pods `<RELEASE_NAME>-sumologic-otelcol-instrumentation-<hash>, <RELEASE_NAME>-sumologic-traces-gateway-<hash>, <RELEASE_NAME>-sumologic-traces-sampler-<hash>`
 * Kubernetes metadata tags such as `pod` and `replicaset` should be applied to all spans.
 * The OpenTelemetry Collector can export metrics, which include information such as the number of spans exported. Several metrics starting with `otelcol_` will become available, such as `otelcol_exporter_sent_spans` and `otelcol_receiver_accepted_spans`.
-* **OpenTelemetry Collector can have logging exporter enabled.** This will put on the output contents of spans (with some sampling above a certain rate). To enable, apply the following flags when installing/upgrading the collector (appending logging to the list of exporters):
+* **OpenTelemetry Collector can have Debug exporter enabled.** This will put on the output contents of spans (with some sampling above a certain rate). To enable, apply the following flags when installing/upgrading the collector (appending `debug` to the list of exporters):
 
     ```bash
     helm upgrade collection sumologic/sumologic \
       --namespace sumologic \
       ...
-      --set tracesSampler.config.exporters.logging.logLevel=debug \
-      --set tracesSampler.config.service.pipelines.traces.exporters="{otlphttp,logging}"
+      --set tracesSampler.config.exporters.debug.verbosity=detailed \
+      --set tracesSampler.config.service.pipelines.traces.exporters="{otlphttp,debug}"
     ```
 
   Having this enabled, `kubectl logs -n sumologic collection-sumologic-traces-sampler-<ENTER ACTUAL POD ID>` might yield the following output:

--- a/docs/send-data/kubernetes/troubleshoot-collection.md
+++ b/docs/send-data/kubernetes/troubleshoot-collection.md
@@ -345,14 +345,14 @@ metadata:
     config:
       merge:
         exporters:
-          logging:
+          debug:
             verbosity: detailed
         service:
           pipelines:
             metrics:
               exporters:
                 - sumologic/default
-                - logging
+                - debug
 ```
 
 This configuration ensures that all metrics are printed to stdout and they are not collected by logs collector to keep your ingest low.

--- a/docs/send-data/opentelemetry-collector/quickstart.md
+++ b/docs/send-data/opentelemetry-collector/quickstart.md
@@ -83,18 +83,18 @@ receivers:
     scrapers:
       memory:
 
-  exporters:
-    logging:
-      loglevel: debug
+exporters:
+  debug:
+    verbosity: detailed
 
-  service:
-    pipelines:
-      metrics:
-        receivers:
-          - hostmetrics
-        exporters:
-          - sumologic
-          - logging
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+      exporters:
+        - sumologic
+        - debug
 ```
 
 <details>
@@ -132,7 +132,7 @@ At this point, the collector should be running and sending memory stats data int
 
 Then after that, every 5 seconds you should see a line like:
 
-`[...] MetricsExporter {"kind": "exporter", "data_type": "metrics", "name": "logging", "#metrics": 1} [...]`
+`[...] MetricsExporter {"kind": "exporter", "data_type": "metrics", "name": "debug", "#metrics": 1} [...]`
 
 If you see that kind of output, the collector has successfully set up a connection to Sumo Logic and is sending memory stats metrics as expected. Great! Now let’s go find those in Sumo.
 


### PR DESCRIPTION

## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [ ] Yes, I've run `yarn install`
- [x] No, does not apply to me

## Purpose of this pull request

This pull request replaces occurrences of the OpenTelemetry Collector's Logging exporter with Debug exporter, as the Logging exporter is deprecated: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.94.1/exporter/loggingexporter/README.md.

https://sumologic.atlassian.net/browse/OSC-543

## Select the type of change:

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
