### PR TITLE
Make the same statement between TAXII 1 and 2

### DIFF
--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source.md
@@ -114,7 +114,7 @@ Below is a list of Sumo Logic recommended configuration examples for specific th
 | Vendor | Notes |
 | :-- | :-- |
 | <a href="/files/c2c/taxii-1/alien-vault-config.json" target="_blank">AlienVault</a> | Use your API key as the HTTP username and leave the password blank. |
-| <a href="/files/c2c/taxii-1/recorded-future-config.json" target="_blank">Recorded Future</a> | Use your API key as the HTTP password and use any non-empty string as username. The Recorded Future TAXII v1 service supports Recorded Future’s [default and large risk lists](https://support.recordedfuture.com/hc/en-us/articles/115008327148-Default-and-Large-Risk-Lists), as well as collections for each risk rule. More information can be found on the [Recorded Future Support portal](https://support.recordedfuture.com/hc/en-us/articles/115004303128-TAXII-V1-service). |
+| <a href="/files/c2c/taxii-1/recorded-future-config.json" target="_blank">Recorded Future</a> | Use your API key as the HTTP password and leave the username blank. The Recorded Future TAXII v1 service supports Recorded Future’s [default and large risk lists](https://support.recordedfuture.com/hc/en-us/articles/115008327148-Default-and-Large-Risk-Lists), as well as collections for each risk rule. More information can be found on the [Recorded Future Support portal](https://support.recordedfuture.com/hc/en-us/articles/115004303128-TAXII-V1-service). |
 
 ## FAQ
 


### PR DESCRIPTION
## Purpose of this pull request

This PR updates our recommended configuration for our TAXII 1 client with the vendor Recorded Future. It should be the same between our TAXII 1 and 2 C2C client where the user should leave the username blank and use their API key as the password.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
