### PR TITLE
feat: add `-Fips` option to Windows Otelcol installer

### DIFF
--- a/docs/send-data/opentelemetry-collector/install-collector/windows.md
+++ b/docs/send-data/opentelemetry-collector/install-collector/windows.md
@@ -71,6 +71,7 @@ The script is going to perform the following operations:
 | `-InstallationToken` | Installation token      | Yes       |
 | `-Tags`         | Sets tags for collector. This argument should be a map. | Yes, for example `@{"host.group" = "default"; "deployment.environment" = "default"}` |
 | `-InstallHostMetrics` | Installs the hostmetrics configuration to collect host metrics. The default is `$False`. | Yes, for example: `-InstallHostMetrics $True` or `-InstallHostMetrics $False`. |
+| `-Fips` | If set to `$True`, installs the FIPS-compliant binary. The default is `$False`. See [FIPS](#fips) section for more details. | Yes, for example: `-Fips $True` or `-Fips $False` |
 
 ### Manual Step-by-Step Installation
 
@@ -132,7 +133,7 @@ Restart `Sumo Logic OpenTelemetry Collector` (`OtelcolSumo`) service to apply th
 
 #### FIPS
 
-We currently do not build FIPS binary for Windows.
+To install FIPS compliant binary, add `-Fips $True` option to the installation command.
 
 Refer to [BoringCrypto and FIPS compliance](https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/fips.md) in our repository for more details.
 


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

Adds the `-Fips` option to the Windows installer docs for OpenTelemetry Collector. The option has been available since Sumo Otelcol `v0.89.0-sumo-0` (see https://github.com/SumoLogic/sumologic-otel-collector/pull/1328), but not documented.

## Select the type of change:

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
