### PR TITLE
Fix typo in Network Sensor Deployment Guide

### DIFF
--- a/docs/cse/sensors/network-sensor-deployment-guide.md
+++ b/docs/cse/sensors/network-sensor-deployment-guide.md
@@ -105,7 +105,7 @@ yum update -y
 yum install -y kernel-$(uname -r) kernel-headers-$(uname -r) kernel-devel-$(uname -r) gcc*
 dnf install -y 'dnf-command(config-manager)'
 dnf config-manager --set-enabled powertools
-yum install -y elfutils-libelf-devel python36
+yum install -y elfutils-libelf-devel python3
 reboot
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes a typo in this section:
https://help.sumologic.com/docs/cse/sensors/network-sensor-deployment-guide/#prerequisites-for-centos

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

The typo was reported in PR #3703.

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me
