### PR TITLE
fix: fix TOC for Windows Otelcol installation

### DIFF
--- a/docs/send-data/opentelemetry-collector/install-collector/windows.md
+++ b/docs/send-data/opentelemetry-collector/install-collector/windows.md
@@ -101,7 +101,7 @@ Running  OtelcolSumo        Sumo Logic OpenTelemetry Collector
 ```
 Alternatively, you can open `Services.msc` and check whether Sumo Logic OTel Collector Service is running or not.
 
-## Additional Settings
+### Additional Settings
 
 This section describes common OpenTelemetry customizations.
 
@@ -137,7 +137,7 @@ To install FIPS compliant binary, add `-Fips $True` option to the installation c
 
 Refer to [BoringCrypto and FIPS compliance](https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/fips.md) in our repository for more details.
 
-### Uninstall
+## Uninstall
 
 1. Go to **Add or remove programs**.<br/> <img src={useBaseUrl('img/send-data/opentelemetry-collector/windows-uninstall-1.png')} alt="windows-uninstallation-1.png" width="550" />
 1. Find **OpenTelemetry Collector** and click **Uninstall**.<br/>  <img src={useBaseUrl('img/send-data/opentelemetry-collector/windows-uninstall-2.png')} alt="windows-uninstallation-2.png" width="550" />


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

Adjusts the Table of Contents for Otelcol Windows installation to match Linux and MacOS
- `Additional Settings` go under `Install`
- `Uninstall` is at the same level as `Install`

## Select the type of change:

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
