### PR TITLE
Annotate comments for threatlookup operator

### DIFF
--- a/docs/integrations/amazon-aws/waf.md
+++ b/docs/integrations/amazon-aws/waf.md
@@ -60,7 +60,7 @@ _sourceCategory=AWS/WAF {{client_ip}}
 | parse "\"httpMethod\":\"*\"," as httpMethod,"\"httpVersion\":\"*\"," as httpVersion,"\"uri\":\"*\"," as uri, "{\"clientIp\":\"*\",\"country\":\"*\"" as clientIp,country, "\"action\":\"*\"" as action, "\"matchingNonTerminatingRules\":[*]" as matchingNonTerminatingRules, "\"rateBasedRuleList\":[*]" as rateBasedRuleList, "\"ruleGroupList\":[*]" as ruleGroupList, "\"httpSourceId\":\"*\"" as httpSourceId, "\"httpSourceName\":\"*\"" as httpSourceName, "\"terminatingRuleType\":\"*\"" as terminatingRuleType, "\"terminatingRuleId\":\"*\"" as terminatingRuleId, "\"webaclId\":\"*\"" as webaclId nodrop
 | lookup type, actor, raw, threatlevel as malicious_confidence from sumo://threat/cs on threat=clientip
 ```
-<!-- Replace code example with this after `sumo://threat/i471` is replaced by `threatlookup`:
+<!-- Per DOCS-643, replace code example with this after `sumo://threat/cs` is replaced by `threatlookup`:
 ```sql title="Client IP Threat Info"
 _sourceCategory=AWS/WAF {{client_ip}}
 | parse "\"httpMethod\":\"*\"," as httpMethod,"\"httpVersion\":\"*\"," as httpVersion,"\"uri\":\"*\"," as uri, "{\"clientIp\":\"*\",\"country\":\"*\"" as clientIp,country, "\"action\":\"*\"" as action, "\"matchingNonTerminatingRules\":[*]" as matchingNonTerminatingRules, "\"rateBasedRuleList\":[*]" as rateBasedRuleList, "\"ruleGroupList\":[*]" as ruleGroupList, "\"httpSourceId\":\"*\"" as httpSourceId, "\"httpSourceName\":\"*\"" as httpSourceName, "\"terminatingRuleType\":\"*\"" as terminatingRuleType, "\"terminatingRuleId\":\"*\"" as terminatingRuleId, "\"webaclId\":\"*\"" as webaclId nodrop

--- a/docs/observability/aws/integrations/aws-dynamodb.md
+++ b/docs/observability/aws/integrations/aws-dynamodb.md
@@ -69,7 +69,7 @@ _sourceCategory=Labs/AWS/DynamoDB account=* namespace=* "\"eventSource\":\"dynam
 | sum (ip_count) as threat_count
 ```
 
-<!-- Replace code example with this after `sumo://threat/i471` is replaced by `threatlookup`:
+<!-- Per DOCS-643, replace code example with this after `sumo://threat/cs` is replaced by `threatlookup`:
 ```sql title="All IP Threat Count"
 _sourceCategory=Labs/AWS/DynamoDB account=* namespace=* "\"eventSource\":\"dynamodb.amazonaws.com\""
 | json "eventName", "awsRegion", "requestParameters.tableName", "sourceIPAddress", "userIdentity.userName" as event_name, Region, entity, ip_address, user

--- a/docs/search/search-query-language/search-operators/threatip.md
+++ b/docs/search/search-query-language/search-operators/threatip.md
@@ -6,7 +6,7 @@ sidebar_label: threatip
 
 The `threatip` operator correlates data in the [Sumo Logic threat intelligence sources](/docs/security/threat-intelligence/about-threat-intelligence/#sumo-logic-threat-intelligence-sources) based on IP addresses from your log data. This provides security analytics that helps you to detect threats in your environment, while also protecting against sophisticated and persistent cyber-attacks. 
 
-<!-- 
+<!-- Add this per DOCS-815:
 You can also use the [`threatlookup`](/docs/search/search-query-language/search-operators/threatlookup/) search operator to search threat intelligence indicators.
 -->
 

--- a/docs/search/search-query-language/search-operators/tolowercase-touppercase.md
+++ b/docs/search/search-query-language/search-operators/tolowercase-touppercase.md
@@ -55,7 +55,7 @@ which provides results like:
 | lookup raw from sumo://threat/cs on threat = hash{code}
 ```
 
-<!-- Replace code example with this after `sumo://threat/i471` is replaced by `threatlookup`:
+<!-- Per DOCS-643, replace code example with this after `sumo://threat/cs` is replaced by `threatlookup`:
 ```sql
 *
 | limit 1

--- a/docs/search/subqueries.md
+++ b/docs/search/subqueries.md
@@ -389,7 +389,7 @@ _sourceCategory=weblogs
 | where threatlevel = "high"
 | compose src_ip]
 ```
-<!-- Replace code example with this after `sumo://threat/i471` is replaced by `threatlookup`:
+<!-- Per DOCS-643, replace code example with this after `sumo://threat/cs` is replaced by `threatlookup`:
 ```sql
 _sourceCategory=weblogs
 [subquery:_sourceCategory="Labs/SecDemo/guardduty" "EC2 Instance" "communicating on an unusual server port 22"

--- a/docs/security/additional-security-features/threat-detection-and-investigation.md
+++ b/docs/security/additional-security-features/threat-detection-and-investigation.md
@@ -298,7 +298,7 @@ We need a way to see if any of the IP addresses we have logged are known threats
    | fields - ip_address,malicious_confidence,actor,kill_chains,ip_address_types,_sourceCategory,_source | count by _timeslice
    | outlier _count window=5,threshold=3,consecutive=1,direction=+-
    ```
-<!-- Replace code example with this after `sumo://threat/i471` is replaced by `threatlookup`:
+<!-- Per DOCS-643, replace code example with this after `sumo://threat/cs` is replaced by `threatlookup`:
    ```
    _sourceCategory=Labs/AWS/CloudTrail 
    | parse regex "(?<ip_address>\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})" 

--- a/docs/security/threat-intelligence/find-threats.md
+++ b/docs/security/threat-intelligence/find-threats.md
@@ -37,7 +37,7 @@ To find threats using IP addresses, use the `threatip` search operator. This ope
 
 For more information, see [threatip Search Operator](/docs/search/search-query-language/search-operators/threatip/).
 
-<!--
+<!-- Add per DOCS-815:
 ## threatlookup operator
 
 You can use the `threatlookup` search operator to find matches to indicators in any source in the Sumo Logic [threat intelligence](/docs/security/threat-intelligence/) datastore. 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds ticket numbers to some `threatlookup` comments so we can keep track of why the comments are there.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

Related to [DOCS-643](https://sumologic.atlassian.net/browse/DOCS-643) and [DOCS-815](https://sumologic.atlassian.net/browse/DOCS-815).
