### PR TITLE
Updating default payload for PagerDuty v2

### DIFF
--- a/docs/alerts/webhook-connections/pagerduty.md
+++ b/docs/alerts/webhook-connections/pagerduty.md
@@ -51,7 +51,6 @@ The URL and supported payload are different based on the version of the PagerDut
    {
      "routing_key": "SERVICE KEY",
      "event_action": "trigger",
-     "description": "{{TriggerType}} Alert:{{AlertName}}",
      "client": "Sumo Logic",
      "client_url": "{{AlertResponseURL}}",
      "payload": {


### PR DESCRIPTION
## Purpose of this pull request
https://developer.pagerduty.com/api-reference/368ae3d938c9e-send-an-event-to-pager-duty - pagerduty v2 api doesn't support `description` field so removing it from our docs as well.

<!-- Enter the GitHub Issue number or the Jira project and number (e.g., SUMO-12345) -->

## Select the type of change:
<!-- What types of changes does your code introduce? Select the checkbox after creating the PR. -->

- [ ] Minor Changes - Typos, formatting, slight revisions, .clabot
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)
