### PR TITLE
Add CID entries for "Estimate Scan Data" article

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -3869,5 +3869,7 @@
   "/docs/manage/partitions-data-tiers/decommission-partition": "/docs/manage/partitions/decommission-partition",
   "/docs/manage/partitions-data-tiers/data-tiers": "/docs/manage/partitions/data-tiers",
   "/docs/manage/partitions-data-tiers/data-tiers-faqs": "/docs/manage/partitions/data-tiers/data-tiers-faqs",
-  "/docs/manage/partitions-data-tiers/searching-data-tiers": "/docs/manage/partitions/data-tiers/searching-data-tiers"
-}
+  "/docs/manage/partitions-data-tiers/searching-data-tiers": "/docs/manage/partitions/data-tiers/searching-data-tiers",
+  "/docs/manage/partitions-data-tiers/flex-pricing/estimate-and-actual-scan-data": "/docs/manage/partitions/flex/estimate-scan-data",
+  "/docs/manage/partitions/flex/estimate-and-actual-scan-data": "/docs/manage/partitions/flex/estimate-scan-data"
+} 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds redirects to our CID file that point to this article:
https://help.sumologic.com/docs/manage/partitions/flex/estimate-scan-data/

The article file was renamed by PR #3855, but we forgot to do a CID for the renaming.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

PR created per [a request in the #dochub Slack channel](https://sumologic.slack.com/archives/C0S86TM6K/p1711552596855849) .
