### PR TITLE
Update dedup.md - Add supported content

### DIFF
--- a/docs/search/search-query-language/search-operators/dedup.md
+++ b/docs/search/search-query-language/search-operators/dedup.md
@@ -15,6 +15,7 @@ The `dedup` operator is supported for the following features:
 * [Log Search](/docs/search)
 * [Dashboards](/docs/dashboards), including live mode
 * [Scheduled Searches](/docs/alerts/scheduled-searches/schedule-search.md)
+* [Monitors](/docs/alerts/monitors/)
 
 ## Syntax
 


### PR DESCRIPTION
It appears Monitors was missing from the list of supported content for the dedup operator. I was able to save a monitor with the dedup operator without issue.

## Purpose of this pull request

This pull request... <!-- brief description here -->


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
