### PR TITLE
DOCS-266 - Redirect for release note

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -3276,6 +3276,7 @@
   "/docs/releasenotes/service": "/release-notes-service",
   "/release-notes-service/welcome": "/release-notes-service",
   "/release-notes-service/2023/11/27/cis-for-aws": "/release-notes-service/2023/12/31/#november-27-2023-apps",
+  "/release-notes-service/2042/06/10/manage": "/release-notes-service/2024/06/10/manage",
   "/Send-Data/Applications-and-Other-Data-Sources/Azure-Audit/02Collect-Logs-for-Azure-Audit-from-Event-Hub": "/docs/integrations/microsoft-azure/audit",
   "/Send-Data/Collect-from-Other-Data-Sources/Azure_Monitoring/Collect_Logs_from_Azure_Monitor": "/docs/send-data/collect-from-other-data-sources/azure-monitoring/collect-logs-azure-monitor",
   "/Send-Data/Collect-from-Other-Data-Sources/Azure_Monitoring/Collect_Metrics_from_Azure_Monitor": "/docs/send-data/collect-from-other-data-sources/azure-monitoring/collect-metrics-azure-monitor",


### PR DESCRIPTION
## Purpose of this pull request

This pull request redirects the incorrect release note link: 
https://help.sumologic.com/release-notes-service/2042/06/10/manage/

to the correct one:
https://help.sumologic.com/release-notes-service/2024/06/10/manage/


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-266](https://sumologic.atlassian.net/browse/DOCS-266)
