### PR TITLE
RUM metrics overhaul for readability

### DIFF
--- a/docs/apm/real-user-monitoring/metrics.md
+++ b/docs/apm/real-user-monitoring/metrics.md
@@ -15,86 +15,140 @@ For ad hoc queries, you can find these metrics in [Metrics Explorer](/docs/metr
 _contenttype=rummetricfromtrace
 ```
 
-## Document Load Metrics
+## Document load metrics
 
-The following table has details on the Document Load metrics collected from JavaScript. These are available in each trace in the `documentLoad` and `documentFetch` spans as span events in the details panel and also used in the Real User Monitoring app to populate the Website Performance and UI Paint Timings panels.
+The following document load metrics are collected from JavaScript. These are available in each trace in the `documentLoad` and `documentFetch` spans as span events in the details panel and also used in the Real User Monitoring app to populate the Website Performance and UI Paint Timings panels.
 
-| Name | Calculation |
-|:---|:---|
-| `browser_time_to_dns_resolution_end` | domainLookupEnd - span start time (fetch start) |
-| `browser_time_to_ssl_end` | if secureConnectionStart > 0: connectionEnd - span start time (fetch start) else NaN |
-| `browser_time_to_tcp_established` | if secureConnectionStart > 0: secureConnectionStart - span start time (fetch start) else connectionEnd - span start time (fetch start) |
-| `browser_time_to_request_end`  | responseStart - span start time (fetch start) |
-| `browser_time_to_fb` <a href="#ttfb">**`*`**</a> | responseEnd - span start time (fetch start) |
-| `browser_time_to_response_end` | domInteractive - span start time (fetch start) |
-| `browser_time_to_interactive` | domComplete - span start time (fetch start) |
-| `browser_time_to_processing_end` | loadEventEnd - span start time (fetch start) |
+These metrics, presented in the form of areas on the **Website Performance** panels on [RUM dashboards](/docs/apm/real-user-monitoring/dashboards), can help you understand the sequence of events (pictured below) from user clicks to a fully loaded document.
 
-The above metrics, presented in the form of areas on the **Website Performance** panels on [RUM dashboards](/docs/apm/real-user-monitoring/dashboards), can help you understand the sequence of events (pictured below) from user clicks to a fully loaded document.<br/>![Diagram showing various navigation metrics from user clicks to a fully loaded document, including DNS resolution, SSL connection, TCP establishment, request end, first byte, response end, interactive time, and processing end](/img/rum/Navigation-metrics.png)
+![Diagram showing various navigation metrics from user clicks to a fully loaded document, including DNS resolution, SSL connection, TCP establishment, request end, first byte, response end, interactive time, and processing end](/img/rum/Navigation-metrics.png)
 
-<a name="ttfb"><strong>*</strong> Time to first byte</a> (<code>browser_time_to_fb</code>): measures the delay between start of the page load and moment when the first byte of the response appears. It helps identify when a web server is too slow to respond to requests. You'll find this metric on the Navigation Timings chart.<br/><img src={useBaseUrl('img/rum/nav-timings.png')} alt="Screenshot of the Real User Monitoring interface showing detailed metrics and performance data for web applications" />
+Timing metrics are not calculated if the visibility state of the document is "hidden" at any point during the load.
 
-Timing metrics are not calculated if the visibility state of the document was "hidden" at any point during the load.
-
+:::info
 See [W3C navigation timing](https://www.w3.org/TR/navigation-timing/) for details on how an interface for web applications defines its access timing information concerning navigation and other elements.
+:::
+
+### `browser_time_to_dns_resolution_end`
+
+**Calculation**. domainLookupEnd - span start time (fetch start).
+
+### `browser_time_to_ssl_end`
+
+**Calculation**. if secureConnectionStart > 0: connectionEnd - span start time (fetch start) else NaN.
+
+### `browser_time_to_tcp_established`
+
+**Calculation**. if secureConnectionStart > 0: secureConnectionStart - span start time (fetch start) else connectionEnd - span start time (fetch start).
+
+### `browser_time_to_request_end`  
+**Calculation**. responseStart - span start time (fetch start).
+
+### `browser_time_to_fb`
+
+**Calculation**. responseEnd - span start time (fetch start).
+
+This metric, Time to first byte, measures the delay between start of the page load and moment when the first byte of the response appears. It helps identify when a web server is too slow to respond to requests. You'll find this metric on the Navigation Timings chart.
+
+<img src={useBaseUrl('img/rum/nav-timings.png')} alt="Screenshot of the Real User Monitoring interface showing detailed metrics and performance data for web applications" style={{border: '1px solid gray'}} />
+
+### `browser_time_to_response_end`
+
+**Calculation**. domInteractive - span start time (fetch start).
+
+### `browser_time_to_interactive`
+
+**Calculation**. domComplete - span start time (fetch start).
+
+### `browser_time_to_processing_end`
+
+**Calculation**. loadEventEnd - span start time (fetch start).
 
 
-## Rendering Events Metrics
+## Rendering events metrics
 
 These metrics, which populate in the **UI Paint Timings** panel on RUM dashboards, explain rendering events inside the user's browser.
 
-| Name | Calculation |
-|:---|:---|
-| `browser_time_to_fp` | firstPaint - span start time (fetch start) |
-| `browser_time_to_fcp` | firstContentfulPaint - span start time (fetch start) |
-| `browser_time_to_lcp` | largestContentfulPaint - span start time (fetch start) |
+### `browser_time_to_fp`
 
+**Calculation**. firstPaint - span start time (fetch start).
 
-* [First Paint](https://developer.mozilla.org/en-US/docs/Glossary/First_paint): measures the time from page fetch start (span start time) to the moment when the browser renders the first pixels to the screen, rendering anything that is visually different from what was on the screen prior to navigation. It answers the question, "Is it happening?" 
-* [First Contentful Paint](https://web.dev/fcp/): measures the time from page fetch start (span start time) to the moment when any part of the page's content is rendered on the screen. For this metric, "content" refers to text, images (including background images), `<svg>` elements, or non-white `<canvas>` elements.
-* [Largest Contentful Paint](https://web.dev/lcp/): measures the time from page fetch start (span start time) to the moment when the largest image or text block visible within the viewport is rendered.
+[First Paint](https://developer.mozilla.org/en-US/docs/Glossary/First_paint) measures the time from page fetch start (span start time) to the moment when the browser renders the first pixels to the screen, rendering anything that is visually different from what was on the screen prior to navigation. It answers the question, "Is it happening?" 
+
+### `browser_time_to_fcp`
+
+**Calculation**. firstContentfulPaint - span start time (fetch start).
+
+[First Contentful Paint](https://web.dev/fcp/) measures the time from page fetch start (span start time) to the moment when any part of the page's content is rendered on the screen. For this metric, "content" refers to text, images (including background images), `<svg>` elements, or non-white `<canvas>` elements.
+
+### `browser_time_to_lcp`
+
+**Calculation**. largestContentfulPaint - span start time (fetch start).
+
+[Largest Contentful Paint](https://web.dev/lcp/) measures the time from page fetch start (span start time) to the moment when the largest image or text block visible within the viewport is rendered.
 
 These are only loosely related to navigation timings and in many cases, some of them may appear long after the page is fully loaded in the browser, which indicates rendering slowdowns.
 
 
-## Core Web Vitals Metrics
+## Core Web Vitals metrics
 
 [Core Web Vitals (CWV)](https://web.dev/vitals/) is an initiative by Google that defines web page KPIs. Each CWV represents a distinct facet of the user experience that's measurable in the field and reflects the real-world experience of a critical user-centric outcome.
 
-| Name | Calculation |
-|:---|:---|
-| `browser_time_fid` | From CVW First Input Delay API |
-| `browser_time_to_lcp` | largestContentfulPaint - span start time (fetch start) |
-| `browser_cls` | From CVW Cumulative Layout Shift API |
+CWV focuses on three aspects of the user experience: document loading, interactivity, and visual stability. This includes the following metrics (and their respective thresholds): `browser_time_fid`, `browser_time_to_lcp`, and `browser_cls`.
 
-CWV focuses on three aspects of the user experience: document loading, interactivity, and visual stability. This includes the following metrics (and their respective thresholds):
+<img src={useBaseUrl('img/rum/core-web-vitals.png')} alt="Visual representation of Core Web Vitals metrics within the Real User Monitoring dashboard, highlighting key performance indicators like FID, LCP, and CLS" />
 
-* [First Input Delay (FID)](https://web.dev/fid/): measures interactivity. To provide a good user experience, pages should have a FID of **100 milliseconds** or less.
-* [Largest Contentful Paint (LCP)](https://web.dev/lcp/): measures loading performance. To provide a good user experience, LCP should occur within **2.5 seconds** of when the page first starts loading.
-* [Cumulative Layout Shift (CLS)](https://web.dev/cls/): measures visual stability. To provide a good user experience, pages should maintain a CLS of **0.1** or less.<br/><img src={useBaseUrl('img/rum/core-web-vitals.png')} alt="Visual representation of Core Web Vitals metrics within the Real User Monitoring dashboard, highlighting key performance indicators like FID, LCP, and CLS" />
+These CWV KPIs are captured and displayed on Overview dashboards for Document Load action types. Detailed metrics are available in span metadata for every transaction trace.
 
-The above three CWV KPIs are captured and displayed on Overview dashboards for Document Load action types. Detailed metrics are available in span metadata for every transaction trace.<br/><img src={useBaseUrl('img/rum/prada-documentload.png')} alt="Example of span metadata for transaction traces displayed in the Real User Monitoring dashboard, providing detailed performance insights" />
+<img src={useBaseUrl('img/rum/prada-documentload.png')} alt="Example of span metadata for transaction traces displayed in the Real User Monitoring dashboard, providing detailed performance insights" style={{border: '1px solid gray'}} />
 
-## XHR Monitoring Metrics
+### `browser_time_fid`  
 
-An XML HTTP Request (XHR) is a form of communication between the browser and the application backend without (re)loading of the page. A typical example is where a page needs to update a ticker of a price automatically or after pressing the “update price” button next to it.
+**Calculation**. From CVW First Input Delay API.
 
-XHR technique is quite often used in _single-page apps_ &#8212; apps that load the page once and then provide all interaction and navigation without loading more documents. Pages can generate one or more XHR requests, typically in the form of HTTP POSTs/GETs, related to various user actions on a page. Sumo Logic provides following monitoring coverage for XHR interactions:
+[First Input Delay (FID)](https://web.dev/fid/) measures interactivity. To provide a good user experience, pages should have a FID of **100 milliseconds** or less.
 
-Pages can generate one or more XHR requests, typically in the form of HTTP Posts, related to various user actions on a page. What we do with this, is:
-* Measure the following performance timings:
+### `browser_time_to_lcp`
 
-  | Name | Calculation |
-  |:---|:---|
-  | `browser_time_to_first_xhr` | time from UI interaction until first HTTP `POST` appears |
-  | `browser_time_to_last_xhr` | time from UI interaction until last HTTP `POST` ends) |
-  | `browser_time_to_xhr_processing_end` | time from UI interaction until all browser-side processing of all XHR requests is done |
-  | `browser_time_in_xhr_calls` | total time when the transaction was “busy” with executing XHR communication |
+**Calculation**. largestContentfulPaint - span start time (fetch start).
 
-* Measure how many XHR requests have been generated
-* Identify the user action that triggered the XHRs by blending UI interaction (e.g., `“click on Pay”`) with the page name (e.g., `http://www.acme.com/checkout`) results in following action name `"Click on Pay on http://www.acme.com/checkout"`
-* Measure any erroneous HTTP response to XHR POST calls and count them as XHR errors
-* Allow to drill-down via EI to specific traces that explain full process of loading and execution of each such transaction<br/><img src={useBaseUrl('img/rum/xhr-action.png')} alt="Interface for monitoring XHR interactions, displaying performance timings and metrics for XMLHttpRequests within a web application" />
+[Largest Contentful Paint (LCP)](https://web.dev/lcp/) measures loading performance. To provide a good user experience, LCP should occur within **2.5 seconds** of when the page first starts loading.
+
+### `browser_cls`
+
+**Calculation**. From CVW Cumulative Layout Shift API.
+
+[Cumulative Layout Shift (CLS)](https://web.dev/cls/) measures visual stability. To provide a good user experience, pages should maintain a CLS of **0.1** or less.
+
+## XHR monitoring metrics
+
+An XML HTTP Request (XHR) is a form of communication between the browser and the application backend without reloading the page. A typical example is when a page needs to update a price ticker automatically or after pressing the “update price” button next to it.
+
+The XHR technique is frequently used in _single-page apps_ &#8212; apps that load the page once and then provide all interaction and navigation without loading additional documents. These pages can generate one or more XHR requests, typically in the form of HTTP POSTs/GETs, related to various user actions on a page. Sumo Logic provides the following monitoring coverage for XHR interactions:
+
+Pages can generate one or more XHR requests, typically in the form of HTTP POSTs, related to various user actions on a page. The following performance timings are measured:
+
+### `browser_time_to_first_xhr`
+
+Time from the UI interaction until the first HTTP POST appears.
+
+### `browser_time_to_last_xhr`
+
+Time from the UI interaction until the last HTTP POST ends.
+
+### `browser_time_to_xhr_processing_end`
+
+Time from the UI interaction until all browser-side processing of all XHR requests is completed.
+
+### `browser_time_in_xhr_calls`
+
+The total time when the transaction was “busy” executing XHR communication.
+
+In addition to these metrics, the system also measures how many XHR requests have been generated and identifies the user action that triggered the XHRs by blending the UI interaction (e.g., `“click on Pay”`) with the page name (e.g., `http://www.acme.com/checkout`). This results in an action name like `"Click on Pay on http://www.acme.com/checkout"`. Any erroneous HTTP responses to XHR POST calls are counted as XHR errors.
+
+We also measure any erroneous HTTP responses to XHR POST calls, counting them as XHR errors, and provide drill-down capabilities via EI to specific traces that explain the full process of loading and executing each transaction.
+
+<img src={useBaseUrl('img/rum/xhr-action.png')} alt="Interface for monitoring XHR interactions, displaying performance timings and metrics for XMLHttpRequests within a web application" style={{border: '1px solid gray'}} />
 
 <!--
 ### Navigation (Route Change) Metrics
@@ -107,7 +161,7 @@ Every time we open a new tab in Sumo, we do a route change (but we are not loadi
 <img src={useBaseUrl('img/rum/nav-action.png')} alt="Real User Monitoring" />
 -->
 
-## Longtask Delay Metrics
+## Longtask delay metrics
 
 This section describes how to trace and measure [Longtask delays](https://github.com/w3c/longtasks), which is when the main browser UI thread becomes locked for extended periods (greater than 50 milliseconds) and blocks other critical tasks (including user input) from being executed.
 
@@ -115,4 +169,4 @@ This impacts the user's experience. They can perceive this as a "frozen browser�
 * Displays them as individual spans marking how long the browser was frozen<br/><img src={useBaseUrl('img/rum/prada-nav.png')} alt="Graphical representation of longtask delays in the browser UI, showing how these delays impact user experience and are captured in individual spans" />
 * Aggregates the above data into two metrics:
    * Longtask delay: average duration of longtask span
-   * Time in longtasks: total time spent in longtasks per user action/trace<br/><img src={useBaseUrl('img/rum/longtask.png')} alt="Aggregated data metrics for longtask delays in the Real User Monitoring dashboard, displaying average duration and total time spent in longtasks per user action or trace." />
+   * Time in longtasks: total time spent in longtasks per user action/trace<br/><img src={useBaseUrl('img/rum/longtask.png')} alt="Aggregated data metrics for longtask delays in the Real User Monitoring dashboard, displaying average duration and total time spent in longtasks per user action or trace." style={{border: '1px solid gray'}} />

--- a/docs/apm/real-user-monitoring/metrics.md
+++ b/docs/apm/real-user-monitoring/metrics.md
@@ -42,6 +42,7 @@ See [W3C navigation timing](https://www.w3.org/TR/navigation-timing/) for detai
 **Calculation**. if secureConnectionStart > 0: secureConnectionStart - span start time (fetch start) else connectionEnd - span start time (fetch start).
 
 ### `browser_time_to_request_end`  
+
 **Calculation**. responseStart - span start time (fetch start).
 
 ### `browser_time_to_fb`


### PR DESCRIPTION
## Purpose of this pull request

RUM metrics doc page overhaul for readability. Metrics are now listed as H3s instead of in-table.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
