### PR TITLE
Update GitHub Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }}
       url: ${{ inputs.hostname }}${{ inputs.base_url }}

--- a/.github/workflows/delete-review.yml
+++ b/.github/workflows/delete-review.yml
@@ -4,7 +4,7 @@ on: delete
 
 jobs:
   delete-branch-environment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment:
       name: review/${{ github.ref_name }}
     env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     build-and-deploy:
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-latest
       env:
           CI: true
           NODE_ENV: production


### PR DESCRIPTION
## Purpose of this pull request

Switched `runs-on: ubuntu-20.04` to `ubuntu-22.04` to address upcoming deprecation scheduled for April 15, 2025 [GitHub notice](https://github.com/actions/runner-images/issues/11101). This should also resolve internal errors encountered during the `delete-branch-environment` job.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
