### PR TITLE
Fixed error in c2c/slack-source.md

### DIFF
--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/slack-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/slack-source.md
@@ -116,7 +116,7 @@ and `<CLIENT_SECRET>` variables in the following URL. <br/> `https://slack.com/a
 
 ### Source configuration
 
-When you create a SailPoint Source, you add it to a Hosted Collector. Before creating the Source, identify the Hosted Collector you want to use or create a new Hosted Collector. For instructions, see [Create a Hosted Collector](/docs/send-data/hosted-collectors/configure-hosted-collector).
+When you create a Slack Source, you add it to a Hosted Collector. Before creating the Source, identify the Hosted Collector you want to use or create a new Hosted Collector. For instructions, see [Create a Hosted Collector](/docs/send-data/hosted-collectors/configure-hosted-collector).
 
 To configure a Duo Source:
 

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/slack-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/slack-source.md
@@ -118,7 +118,7 @@ and `<CLIENT_SECRET>` variables in the following URL. <br/> `https://slack.com/a
 
 When you create a Slack Source, you add it to a Hosted Collector. Before creating the Source, identify the Hosted Collector you want to use or create a new Hosted Collector. For instructions, see [Create a Hosted Collector](/docs/send-data/hosted-collectors/configure-hosted-collector).
 
-To configure a Duo Source:
+To configure a Slack Source:
 
 1. <!--Kanso [**Classic UI**](/docs/get-started/sumo-logic-ui/). Kanso--> In the main Sumo Logic menu, select **Manage Data > Collection > Collection**. <!--Kanso <br/>[**New UI**](/docs/get-started/sumo-logic-ui-new/). In the Sumo Logic top menu select **Configuration**, and then under **Data Collection** select **Collection**. You can also click the **Go To...** menu at the top of the screen and select **Collection**. Kanso-->
 1. On the Collectors page, click **Add Source** next to a Hosted Collector.


### PR DESCRIPTION
Documentation stated "SailPoint" but should be Slack.

## Purpose of this pull request

This pull request fixes a minor mistake in the Hosted Collectors -> Cloud to Cloud Integration -> Slack Source documentation, which states *SailPoint*. 


## Select the type of change

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

N/A
