### PR TITLE
fix: use latest version of Otelcol in installattion docs

### DIFF
--- a/docs/send-data/opentelemetry-collector/install-collector/linux.md
+++ b/docs/send-data/opentelemetry-collector/install-collector/linux.md
@@ -89,7 +89,7 @@ The following arguments can be passed to the script:
 | `--skip-installation-token` | `k`        | Skips requirement for installation token. This option do not disable default configuration creation.      | No          |
 | `--tag`                     | `t`        | Sets tag for collector. This argument can be use multiple times. One per tag.              | Yes, in `key=value` format |
 | `--download-only`           | `w`        | Download new binary only and skip configuration part.           | No                         |
-| `--version`                 | `v`        | Version of Sumo Logic Distribution for OpenTelemetry Collector to install. By default, it gets latest version.             | Yes, e.g. `0.71.0-sumo-0`  |
+| `--version`                 | `v`        | Version of Sumo Logic Distribution for OpenTelemetry Collector to install. By default, it gets latest version.             | Yes, e.g. `0.94.0-sumo-2`  |
 | `--skip-config`             | `s`        | Do not create default configuration            | No                         |
 | `--skip-systemd`            | `d`        | Preserves from Systemd service installation.               | No                         |
 | `--fips`                    | `f`        | Install the FIPS-compliant binary. See [FIPS section](#fips) for more details.             | No                         |
@@ -109,7 +109,7 @@ The following env variables can be used along with script:
 
 #### Step 1. Download the Binary
 
-Examples for OpenTelemetry Collector version `0.73.0-sumo-0`.
+Examples for OpenTelemetry Collector version `0.94.0-sumo-2`.
 
 <Tabs
   className="unique-tabs"
@@ -123,7 +123,7 @@ Examples for OpenTelemetry Collector version `0.73.0-sumo-0`.
 
 ```bash
 curl -sLo otelcol-sumo \
-"https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.73.0-sumo-0/otelcol-sumo-0.73.0-sumo-0-linux_amd64"
+"https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.94.0-sumo-2/otelcol-sumo-0.94.0-sumo-2-linux_amd64"
 ```
 
 </TabItem>
@@ -131,7 +131,7 @@ curl -sLo otelcol-sumo \
 
 ```bash
 curl -sLo otelcol-sumo \
-"https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.73.0-sumo-0/otelcol-sumo-0.73.0-sumo-0-linux_arm64"
+"https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.94.0-sumo-2/otelcol-sumo-0.94.0-sumo-2-linux_arm64"
 ```
 
 </TabItem>

--- a/docs/send-data/opentelemetry-collector/install-collector/macos.md
+++ b/docs/send-data/opentelemetry-collector/install-collector/macos.md
@@ -87,7 +87,7 @@ The following arguments can be passed to the script:
 | `--skip-installation-token` | `k`        | Skips requirement for installation token. This option do not disable default configuration creation.           | No      |
 | `--tag`                     | `t`        | Sets tag for collector. This argument can be use multiple times. One per tag.               | Yes, in `key=value` format |
 | `--download-only`           | `w`        | Download new binary only and skip configuration part.                                       | No                         |
-| `--version`                 | `v`        | Version of Sumo Logic Distribution for OpenTelemetry Collector to install. By default, it gets latest version.                                                               | Yes (for example: `0.71.0-sumo-0`)  |
+| `--version`                 | `v`        | Version of Sumo Logic Distribution for OpenTelemetry Collector to install. By default, it gets latest version.                                                               | Yes (for example: `0.94.0-sumo-2`)  |
 | `--skip-config`             | `s`        | Do not create default configuration        | No                         |
 | `--skip-systemd`            | `d`        | Preserves from Systemd service installation.                                               | No        |
 | `--fips`                    | `f`        | Install the FIPS-compliant binary. See [FIPS section](#fips) for more details.              | No                         |
@@ -107,7 +107,7 @@ The following env variables can be used along with script:
 
 #### Step 1. Download the binary
 
-Examples for OpenTelemetry Collector version `0.73.0-sumo-0`.
+Examples for OpenTelemetry Collector version `0.94.0-sumo-2`.
 
 <Tabs
   className="unique-tabs"
@@ -120,14 +120,14 @@ Examples for OpenTelemetry Collector version `0.73.0-sumo-0`.
 <TabItem value="amd64 (x86-64)">
 
 ```bash
-curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.73.0-sumo-0/otelcol-sumo-0.73.0-sumo-0-darwin_amd64"
+curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.94.0-sumo-2/otelcol-sumo-0.94.0-sumo-2-darwin_amd64"
 ```
 
 </TabItem>
 <TabItem value="arm64 (Apple Silicon)">
 
 ```bash
-curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.73.0-sumo-0/otelcol-sumo-0.73.0-sumo-0-darwin_arm64"
+curl -sLo otelcol-sumo "https://github.com/SumoLogic/sumologic-otel-collector/releases/download/v0.94.0-sumo-2/otelcol-sumo-0.94.0-sumo-2-darwin_arm64"
 ```
 
 


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

A customer has pointed out we use an old version in docs.

## Select the type of change:

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
