### PR TITLE
Fix restrict wording

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -3470,6 +3470,7 @@
   "/release-notes-service/welcome": "/release-notes-service",
   "/release-notes-service/2023/11/27/cis-for-aws": "/release-notes-service/2023/12/31/#november-27-2023-apps",
   "/release-notes-service/2042/06/10/manage": "/release-notes-service/2024/12/31",
+  "/release-notes-service/2024/03/20/flex/": "/release-notes-service/2024/12/31/#march-20-2024-manage",
   "/Send-Data/Applications-and-Other-Data-Sources/Azure-Audit/02Collect-Logs-for-Azure-Audit-from-Event-Hub": "/docs/integrations/microsoft-azure/audit",
   "/Send-Data/Collect-from-Other-Data-Sources/Azure_Monitoring/Collect_Logs_from_Azure_Monitor": "/docs/send-data/collect-from-other-data-sources/azure-monitoring/ms-azure-event-hubs-source/",
   "/Send-Data/Collect-from-Other-Data-Sources/Azure_Monitoring/Collect_Metrics_from_Azure_Monitor": "/docs/send-data/collect-from-other-data-sources/azure-monitoring/collect-metrics-azure-monitor",

--- a/docs/manage/partitions/data-tiers/faq.md
+++ b/docs/manage/partitions/data-tiers/faq.md
@@ -29,7 +29,7 @@ In contrast, debug or other verbose log sources that are only used to troublesho
 
 You can use [Role-Based Access Control (RBAC)](/docs/manage/users-roles/roles/role-based-access-control) to restrict access to partitions in the Infrequent or Frequent Tiers. Although you can’t use a role search filter to restrict access to a partition by name, you can filter by the metadata that forms the routing expression for a partition. 
 
-For example, if you want to strict access to a partition whose routing expression is:
+For example, if you want to restrict access to a partition whose routing expression is:
 
 ```
 _sourceCategory=staging/*

--- a/docs/manage/partitions/flex/faq.md
+++ b/docs/manage/partitions/flex/faq.md
@@ -28,7 +28,7 @@ With Flex Pricing, there is no cost to ingest and index log data, and no require
 
 Yes, you can use [Role-Based Access Control (RBAC)](/docs/manage/users-roles/roles/role-based-access-control) to restrict access to partitions in Flex. Although you can’t use a role search filter to restrict access to a partition by name, you can filter by the metadata that forms the routing expression for a partition.
 
-For example, if you want to strict access to a partition whose routing expression is:
+For example, if you want to restrict access to a partition whose routing expression is:
 
 ```
 _sourceCategory=staging/*


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes a wording problem in these sections:
- https://help.sumologic.com/docs/manage/partitions/flex/faq/#can-i-restrict-access-to-flex-data-to-select-users
- https://help.sumologic.com/docs/manage/partitions/data-tiers/faq/#can-i-restrict-access-to-infrequent-or-frequent-data-to-select-users

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

From a [request in the #dochub Slack channel](https://sumologic.slack.com/archives/C0S86TM6K/p1736317267801369).
