### PR TITLE
feat: add `-Version` option to Windows installation script

### DIFF
--- a/docs/send-data/opentelemetry-collector/install-collector/windows.md
+++ b/docs/send-data/opentelemetry-collector/install-collector/windows.md
@@ -72,6 +72,7 @@ The script is going to perform the following operations:
 | `-Tags`         | Sets tags for collector. This argument should be a map. | Yes, for example `@{"host.group" = "default"; "deployment.environment" = "default"}` |
 | `-InstallHostMetrics` | Installs the hostmetrics configuration to collect host metrics. The default is `$False`. | Yes, for example: `-InstallHostMetrics $True` or `-InstallHostMetrics $False`. |
 | `-Fips` | If set to `$True`, installs the FIPS-compliant binary. The default is `$False`. See [FIPS](#fips) section for more details. | Yes, for example: `-Fips $True` or `-Fips $False` |
+| `-Version` | Version of Sumo Logic Distribution for OpenTelemetry Collector to install. By default, it gets latest version. | Yes, for example: `-Version 0.94.0-sumo-2` |
 
 ### Manual Step-by-Step Installation
 


### PR DESCRIPTION
## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me

## Purpose of this pull request

Adds the `-Version` option to Otelcol Windows installation docs. This option has been available from the start.

## Select the type of change:

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
