### PR TITLE
DOCS-SUMO-248716 - Update search filter limitations

### DIFF
--- a/docs/manage/users-roles/roles/construct-search-filter-for-role.md
+++ b/docs/manage/users-roles/roles/construct-search-filter-for-role.md
@@ -20,7 +20,6 @@ The explanations of the behavior of each example filter assume that no other rol
 The sections below list search filter limitations, and describe how you can use keywords, wildcards, metadata, and logical operators in filters. 
 
 * Role filters should include only keyword expressions or built-in metadata field expressions using these fields: `_sourcecategory`, `_collector`, `_source`, `_sourcename`, `_sourcehost`.
-* Using `_index` or `_view` in a role filter scope is not supported.
 * Role filters cannot include vertical pipes (`|`).
 * Role filters apply to log searches, not metric searches.
 * The [_dataTier](/docs/manage/partitions/data-tiers/searching-data-tiers/) search modifier is not supported in role filters.


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the "Search filter limitations" section of https://help.sumologic.com/docs/manage/users-roles/roles/construct-search-filter-for-role/#search-filter-limitations

It removes this line:
> Using _index or _view in a role filter scope is not supported.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[SUMO-248716](https://sumologic.atlassian.net/browse/SUMO-248716)
