### PR TITLE
SUMO-126818 - Add note about localhost error

### DIFF
--- a/docs/integrations/hosts-operating-systems/opentelemetry/windows-opentelemetry.md
+++ b/docs/integrations/hosts-operating-systems/opentelemetry/windows-opentelemetry.md
@@ -55,7 +55,7 @@ import SetupColl from '../../../reuse/apps/opentelemetry/set-up-collector.md';
 
 ### Step 2: Configure integration
 
-In this step, you will configure the yaml file required for Windows event logs and metrics Collection.
+In this step, you will configure the YAML file required for Windows event logs and metrics Collection.
 
 Any custom fields can be tagged along with the data in this step.
 
@@ -65,7 +65,7 @@ import ProcMetrics from '../../../reuse/apps/opentelemetry/process-metric-collec
 
 <ProcMetrics/>
 
-Click on the **Download YAML File** button to get the yaml file.<br/><img src={useBaseUrl('img/integrations/hosts-operating-systems/Windows-YAML.png')} alt="Windows-YAML" style={{border:'1px solid gray'}} width="800"/>
+Click on the **Download YAML File** button to get the YAML file.<br/><img src={useBaseUrl('img/integrations/hosts-operating-systems/Windows-YAML.png')} alt="Windows-YAML" style={{border:'1px solid gray'}} width="800"/>
 
 ### Step 3: Send logs to Sumo
 
@@ -85,7 +85,7 @@ import LogsIntro from '../../../reuse/apps/opentelemetry/send-logs-intro.md';
 
 <TabItem value="Windows">
 
-1. Copy the yaml file to `C:\ProgramData\Sumo Logic\OpenTelemetry Collector\config\conf.d` folder in the machine that needs to be monitored.
+1. Copy the YAML file to `C:\ProgramData\Sumo Logic\OpenTelemetry Collector\config\conf.d` folder in the machine that needs to be monitored.
 2. Restart the collector using:
   ```sh
   Restart-Service -Name OtelcolSumo
@@ -121,6 +121,10 @@ import PuppetNoEnv from '../../../reuse/apps/opentelemetry/puppet-without-env.md
 import LogsOutro from '../../../reuse/apps/opentelemetry/send-logs-outro.md';
 
 <LogsOutro/>
+
+:::note
+If you receive an error during installation that includes the message `failed to bind to address localhost`, change all instances of `localhost` to `127.0.0.1` in the YAML file. 
+:::
 
 ## Sample metrics message
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds a note to the following section per a request in the [#dochub Slack channel](https://sumologic.slack.com/archives/C0S86TM6K/p1709128518435919): https://help.sumologic.com/docs/integrations/hosts-operating-systems/opentelemetry/windows-opentelemetry/#step-3-send-logs-to-sumo

It also changes instances of "yaml" to "YAML".

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [x] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## PLEASE READ

Following a recent back-end update, all contributors with a local clone or fork of our repository are required to run `yarn install`. This does not apply to [direct page edits](https://help.sumologic.com/docs/contributing/edit-doc/#minor-edits).

- [x] Yes, I've run `yarn install`
- [ ] No, does not apply to me
