### PR TITLE
Adjust date on Cloud SOAR on-premises release note

### DIFF
--- a/blog-csoar/2023/12-31.md
+++ b/blog-csoar/2023/12-31.md
@@ -98,7 +98,7 @@ We've also improved multiple integrations and introduced new actions, implemente
 
 As of **November 15, 2023**, Sumo Logic's on-premises SOAR solution no longer receives updates, and Sumo Logic Engineering no longer develops, repairs, maintains, or tests the software.
 
-Effective **December 1, 2024**, Sumo Logic’s on-premises SOAR solution reaches end-of-life and becomes obsolete. Beginning on that date, it no longer receives applicable support entitled by active support contracts or by applicable warranty terms and conditions.
+Effective **December 31, 2024**, Sumo Logic’s on-premises SOAR solution reaches end-of-life and becomes obsolete. Beginning on that date, it no longer receives applicable support entitled by active support contracts or by applicable warranty terms and conditions.
 
 To upgrade to Sumo Logic’s [Cloud SOAR](/docs/cloud-soar/) offering, reach out to your Sumo Logic representative.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request changes the end-of-life date for Cloud SOAR on-premises from December 1 to December 31 2024 in the previously-published release note:
https://help.sumologic.com/release-notes-csoar/2023/12/31/#november-1-2023---application-update

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

Related to [DOCS-341](https://sumologic.atlassian.net/browse/DOCS-341).
