### PR TITLE
Fix regex in processing rule for zscaler-private-access.md

### DIFF
--- a/docs/integrations/security-threat-detection/zscaler-private-access.md
+++ b/docs/integrations/security-threat-detection/zscaler-private-access.md
@@ -49,7 +49,7 @@ To collect logs for ZPA, do the following in Sumo Logic:
     * **Timestamp Format**. Auto Detect
 4. In the Processing Rules for Logs section, add a Processing Rule:
     * **Name:** `Remove Syslog String`
-    * **Filter**: `(\<\d+\>1 - - - - - - \>\{)`
+    * **Filter**: `(\<\d+\>1 - - - - - - \<\>\{)`
     * **Type**: `Mask messages that match`
     * **Mask String**: `{`
 5. Click **Save**.


### PR DESCRIPTION
## Purpose of this pull request

Without this change the regex will fail to match the `<165>1 - - - - - - <>` that shows up in the logs being sent to the syslog collector.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
