### PR TITLE
Update documentation to remove rate limit options

### DIFF
--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cyberark-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cyberark-source.md
@@ -60,18 +60,9 @@ To configure a CyberArk EPM Source, follow the steps below:
     * For the US datacenter, the dispatch server URL is `https://login.epm.cyberark.com`.
     * For the EU datacenter, the dispatch server URL is `https://eu.epm.cyberark.com`.
 1. **Application ID**. An application ID is a unique identifier that helps an API recognize which application or program is accessing it. It's like a name tag that allows the API to keep track of different applications using it. For example, *sumologic*.
-1. **Adjust Rate Limit for Admin Audit Events**. This option allows to customize the number of requests the CyberArk C2C source can make to [AdminAudit](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/GetAdminAuditData.htm) endpoint. By default, it's set to 5 requests every 60 seconds, as stated in the [CyberArk API documentation](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/WebServicesIntro.htm).
-	1. **Number of Calls (optional)**: The number of calls in the given time frame. This field is pre-filled with 5.
-	1. **Per Second(s) (optional)**: The duration of the time frame. This field is pre-filled with 60.
 1. **Collect Detailed Raw Events**. This option enables the CyberArk C2C Source to collect detailed raw events from the CyberArk EPM. By default, the source can make 1000 requests every 5 minutes to [Detailed Raw Events](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/GetDetailedRawEvents.htm) endpoint, as stated in the [CyberArk API documentation](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/WebServicesIntro.htm). Use below options to adjust this settings.
-	1. **Number of Calls (optional)**: The number of calls in the given time frame. This field is pre-filled with 1000.
-	1. **Per Second(s) (optional)**: The duration of the time frame. This field is pre-filled with 300.
 1. **Collect Aggregated Policy Audit Events**. This option enables the C2C Source to collect aggregated policy audit events from the CyberArk EPM. By default, the source can make 1000 requests every 5 minutes to [Aggregated Policy Audit Events](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/GetAggregatedPolicyAudits.htm) endpoint, as stated in the [CyberArk API documentation](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/WebServicesIntro.htm). Use below options to adjust this settings.
-	1. **Number of Calls (optional)**: The number of calls in the given time frame. This field is pre-filled with 1000.
-	1. **Per Second(s) (optional)**: The duration of the time frame. This field is pre-filled with 300.
 1. **Collect Policy Audit Raw Events**. This option enables the C2C Source to collect policy audit raw events from the CyberArk EPM. By default, the source can make 1000 requests every 5 minutes to [Policy Audit Raw Events](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/GetPolicyAuditRawEventDetails.htm) endpoint, as stated in the [CyberArk API documentation](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/WebServicesIntro.htm). Use below options to adjust this settings.
-	1. **Number of Calls (optional)**: The number of calls in the given time frame. This field is pre-filled with 1000.
-	1. **Per Second(s) (optional)**: The duration of the time frame. This field is pre-filled with 300.
 1. **Polling Interval**. The polling interval is the frequency at which the CyberArk C2C Source will check for updates from the CyberArk EPM (Endpoint Privilege Manager). This field is pre-filled with 600.
 1. When you are finished configuring the Source, click **Save**.
 
@@ -106,11 +97,10 @@ Sources can be configured using UTF-8 encoded JSON files with the Collector Ma
 | password | String | Yes |  `null` | Password for your CyberArk EPM account. |  |
 | epm_server | String | Yes |  `null` | Dispatch Server of the CyberArk EPM. | |
 | application_id | String | Yes |  `null` | Unique identifier of the application who is accessing the API. |  |
-| ratelimit  | boolean | No  | True | Removes the request limitations imposed on the CyberArk C2C source. |  |
 | detailed_raw_events | boolean | No  | False | Collects detailed raw events. |  |
 | aggregated_policy_audits | boolean | No | False | Collects aggregated policy audits events. |  |
 | policy_audit_raw_events | boolean | No | False | Collects policy audit raw events. |  |
-| polling_interval | integer | Yes | 30 | Frequency of C2C updates from EPM. |  |  
+| polling_interval | integer | Yes | 600 | Frequency of C2C updates from EPM. |  |  
 
 ### JSON example
 
@@ -128,7 +118,7 @@ Sources can be configured using UTF-8 encoded JSON files with the Collector Ma
 
 * **Session Timeout**. The session timeout for all APIs is part of the session token and is defined by the Timeout for inactive session Server Configuration parameter.
 
-* **Adjust Request Limitations**. The CyberArk C2C source has default restrictions on the number of requests to the CyberArk EPM Server, as explained in the [CyberArk API Limitations](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/WebServicesIntro.htm#APIlimitations) documentation. However, if your server has its custom limit for requests per second(s), you can use the provided options when configuring the source.
+* **Adjust Request Limitations**. The CyberArk C2C source has default restrictions on the number of requests to the CyberArk EPM Server per customer, as explained in the [CyberArk API Limitations](https://docs.cyberark.com/EPM/Latest/en/Content/WebServices/WebServicesIntro.htm#APIlimitations) documentation.
 
 :::note
 When setting the poll frequency, it's recommended to consider these limitations and set the frequency to a reasonable value to ensure that the C2C operates efficiently without overwhelming the server.

--- a/static/files/c2c/cyberark/example.json
+++ b/static/files/c2c/cyberark/example.json
@@ -7,11 +7,10 @@
 			"password": "Sumo@123",
 			"application_id": "sumologic-c2c",
 			"epm_server": "https://in.epm.cyberark.com",
-			"ratelimit": true,
 			"detailed_raw_events": false,
 			"aggregated_policy_audits": false,
 			"policy_audit_raw_events": false,
-			"polling_interval": 30
+			"polling_interval": 600
 		},
 		"schemaRef": {
 			"type": "CyberArk EPM"

--- a/static/files/c2c/cyberark/example.tf
+++ b/static/files/c2c/cyberark/example.tf
@@ -9,11 +9,10 @@ resource "sumologic_cloud_to_cloud_source" "cyberark_test_source" {
 			"password": "Sumo@123",
 			"application_id": "sumologic-c2c",
 			"epm_server": "https://in.epm.cyberark.com",
-			"ratelimit": true,
 			"detailed_raw_events": false,
 			"aggregated_policy_audits": false,
 			"policy_audit_raw_events": false,
-			"polling_interval": 30
+			"polling_interval": 600
   })
 }
 resource "sumologic_collector" "collector" {


### PR DESCRIPTION
## Purpose of this pull request

This pull request remove references to the rate limit for Cyberark EPM as that is no longer an option for customers


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

CONN-3807
