### PR TITLE
Remove reference to deprecated admonition style

### DIFF
--- a/docs/api/collector-management/index.md
+++ b/docs/api/collector-management/index.md
@@ -11,7 +11,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Collector Management API gives you the ability to manage Collectors and Sources from HTTP endpoints. See the topics below for Collector API and Source API methods and examples, as well as upgrading and downgrading Collectors using the API.
 
-:::caution
+:::warning
 Collector Management APIs are not yet built with OpenAPI specifications and therefore not included in our [Swagger docs](https://api.sumologic.com/docs/). Instead, refer to the below documentation.
 :::
 


### PR DESCRIPTION
## Purpose of this pull request

Remove reference to admonition style "caution", which was deprecated in favor of "warning" with the update to Docusaurus v3.0

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
