### PR TITLE
Fix broken service map icon

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -217,7 +217,7 @@ To connect with other Sumo Logic users, post feedback, or ask a question, visit 
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/api/service-map"><img src={useBaseUrl('img/apm/traces/servicemap.png')} alt="Thumbnail icon" width="50"/><h4>Service Map</h4></a>
+  <a href="/docs/api/service-map"><img src={useBaseUrl('img/apm/services-map-icon.png')} alt="Thumbnail icon" width="50"/><h4>Service Map</h4></a>
   </div>
 </div>
 <div className="box smallbox card">

--- a/docs/api/service-map.md
+++ b/docs/api/service-map.md
@@ -10,7 +10,7 @@ import ApiErrors from '../reuse/api-errors.md';
 import ApiIntro from '../reuse/api-intro.md';
 import ApiRoles from '../reuse/api-roles.md';
 
-<img src={useBaseUrl('img/apm/traces/servicemap.png')} alt="Thumbnail icon" width="50"/>
+<img src={useBaseUrl('img/apm/services-map-icon.png')} alt="Thumbnail icon" width="50"/>
 
 The Service Map API allows you to fetch a graph representation of the Service Map, which is a high-level view of your application environment, automatically derived from tracing data. For more information, see [Service Map](/docs/apm/services-list-map).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes broken service map icons in these articles:
- https://help.sumologic.com/docs/api/
- https://help.sumologic.com/docs/api/service-map/

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

NA
