### PR TITLE
Fix Classic UI links for Setup Wizard and Root Cause Explorer

### DIFF
--- a/docs/observability/root-cause-explorer.md
+++ b/docs/observability/root-cause-explorer.md
@@ -11,7 +11,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 
 :::warning
-Root Cause Explorer has been deprecated. It is available only in the [Classic UI](/docs/get-started/sumo-logic-ui/). We recommend using other [Observability](/docs/observability/) tools instead.
+Root Cause Explorer has been deprecated. It is available only in the [Classic UI](/docs/get-started/sumo-logic-ui-classic/). We recommend using other [Observability](/docs/observability/) tools instead.
 :::
  
 

--- a/docs/send-data/setup-wizard.md
+++ b/docs/send-data/setup-wizard.md
@@ -8,14 +8,14 @@ description: Use the Setup Wizard to quickly get started sending data to Sumo Lo
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 :::note
-The Setup Wizard is deprecated. It is only available in the [Classic UI](/docs/get-started/sumo-logic-ui/). We recommend using the [App Catalog](/docs/integrations/) to onboard your data.
+The Setup Wizard is deprecated. It is only available in the [Classic UI](/docs/get-started/sumo-logic-ui-classic/). We recommend using the [App Catalog](/docs/integrations/) to onboard your data.
 :::
 
 The Setup Wizard (deprecated) lets you get data in your Sumo Logic account quickly. It guides you step-by-step based on the type of data you want to send. After data collection is running, the Setup Wizard installs a Sumo Logic App with pre-configured Dashboards that allow you to analyze your data. The Setup Wizard provides detailed instructions to help you with each step of the configuration.
 
 Before you begin, [sign up](/docs/get-started/sign-up.md) for a Sumo Logic account and activate it.
 
-To open the Setup Wizard, in the [Classic UI](/docs/get-started/sumo-logic-ui/) select **Manage Data** > **Collection** > **Collection**, and then click the **Setup Wizard** link on the top right of the Collection page.
+To open the Setup Wizard, in the [Classic UI](/docs/get-started/sumo-logic-ui-classic/) select **Manage Data** > **Collection** > **Collection**, and then click the **Setup Wizard** link on the top right of the Collection page.
 
 <img src={useBaseUrl('img/get-started/setup-wizard.png')} alt="setup-wizard" />
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes links to the Classic UI tour article in these articles:
- https://help.sumologic.com/docs/send-data/setup-wizard/
- https://help.sumologic.com/docs/observability/root-cause-explorer/


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-207](https://sumologic.atlassian.net/browse/DOCS-207)
