### PR TITLE
Fix "Search Job APIs" article

### DIFF
--- a/docs/api/search-job.md
+++ b/docs/api/search-job.md
@@ -931,6 +931,8 @@ https://api.sumologic.com/api/v1/search/jobs/37589506F194FC80
 
 </details>
 
+</details>
+
 ## Bash this Search Job
 
 You can use the following script to exercise the API.
@@ -1005,4 +1007,4 @@ JOB_ID=$(echo $RESULT | sed 's/^.*"id":"\(.*\)".*$/\1/')
 echo Search job deleted, id: $JOB_ID
 ```
 
-</details>
+


### PR DESCRIPTION
## Purpose of this pull request

This pull request makes a minor update to this article:
https://help.sumologic.com/docs/api/search-job/

The "Bash this search job" heading appeared in the right nav, but not in the article itself. It turned out that there was a misplaced tag that caused the problem (introduced in PR #3801).

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

Done per [a request in the #dochub Slack channel](https://sumologic.slack.com/archives/C0S86TM6K/p1711741029879879). 
