### PR TITLE
Disable /reuse/ directory from search engine results

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -2,4 +2,5 @@
 
 User-agent: *
 Allow: /
+Disallow: /reuse/
 Sitemap: https://help.sumologic.com/sitemap.xml


### PR DESCRIPTION
## Purpose of this pull request

This pull request disallows the /reuse/ directory from our [robots.txt file](https://developers.google.com/search/blog/2010/03/url-removal-explained-part-i-urls#:~:text=To%20request%20removal%20of%20a,%3E%20Crawler%20access%20%3E%20Remove%20URL.), preventing standalone /reuse/ files from appearing in search engine results.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-194
