### PR TITLE
INVS-2087 - killChain attribute

### DIFF
--- a/docs/platform-services/threat-intelligence-indicators.md
+++ b/docs/platform-services/threat-intelligence-indicators.md
@@ -439,7 +439,7 @@ If uploading a CSV file using the API, the file should be contained in a JSON ob
 
 ```
 {
- "csv": "0001,192.0.2.0,ipv4-addr,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,3,malicious-activity,\n
+ "csv": "0001,192.0.2.0,ipv4-addr,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,3,malicious-activity,,\n
 0002,192.0.2.1,ipv4-addr,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,3,malicious-activity,actor3,reconnaissance\n"
 }
 ```

--- a/docs/platform-services/threat-intelligence-indicators.md
+++ b/docs/platform-services/threat-intelligence-indicators.md
@@ -352,6 +352,7 @@ Following is an example threat indicator file in normalized JSON format. (For an
      "confidence": 30,
      "threatType": "malicious-activity",
      "actors": "actor1,actor2",
+     "killChain": "reconnaissance",
      "fields": {
        "kill_chain_name": "lockheed-martin-cyber-kill-chain",
        "kill_chain_phase": "reconnaissance"
@@ -367,6 +368,7 @@ Following is an example threat indicator file in normalized JSON format. (For an
      "confidence": 30,
      "threatType": "malicious-activity",
      "actors": "actor3,actor4",
+     "killChain": "reconnaissance",
      "fields": {
        "kill_chain_name": "lockheed-martin-cyber-kill-chain",
        "kill_chain_phase": "reconnaissance"
@@ -404,8 +406,18 @@ The following attributes are required:
           * `malicious-activity`. Patterns of suspected malicious objects and/or activity.
           * `attribution`. Patterns of behavior that indicate attribution to a particular threat actor or campaign.
           * `unknown` (or not set). There is not enough information available to determine the threat type.
-       * **actors** (string list) is an optional attribute. An identified threat actor such as an individual, organization, or group. For example, `actor1`. This attribute is frequently used in the s_CrowdStrike source.
 
+      The following attributes are optional:
+       * **actors** (string list). An identified threat actor such as an individual, organization, or group. For example, `actor1`. This attribute is frequently used in the s_CrowdStrike source.
+       * **killChain** (string list). The various phases an attacker may undertake to achieve their objectives (as [defined by kill_chain_phase in STIX 2.1](https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_i4tjv75ce50h)). For example, `reconnaissance`. This attribute is frequently used in the s_CrowdStrike source. Although you can use any kill chain definition and values you want, following are example values based on the standard stages in a kill chain:
+          * `reconnaissance`.  Researching potential targets.
+          * `weaponization`. Creation of malware to be used against an identified target.
+          * `delivery`. Infiltration of a target’s network and users. 
+          * `exploitation`. Taking advantage of the vulnerabilities discovered in previous stages to further infiltrate a target’s network and achieve objectives.
+          * `installation`. Install malware and other cyberweapons onto the target network to take control of its systems and exfiltrate valuable data.
+          * `command-and-control`. Communication with the installed malware.
+          * `actions-on-objectives`. Carrying out cyberattack objectives.
+         
 ### CSV format
 
 Comma-separated value (CSV) is a standard format for data upload.
@@ -418,7 +430,7 @@ If uploading a CSV file with the UI, the format should be the same as used for a
 
 ```
 0001,192.0.2.0,ipv4-addr:value,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,30,malicious-activity,
-0002,192.0.2.1,ipv4-addr:value,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,30,malicious-activity,actor3
+0002,192.0.2.1,ipv4-addr:value,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,30,malicious-activity,actor3,reconnaissance
 ```
 
 ##### Upload with the API
@@ -428,7 +440,7 @@ If uploading a CSV file using the API, the file should be contained in a JSON ob
 ```
 {
  "csv": "0001,192.0.2.0,ipv4-addr,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,3,malicious-activity,\n
-0002,192.0.2.1,ipv4-addr,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,3,malicious-activity,actor3\n"
+0002,192.0.2.1,ipv4-addr,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,3,malicious-activity,actor3,reconnaissance\n"
 }
 ```
 
@@ -463,7 +475,17 @@ Columns for the following attributes are required in the upload file:
           * `malicious-activity`. Patterns of suspected malicious objects and/or activity.
           * `attribution`. Patterns of behavior that indicate attribution to a particular threat actor or campaign.
           * `unknown` (or not set). There is not enough information available to determine the threat type.
-       * **actors** (string list) is an optional attribute. An identified threat actor such as an individual, organization, or group. For example, `actor3`. This attribute is frequently used in the s_CrowdStrike source. Note if you don’t provide a value for `actors`, you still must provide the empty column at the end of the row with an extra comma, as shown in the examples above.
+
+      The following attributes are optional: 
+       * **actors** (string list). An identified threat actor such as an individual, organization, or group. For example, `actor3`. This attribute is frequently used in the s_CrowdStrike source. Note if you don’t provide a value for `actors`, you still must provide the empty column at the end of the row with an extra comma, as shown in the examples above.
+       * **killChain** (string list). The various phases an attacker may undertake to achieve their objectives (as [defined by kill_chain_phase in STIX 2.1](https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_i4tjv75ce50h)). For example, `reconnaissance`. This attribute is frequently used in the s_CrowdStrike source. Although you can use any kill chain definition and values you want, following are example values based on the standard stages in a kill chain:
+          * `reconnaissance`.  Researching potential targets.
+          * `weaponization`. Creation of malware to be used against an identified target.
+          * `delivery`. Infiltration of a target’s network and users. 
+          * `exploitation`. Taking advantage of the vulnerabilities discovered in previous stages to further infiltrate a target’s network and achieve objectives.
+          * `installation`. Install malware and other cyberweapons onto the target network to take control of its systems and exfiltrate valuable data.
+          * `command-and-control`. Communication with the installed malware.
+          * `actions-on-objectives`. Carrying out cyberattack objectives.
 
 ### STIX 2.1 JSON format
 

--- a/docs/platform-services/threat-intelligence-indicators.md
+++ b/docs/platform-services/threat-intelligence-indicators.md
@@ -429,7 +429,7 @@ Comma-separated value (CSV) is a standard format for data upload.
 If uploading a CSV file with the UI, the format should be the same as used for a standard CSV file:
 
 ```
-0001,192.0.2.0,ipv4-addr:value,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,30,malicious-activity,
+0001,192.0.2.0,ipv4-addr:value,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,30,malicious-activity,,
 0002,192.0.2.1,ipv4-addr:value,FreeTAXII,2023-02-21T12:00:00.00Z,2025-05-21T12:00:00.00Z,30,malicious-activity,actor3,reconnaissance
 ```
 


### PR DESCRIPTION


## Purpose of this pull request

This pull request adds the killChain attribute to this section:
https://help.sumologic.com/docs/platform-services/threat-intelligence-indicators/#upload-formats

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

Issue: [INVS-2087](https://sumologic.atlassian.net/browse/INVS-2087)

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me
