### PR TITLE
Remove Fed deployment note in all C2C doc

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -3902,5 +3902,6 @@
   "/docs/integrations/security-threat-detection/palo-alto-networks-8":"/docs/integrations/security-threat-detection/palo-alto-networks-9",
   "/docs/integrations/microsoft-azure/windows-legacy-pci-compliance": "/docs/integrations/microsoft-azure/windows-json-pci-compliance",
   "/docs/integrations/web-servers/nginx-legacy": "/docs/integrations/web-servers/nginx",
-  "/docs/integrations/microsoft-azure/active-directory-legacy": "/docs/integrations/microsoft-azure/active-directory-json"
+  "/docs/integrations/microsoft-azure/active-directory-legacy": "/docs/integrations/microsoft-azure/active-directory-json",
+  "/docs/reuse/fed-deployment-note": "/docs/api/getting-started"
 }

--- a/docs/contributing/templates/c2c-source.md
+++ b/docs/contributing/templates/c2c-source.md
@@ -32,7 +32,7 @@ This source is **not** yet available in the [Fed deployment](/docs/api/getting-s
 
 ## Data collected
 
-\Add all the data sources and respective pollig iterval information\
+\Add all the data sources and respective polling interval information.\
 
 | Polling Interval | Data |
 | :--- | :--- |
@@ -49,23 +49,23 @@ Example:
 
 #### Prerequisites
 
-\NOTE: This section doesn't apply to all sources; use only where needed\
+\NOTE: This section doesn't apply to all sources; use only where needed.\
 
-Example: You'll need a Dropbox App Key, App Secret, and Access Code to provide to Sumo Logic. To generate these credentials, ....
+Example: You'll need a Dropbox App Key, App Secret, and Access Code to provide to Sumo Logic. To generate these credentials, ...
 
-\Insert steps to configure the Source in the Vendor UI\
+\Insert steps to configure the Source in the Vendor UI.\
 
 Example: [Vendor configuration](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/dropbox-source/#vendor-configuration)
 
 ### Source configuration
 
-\Insert steps to configure the Source in the Sumo Logic UI\
+\Insert steps to configure the Source in the Sumo Logic UI.\
 
 Example: [Source configuration](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/dropbox-source/#source-configuration)
 
 ## Metadata fields
 
-\Insert meta deta fields in the Sumo Logic UI. Update the below table accordingly.\
+\Insert metadata fields in the Sumo Logic UI. Update the below table accordingly.\
 
 | Field | Value | Description |
 | :--- | :--- | :--- |

--- a/docs/reuse/fed-deployment-note.md
+++ b/docs/reuse/fed-deployment-note.md
@@ -1,3 +1,0 @@
-:::note
-This source is available in [all deployments](/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security), including the Fed deployment.
-:::

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/1password-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/1password-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The 1Password Source provides a secure endpoint to receive sign-in attempts, item usage, and audit events from the [1Password Event API](https://support.1password.com/events-api-reference/). It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/abnormal-security-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/abnormal-security-source.md
@@ -19,10 +19,6 @@ Abnormal Security is a behavioral AI-based email security platform that learns t
 
 The Abnormal Security integration ingests threat data and case data identified by the abnormal threat log and cases using the [Abnormal Security API](https://app.swaggerhub.com/apis-docs/abnormal-security/abx/1.4.1).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/airtable-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/airtable-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Airtable API integration ingests audit logs periodically from the Airtable app platform into the Sumo Logic environment for storing and analyzing data.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/akamai-siem-api-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/akamai-siem-api-source.md
@@ -22,10 +22,6 @@ The Akamai SIEM API Source provides a secure endpoint to receive security events
 This source has a maximum ingest rate of 1 TB/day as measured by the [Data Volume Index](/docs/manage/ingestion-volume/data-volume-index). If your Source exceeds this rate, [contact Sumo Logic support](https://support.sumologic.com) for alternative collection techniques.
 :::
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/armis-api-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/armis-api-source.md
@@ -19,10 +19,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 Armis API is a device security platform that discover devices, tracks behavior, detects threats, and takes action to protect your business.
 The Source integration ingests alert and device data from the Armis platform.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/asana-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/asana-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Asana Audit Logs API Integration ingests events from [Asana Audit Logs API](https://developers.asana.com/reference/audit-log-api). Asana can help you to break down large work into manageable tasks. It's a comprehensive work management tool that allows you to track project and task progress, share files, comments, and notes, and keep track of deadlines.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/aws-cost-explorer-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/aws-cost-explorer-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The AWS Cost Explorer Source collects cost and usage reports from [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/). You have the option to collect from one or more specific [AWS cost types](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-exploring-data.html) and set how often reports are collected.
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/azure-event-hubs-cloud-to-cloud-source-migration.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/azure-event-hubs-cloud-to-cloud-source-migration.md
@@ -14,10 +14,6 @@ Cloud-to-Cloud sources have several advantages, including:
 * Less overhead of maintenance and upgrades, since cloud-to-cloud sources are upgraded automatically for bug fixes.
 * Lesser cost since the old collection method is used to create multiple resources such as storage accounts, application insights, and azure functions in your account while cloud-to-cloud sources are hosted in sumo logic infra. On the other hand, a cloud-to-cloud event hub source requires you to create only an event hub in your Azure account.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Step 1. Choose a migration strategy
 
 Choose a migration strategy that is more convenient for you. Migration can be done in two ways:

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/azure-event-hubs-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/azure-event-hubs-source.md
@@ -25,10 +25,6 @@ This cloud-to-cloud Azure Event Hubs Source provides a secure endpoint to receiv
 See [Migrating from Azure Function-Based Collection to Event Hub Cloud-to-Cloud Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/azure-event-hubs-cloud-to-cloud-source-migration).
 :::
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/box-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/box-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Box API integration ingests events from the [Get Events API](https://developer.box.com/reference/get-events/). It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/carbon-black-cloud-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/carbon-black-cloud-source.md
@@ -22,10 +22,6 @@ The Carbon Black Cloud Source provides a secure endpoint to receive data from 
 The Event Forwarder is recommended by VMWare Carbon Black over APIs for obtaining large amounts of data from Carbon Black Cloud in real time. Sumo Logic recommends using the Event Forwarder in combination with a Sumo Logic Amazon S3 Source instead of a Carbon Black Cloud Source. For details, see [how to collect logs for Carbon Black](/docs/integrations/security-threat-detection/vmware-carbon-black).
 :::
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/carbon-black-inventory-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/carbon-black-inventory-source.md
@@ -20,10 +20,6 @@ The Carbon Black Inventory Source provides a secure endpoint to receive data f
 
 [See how inventory data is used in Cloud SIEM](/docs/cse/records-signals-entities-insights/view-manage-entities.md).
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cato-networks-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cato-networks-source.md
@@ -17,10 +17,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Cato Networks is a cloud-native, global SD-WAN provider that delivers a secure, optimized, and agile global network for businesses of all sizes. Cato's cloud-based platform converges multiple network and security functions into a unified solution that includes SD-WAN, network security, cloud security, and secure access service edge (SASE) capabilities.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cisco-amp-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cisco-amp-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Cisco AMP Source provides a secure endpoint to receive data from the Cisco Amp [System Log API](https://api-docs.amp.cisco.com/api_resources?api_host=api.amp.cisco.com&api_version=v1). It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cisco-meraki-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cisco-meraki-source.md
@@ -12,10 +12,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Cisco Meraki Source provides a secure endpoint to receive data from the Meraki organization and networks and ingests event logs pertaining to them. It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cisco-vulnerability-management-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cisco-vulnerability-management-source.md
@@ -17,10 +17,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Cisco Vulnerability Management, formerly known as Kenna Security, provides you with the necessary contextual insights and threat intelligence to proactively intercept and respond effectively to potential exploits. The Cisco Vulnerability Management integration collects assets and vulnerability data from the [Cisco API](https://apidocs.kennasecurity.com/reference/welcome).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/citrix-cloud-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/citrix-cloud-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Citrix Cloud source collects the system, operation, and session logs using the Citrix Cloud API and Citrix DaaS REST API to Sumo Logic. Citrix Cloud is a workspace management platform for IT administrators to design, deliver, and manage virtual desktops and applications, and other services, such as file sharing, on any device.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloudquery-azure-plugin-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloudquery-azure-plugin-source.md
@@ -24,10 +24,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 You can use the CloudQuery integration to pull inventory from Azure APIs using CloudQuery SDK and send it to Sumo Logic.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## About Vendor
 
 CloudQuery is an open source CSPM vendor that allows the customer to analyze different vendors (for example, AWS, GCP, Azure) to see possible vulnerabilities.

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloudquery-gcp-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloudquery-gcp-source.md
@@ -26,10 +26,6 @@ import TerraformExample from '!!raw-loader!/files/c2c/cloudquery-gcp/example.tf'
 
 The CloudQuery GCP integration pulls inventory from various Google Cloud Platform (GCP) APIs via the CloudQuery GCP plugin, transforms it into the CloudQuery schema, and then sends it to Sumo Logic.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloudquery-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloudquery-source.md
@@ -28,10 +28,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The CloudQuery integration is used to pull inventory from the AWS APIs and transform them into the CloudQuery schema and send it to Sumo Logic.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/code42-incydr-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/code42-incydr-source.md
@@ -19,10 +19,6 @@ The Code42 Incydr is an insider risk management solution that allows you to dete
 
 Code42 Incydr source is used to analyze and fetch file events, alerts and audit logs from the Code42 Incydr API and send it to Sumo Logic.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/config-based-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/config-based-source.md
@@ -16,10 +16,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 With our configuration-based (_config-based_) cloud source, you can collect log data from vendor APIs with a modular configuration. The goal of this source is for Sumo Logic to expand the configuration modules over time giving greater compatibility with vendor APIs, but to acknowledge complex APIs will still require a specific cloud source and not be compatible with this source.
 
-:::note
-This source is available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Setup
 
 Follow the sections below to gather the required vendor information and setup the source with a compatible configuration.

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-fdr-host-inventory.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-fdr-host-inventory.md
@@ -21,10 +21,6 @@ The CrowdStrike FDR Host Inventory Source provides a secure endpoint to receive 
 The CrowdStrike API documentation is not public and can only be accessed by partners or customers.
 :::
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-fdr-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-fdr-source.md
@@ -21,10 +21,6 @@ The CrowdStrike Falcon Data Replicator (FDR) Source provides a secure endpoint 
 The [CrowdStrike API documentation](https://falcon.crowdstrike.com/login/?next=%2Fdocumentation%2F9%2Ffalcon-data-replicator) is not public and can only be accessed by partners or customers.
 :::
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-filevantage.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-filevantage.md
@@ -21,10 +21,6 @@ The CrowdStrike FileVantage source will collect CrowdStrike FileVantage logs by 
 The CrowdStrike API documentation is not public and can only be accessed by partners or customers.
 :::
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-source.md
@@ -23,10 +23,6 @@ The CrowdStrike API documentation is not public and can only be accessed by par
 
 The types of events are defined in the [Streaming API Event Dictionary](https://falcon.crowdstrike.com/support/documentation/62/streaming-api-event-dictionary).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-spotlight-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-spotlight-source.md
@@ -22,10 +22,6 @@ The source will fetch complete vulnerability instance data that has been updated
 The CrowdStrike API documentation is not public and can only be accessed by partners or customers.
 :::
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cse-aws-ec-inventory-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cse-aws-ec-inventory-source.md
@@ -22,10 +22,6 @@ The Cloud SIEM AWS EC2 Inventory Source provides a secure endpoint to receive ev
 
 For information on how inventory data is used in Cloud SIEM, see [Inventory Sources and Data](/docs/cse/administration/inventory-sources-and-data.md).
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cyberark-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cyberark-source.md
@@ -19,10 +19,6 @@ The CyberArk Endpoint Privilege Manager (EPM) is a security solution that helps 
 
 The integration with CyberArk EPM's API allows for retrieving administrative, detailed raw, policy audit, and policy audit raw events from every set in the environment. The [API documentation](https://docs.cyberark.com/Product-Doc/OnlineHelp/EPM/Latest/en/Content/LandingPages/LPDeveloper.htm) provides guidance on accessing and utilizing this information. This integration facilitates retrieving various audit events, including administrative actions, policy violations, and application usage, to generate alerts, reports, and remediation actions that enhance the organization's security posture.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cybereason-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cybereason-source.md
@@ -23,10 +23,6 @@ The Cybereason API documentation is not public and can only be accessed by part
 
 If you want to explicitly allow the static IP addresses used for this Source on Cybereason see our [table of static IP addresses by deployment](cloud-to-cloud-source-versions.md).
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/docusign-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/docusign-source.md
@@ -20,10 +20,6 @@ DocuSign pioneered the development of e-signature technology, and today DocuSign
 
 The DocuSign provides a secure endpoint to receive customer event data from the [DocuSign Monitor API](https://developers.docusign.com/docs/monitor-api/reference/monitor/dataset/getstream/). DocuSign Monitor helps organizations protect their agreements with round-the-clock activity tracking. The Monitor API delivers this activity tracking information directly to existing security stacks or data visualization tools—enabling teams to detect unauthorized activity, investigate incidents, and quickly respond to verified threats.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/dropbox-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/dropbox-source.md
@@ -17,10 +17,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Dropbox Source provides a secure endpoint to receive team events from the [Get Events API](https://www.dropbox.com/developers/documentation/http/teams#team_log-get_events). It securely stores the required authentication, scheduling, and state tracking information.
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/druva-cyber-resilience-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/druva-cyber-resilience-source.md
@@ -20,10 +20,6 @@ The Druva Data Resiliency Cloud provides unified, easy-to-manage data protection
 
 The Druva Cyber Resilience source provides the ability to fetch realize events generated within the Druva Realize product using the [Druva Realize Events API](https://developer.druva.com/reference/listeventsbytracker) and sends it to Sumo Logic. Realize events API helps you to collect unusual data activity events, access events, and login events generated in Druva Cyber Resilience product.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/druva-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/druva-source.md
@@ -21,9 +21,6 @@ The Druva source provides the ability to analyze and fetch event logs from the *
 This integration accesses the Druva inSync API to retrieve audit events. API documents can be found
 [here](https://developer.druva.com/docs/event-apis).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
 
 ## Data collected
 

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/duo-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/duo-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Duo Source provides a secure endpoint to receive authentication logs from the Duo [Authentication Logs API](https://duo.com/docs/adminapi#logs). It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/gmail-tracelogs-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/gmail-tracelogs-source.md
@@ -25,10 +25,6 @@ You'll need to use our [Google BigQuery source](/docs/send-data/hosted-collector
 
 The Gmail Trace Logs integration pulls the Gmail log from the BigQuery using BigQuery Library APIs and ingests them into the Sumo Logic to store, analyze, and alert.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-bigquery-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-bigquery-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Google Cloud’s BigQuery is a fully managed enterprise data warehouse that helps you to manage and analyze your data, which also provides built-in features such as ML, geospatial analysis, and business intelligence. The Google BigQuery integration gets data from a [Google BigQuery](https://cloud.google.com/bigquery) table via a provided query.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-alertcenter.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-alertcenter.md
@@ -22,10 +22,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This topic has information about the Google Workspace AlertCenter Cloud-to-Cloud Source, part of Sumo Logic's [Cloud-to-Cloud Integration Framework](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Google Workspace User Inventory source collects a list of users from the Google Workspace [Users API](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list). It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/jfrog-xray.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/jfrog-xray.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Our JFrog Xray source collects JFrog Xray violations by querying the API for new policy violations when they occur.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/jumpcloud-directory-insights-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/jumpcloud-directory-insights-source.md
@@ -20,10 +20,6 @@ JumpCloud's open directory platform unifies your technology stack across identit
 
 JumpCloud Directory Insights Source is used to collect Directory Insights Events from the JumpCloud platform using the REST API and send it to Sumo Logic.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/knowbe4-api-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/knowbe4-api-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The KnowBe4 API integration collects user events data into Sumo Logic for storage, analysis, and alerting. It ingests events data from the [Events API](https://developer.knowbe4.com/rest/userEvents#tag/Events/operation/listEvents), phishing security tests from the [Phishing Security Tests API](https://developer.knowbe4.com/rest/reporting#tag/Phishing/paths/~1v1~1phishing~1security_tests/get), and recipient results from the [Recipient Results API](https://developer.knowbe4.com/rest/reporting#tag/Phishing/paths/~1v1~1phishing~1security_tests~1%7Bpst_id%7D~1recipients/get).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-azure-ad-inventory-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-azure-ad-inventory-source.md
@@ -20,10 +20,6 @@ The Microsoft Azure AD Inventory Source collects user and device data from t
 
 If you want to explicitly allow the static IP addresses used for this Source on your firewall see our [table of static IP addresses by deployment](cloud-to-cloud-source-versions.md).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-exchange-trace-logs.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-exchange-trace-logs.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Microsoft Exchange Trace Logs Source collects email trace logs from the Office 365 reporting web service via the MessageTrace report under “Exchange reports”. Specific API reference information can be found [here](https://learn.microsoft.com/en-us/previous-versions/office/developer/o365-enterprise-developers/jj984335(v=office.15)).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-azure-ad-reporting-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-azure-ad-reporting-source.md
@@ -22,10 +22,6 @@ Data is polled every five minutes and can take a couple of minutes to be searcha
 
 If you want to explicitly allow the static IP addresses used for this Source on your firewall see our [table of static IP addresses by deployment](cloud-to-cloud-source-versions.md).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-identity-protection-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-identity-protection-source.md
@@ -21,10 +21,6 @@ securely stores the required authentication, scheduling, and state tracking info
 
 If you want to explicitly allow the static IP addresses used for this Source on your firewall see our [table of static IP addresses by deployment](cloud-to-cloud-source-versions.md).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-security-api-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-security-api-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Microsoft Graph Security API Source provides a secure endpoint to receive alerts from the [Microsoft Graph](https://docs.microsoft.com/en-us/graph/overview) Security API endpoint. It securely stores the required authentication, scheduling, and state tracking information. One threat event is reported for each affected device.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mimecast-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mimecast-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Mimecast Source supports collecting SIEM, DLP, Audit, and Hold Message List data from the [Mimecast API](https://developer.services.mimecast.com/apis). It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/miro-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/miro-source.md
@@ -11,10 +11,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Miro Source API integration ingests audit logs obtained from the [Audit log API](https://developers.miro.com/docs/rest-api-reference-guide#audit-logs). You will be able to collect audit logs activity from your Miro platform using our new Miro Cloud-to-Cloud Source connector.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
@@ -30,10 +30,6 @@ The following event types are available to collect:
 * incident
 * endpoint
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-webtx-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-webtx-source.md
@@ -18,10 +18,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The [Netskope WebTx API](https://docs.netskope.com/en/transaction-event-fields.html) integration ingests Web Transaction logs from Netskope Event Stream.
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/okta-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/okta-source.md
@@ -19,10 +19,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 The Okta Source provides a secure endpoint to receive event data from the Okta [System Log API](https://developer.okta.com/docs/reference/api/system-log/), [Users API](https://developer.okta.com/docs/reference/api/users/), and [User's Group API](https://developer.okta.com/docs/reference/api/users/#get-user-s-groups).
 It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/palo-alto-cortex-xdr-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/palo-alto-cortex-xdr-source.md
@@ -21,10 +21,6 @@ By using the Cortex XDR Source Integration, you can easily access and analyze da
 
 The Cortex XDR Source Integration is a valuable Source for security teams that want to enhance their threat detection capabilities and streamline their incident response process. It helps you to effectively monitor your security posture, identify threats in real-time, and respond quickly to potential attacks.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/proofpoint-on-demand-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/proofpoint-on-demand-source.md
@@ -23,10 +23,6 @@ This Source requires you to be licensed for Proofpoint On Demand’s Remote Sy
 The Proofpoint PoD API is not public; you'll need to request details on the API from Proofpoint.
 :::
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/proofpoint-tap-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/proofpoint-tap-source.md
@@ -23,10 +23,6 @@ The Proofpoint integration supports the following four event types:
  * Clicks Permitted
  * Clicks Blocked
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 :::note
 The maximum data retention period for Proofpoint TAP is 7 days, as mentioned in their [documentation](https://help.proofpoint.com/Threat_Insight_Dashboard/API_Documentation/SIEM_API). The integration will only be able to fetch a maximum of the last 7 days data. So there is a chance of data loss if the C2C stops functioning for more than a 7-day time interval.
 :::

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/qualys-vmdr-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/qualys-vmdr-source.md
@@ -14,10 +14,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Qualys VMDR ingests vulnerability data from [Vulnerability API](https://www.qualys.com/docs/qualys-api-vmpc-user-guide.pdf), knowledgeBase data from [KnowledgeBase API](https://www.qualys.com/docs/qualys-api-vmpc-user-guide.pdf), and asset data from [Asset API](https://www.qualys.com/docs/qualys-global-ai-api-v2-user-guide.pdf).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/rapid7-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/rapid7-source.md
@@ -16,10 +16,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Rapid7 source collects asset and vulnerabilities from [Rapid7 InsightVM](https://help.rapid7.com/insightvm/en-us/api/integrations.html) API and sends it to Sumo Logic. InsightVM provides a fully available, scalable, and efficient way to collect vulnerability data and minimize risk. InsightVM automatically evaluates changes in user's networks, allowing security professionals to better understand and quickly manage the risk posed to their organization.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/sailpoint-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/sailpoint-source.md
@@ -17,10 +17,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The SailPoint Source provides a secure endpoint to receive Events and User Inventory data from the [IdentityNow V3 API](https://developer.sailpoint.com/idn/api/v3). It securely stores the required authentication, scheduling, and state tracking information.
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/salesforce-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/salesforce-source.md
@@ -18,10 +18,6 @@ import CollBegin from '../../../reuse/collection-should-begin-note.md';
 
 The Salesforce Source provides a secure endpoint to receive event data from the Salesforce through its [Rest API](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm). The source securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/sentinelone-mgmt-api-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/sentinelone-mgmt-api-source.md
@@ -17,10 +17,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The SentinelOne Mgmt API Source collects data from the SentinelOne Management Console. It securely stores the required authentication, scheduling, and state tracking information.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/slack-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/slack-source.md
@@ -15,10 +15,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This topic describes the Slack Source, part of Sumo Logic's [Cloud-to-Cloud Integration Framework](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework).
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/snowflake-sql-api.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/snowflake-sql-api.md
@@ -25,10 +25,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Snowflake SQL API source can be used to execute SQL queries with aggregation fields and translate the results to metrics. This source only collects metrics and does not currently collect any log data.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 Customers can provide custom SQL queries for the source to execute and a configuration to translate the results to custom metrics data.
 

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/sophos-central-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/sophos-central-source.md
@@ -22,10 +22,6 @@ The Sophos Central Source provides a secure endpoint to receive authentication l
 To link the endpoint data to the alert, you can map the `alert.ManagedAgent.ID` field from the alert response with the `endpointID` field from the endpoint response.
 :::
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source.md
@@ -23,10 +23,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 [STIX/TAXII](https://oasis-open.github.io/cti-documentation/) are two standards used together to exchange threat intelligence information between systems. STIX defines the format and structure of the data. TAXII defines how the API endpoints are served and accessed by clients. This Sumo Logic source supports collecting indicators from STIX/TAXII 1.x.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 :::sumo[Best Practice]
 This source only supports STIX/TAXII 1.x. Sumo Logic recommends using our [STIX/TAXII 2.x source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source/) instead as it is the current version of STIX/TAXII.
 :::

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source.md
@@ -23,10 +23,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 [STIX/TAXII](https://oasis-open.github.io/cti-documentation/) are two standards used together to exchange threat intelligence information between systems. STIX defines the format and structure of the data. TAXII defines how the API endpoints are served and accessed by clients. This Sumo Logic source supports collecting indicators from STIX/TAXII 2.0 and 2.1 versions. The legacy STIX/TAXII 1.x versions are not supported with this source.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 This source collects [threat intelligence indicators](/docs/platform-services/threat-intelligence-indicators/) from a vendor's STIX/TAXII 2.x endpoints. This means the specific endpoints we collect data from are the endpoints defined in the [TAXII standard](https://oasis-open.github.io/cti-documentation/taxii/intro). Vendor APIs must follow the standard. The source will collect all indicators from the TAXII server when it runs for the first time and it will check for updates once an hour. This one-hour polling interval can be adjusted in the source configuration.

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/symantec-web-security-service-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/symantec-web-security-service-source.md
@@ -22,10 +22,6 @@ The Symantec Web Security Service Source provides a secure endpoint to receive W
 * Logs are ingested in batches of 1,000.
 * Logs are polled every five minutes.
 
-:::note
-This source is not available in the [Fed deployment](/docs/api/getting-started#sumo-logic-endpoints-by-deployment-and-firewall-security).
-:::
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/tenable-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/tenable-source.md
@@ -21,10 +21,6 @@ The Tenable Source provides a secure endpoint to ingest audit-log events, vulner
    * The Audit Log API is used to collect [audit logs](https://developer.tenable.com/reference/audit-log-events). It does not provide a pagination function. Logs are polled every 24 hours with a limit of 5,000.
    * The Asset Export API first [exports assets](https://developer.tenable.com/reference/exports-assets-request-export) that are used to initiate export jobs. Next, it gets the export [status](https://developer.tenable.com/reference/exports-assets-request-export) and then [downloads exported assets](https://developer.tenable.com/reference/exports-assets-download-chunk) in a chunk.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/trellix-mvisio-epo-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/trellix-mvisio-epo-source.md
@@ -19,10 +19,6 @@ Trellix is a cybersecurity company that provides cloud-based security solutions 
 
 mVision ePO is a key component of the Trellix security management platform, which provides unified management of endpoint, network, and data security. This can reduce incident response time, strengthen protection, simplify and automate risk and security management, and provide end-to-end network visibility and security.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/webex-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/webex-source.md
@@ -17,10 +17,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Cisco Webex is a cloud-based video conferencing and collaboration product suite, which comprises software including Webex Meetings, Webex Teams, and Webex Devices. This Webex source collects admin audit events and webhooks (meetings, rooms, messages, and memberships) data and sends it to Sumo Logic.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/workday-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/workday-source.md
@@ -21,10 +21,6 @@ Workday is a cloud-based enterprise resource planning (ERP) system that enables 
 
 The Sumo Logic source integration for Workday facilitates retrieving sign-on logs and activity logs from the Workday API.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/zero-networks-segment-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/zero-networks-segment-source.md
@@ -17,10 +17,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Zero Networks is a cybersecurity company that provides cloud-based security solutions for your networks and endpoints. Segment is a solution that aims to provide comprehensive network security by implementing zero-trust principles. With Segment, Zero Networks provides a cloud-based platform that allows you to create micro-segments across the network. These micro-segments are small, isolated portions of the network that are tightly controlled and can only be accessed by authorized users and devices.
 
-import FedDeploymentNote from '../../../reuse/fed-deployment-note.md';
-
-<FedDeploymentNote/>
-
 ## Data collected
 
 | Polling Interval | Data |


### PR DESCRIPTION
## Purpose of this pull request

This pull request is to remove all the Fed Deployment note in all our existing C2C source doc as we made Fed Deployment default for all our C2C sources.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[Cost Savings - Building C2C docker images for Linux/ARM - Update Docs](https://sumologic.atlassian.net/browse/CONN-3242)
