### PR TITLE
Allow Berry widget to expand wider

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -89,9 +89,11 @@ export const Home = () => {
       </Button>
     ))}
   </Stack>
+          </Container>
 
+          <Container maxWidth="lg">
             {/* Inline Chatbot Container */}
-            <Box id="inline-berry-chatbot-container" sx={{ my: 4, p: 2, margin: '0 auto', textAlign: 'center' }}>
+            <Box id="inline-berry-chatbot-container" sx={{ my: 4, py: 2, margin: '0 auto', textAlign: 'center' }}>
             {/* The chatbot will render here */}
             </Box>
           </Container>


### PR DESCRIPTION
## Purpose of this pull request

Allow the inline Berry widget to expand up to a maximum of 1200px (minus some horizontal padding). The chat bubble accommodates around 100 characters per line at its widest.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
