### PR TITLE
correct SUMOLOGIC_URL referent

### DIFF
--- a/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
+++ b/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
@@ -74,7 +74,7 @@ steps below to update the existing hierarchy :
 
 :::note
 - **ACCESS_ID** and **ACCESS_KEY** - Replace parameters with your sumo logic access Id and access key.
-- **SUMOLOGIC_URL** - Replace with [api endpoint URL](https://help.sumologic.com/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) as per deployment.
+- **SUMOLOGIC_URL** - Replace with [API Endpoint URL](https://help.sumologic.com/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) as per deployment.
 - **ID** - Replace with the hierarchy ID as present in the JSON output from Step 1.
 - **JSON_CONTENT_AFTER_UPDATE** - Replace with the JSON updated with new AWS service after Step 2.
 :::

--- a/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
+++ b/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
@@ -73,10 +73,10 @@ update the existing hierarchy to show the new AWS Service. Follow the
 steps below to update the existing hierarchy :
 
 :::note
-- **ACCESS_ID** and **ACCESS_KEY** - Replace parameters with your sumo logic access Id and access key.
-- **SUMOLOGIC_URL** - Replace with [API Endpoint URL](https://help.sumologic.com/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) as per deployment.
-- **ID** - Replace with the hierarchy ID as present in the JSON output from Step 1.
-- **JSON_CONTENT_AFTER_UPDATE** - Replace with the JSON updated with new AWS service after Step 2.
+- **ACCESS_ID** and **ACCESS_KEY**. Replace parameters with your Sumo Logic access Id and access key.
+- **SUMOLOGIC_URL**. Replace with [API Endpoint URL](/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) as per deployment.
+- **ID**. Replace with the hierarchy ID as present in the JSON output from Step 1.
+- **JSON_CONTENT_AFTER_UPDATE**. Replace with the JSON updated with new AWS service after Step 2.
 :::
 
 1. Run the below curl command to get the existing AWS Observability hierarchy.

--- a/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
+++ b/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
@@ -72,6 +72,13 @@ Once all the tags are checked and identified in the metrics, we can
 update the existing hierarchy to show the new AWS Service. Follow the
 steps below to update the existing hierarchy :
 
+:::note
+- **ACCESS_ID** and **ACCESS_KEY** - Replace parameters with your sumo logic access Id and access key.
+- **SUMOLOGIC_URL** - Replace with [api endpoint URL](https://help.sumologic.com/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) as per deployment.
+- **ID** - Replace with the hierarchy ID as present in the JSON output from Step 1.
+- **JSON_CONTENT_AFTER_UPDATE** - Replace with the JSON updated with new AWS service after Step 2.
+:::
+
 1. Run the below curl command to get the existing AWS Observability hierarchy.
    ```bash
    curl -s -H "Content-Type: application/json" --user
@@ -174,13 +181,6 @@ steps below to update the existing hierarchy :
     https://<SUMOLOGIC_URL>/api/v1/entities/hierarchies/<ID> -d
    '<JSON_CONTENT_AFTER_UPDATE>'
    ```
-
-:::note
-1. **ACCESS_ID** and **ACCESS_KEY** - Replace parameters with your sumo logic access Id and access key.
-1. **SUMOLOGIC_URL** - Replace with service endpoint URL as per deployment.
-1. **ID** - Replace with the hierarchy ID as present in the JSON output from Step 1.
-1. **JSON_CONTENT_AFTER_UPDATE** - Replace with the JSON updated with new AWS service after Step 2.
-:::
 
 ### Validate the new Hierarchy
 

--- a/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
+++ b/docs/observability/aws/other-configurations-tools/add-new-aws-service.md
@@ -73,10 +73,11 @@ update the existing hierarchy to show the new AWS Service. Follow the
 steps below to update the existing hierarchy :
 
 :::note
-- **ACCESS_ID** and **ACCESS_KEY**. Replace parameters with your Sumo Logic access Id and access key.
-- **SUMOLOGIC_URL**. Replace with [API Endpoint URL](/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) as per deployment.
-- **ID**. Replace with the hierarchy ID as present in the JSON output from Step 1.
-- **JSON_CONTENT_AFTER_UPDATE**. Replace with the JSON updated with new AWS service after Step 2.
+In the code samples in the following steps:
+- **ACCESS_ID** and **ACCESS_KEY**. Replace with your Sumo Logic access ID and access key.
+- **SUMOLOGIC_URL**. Replace with the [API Endpoint URL](/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) for your deployment.
+- **ID**. Replace with the hierarchy ID as present in the JSON output from Step 1 below.
+- **JSON_CONTENT_AFTER_UPDATE**. Replace with the JSON updated with new AWS service after Step 2 below.
 :::
 
 1. Run the below curl command to get the existing AWS Observability hierarchy.


### PR DESCRIPTION
Users need to use the API endpoint, not the service endpoint (e.g. login page).

## Purpose of this pull request

This pull request corrects and clarifies details around which SUMOLOGIC_URL is used with the example curl commands.

## Select the type of change

- [X ] Minor Changes - Typos, formatting, slight revisions

