### PR TITLE
DOCS-171 - Fix duplicate 'Logs Data Forwarding' entry in left nav

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -2767,7 +2767,6 @@ integrations: [
         'api/health-events',
         'api/ingest-budget-v2',
         'api/ingest-budget-v1',
-        'api/logs-data-forwarding',
         'api/log-search-estimated-usage',
         'api/log-searches',
         'api/logs-data-forwarding',


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes a duplicate "Logs Data Forwarding" entry from the left nav bar.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->
- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-171](https://sumologic.atlassian.net/browse/DOCS-171)
