### PR TITLE
Remove old hidden YouTube links

### DIFF
--- a/docs/alerts/monitors/alert-response.md
+++ b/docs/alerts/monitors/alert-response.md
@@ -33,19 +33,6 @@ Learn how to use alert response.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/3FHomBuFyV8?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Setting up alert response

--- a/docs/alerts/monitors/create-monitor.md
+++ b/docs/alerts/monitors/create-monitor.md
@@ -112,18 +112,6 @@ Learn about AI-driven alerting.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/nMRoYb1YCfg?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 :::
 
 **Use Outlier**

--- a/docs/alerts/monitors/use-playbooks-with-monitors.md
+++ b/docs/alerts/monitors/use-playbooks-with-monitors.md
@@ -99,18 +99,6 @@ Watch this micro lesson to learn about anomaly monitors.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/nMRoYb1YCfg?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 :::
 
 To create an anomaly monitor that runs an automated playbook in response to an alert:

--- a/docs/apm/real-user-monitoring/configure-data-collection.md
+++ b/docs/apm/real-user-monitoring/configure-data-collection.md
@@ -26,18 +26,6 @@ Using the RUM HTTP Traces App for Manual Testing.
   allowfullscreen
 />
 
-<!-- old 
-<Iframe url="https://www.youtube.com/embed/CduT1sqSPmE?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
---> 
 :::
 
 ## Prerequisites

--- a/docs/apm/real-user-monitoring/index.md
+++ b/docs/apm/real-user-monitoring/index.md
@@ -38,19 +38,6 @@ See Real User Monitoring in action.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/3EMl3jyoZjA?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## What You'll Need

--- a/docs/apm/spans.md
+++ b/docs/apm/spans.md
@@ -48,19 +48,6 @@ This micro lesson provides an overview of Span Analytics, and describes the term
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/2cp_0pmzD-A"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 

--- a/docs/apm/traces/get-started-transaction-tracing/opentelemetry-instrumentation/java/index.md
+++ b/docs/apm/traces/get-started-transaction-tracing/opentelemetry-instrumentation/java/index.md
@@ -23,19 +23,6 @@ import Iframe from 'react-iframe';
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/P_74rhI1M30?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Installation

--- a/docs/apm/traces/quickstart.md
+++ b/docs/apm/traces/quickstart.md
@@ -40,18 +40,6 @@ This micro lesson can help you get started with Tracing.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/BTqufvTJ4vE"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 :::
 
 Trace data is visualized through filtered trace lists and icicle charts allowing you to find and troubleshoot faulty transactions easily. See how easy it is to [view and investigate traces](view-and-investigate-traces.md).

--- a/docs/cloud-soar/incidents-triage.md
+++ b/docs/cloud-soar/incidents-triage.md
@@ -43,19 +43,6 @@ Watch this micro lesson to learn more about incidents in Cloud SOAR.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/GDWFGJ8JOqA?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
---> 
-
 :::
 ### Filter incidents
 
@@ -348,19 +335,6 @@ Watch the following micro lesson to learn about dashboards.
   allow="autoplay; fullscreen"
   allowfullscreen
 />
-
-<!-- old
-<Iframe url="https://www.youtube.com/embed/NRdtAvxhuOY?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
 
 :::
 

--- a/docs/contributing/create-edit-doc.md
+++ b/docs/contributing/create-edit-doc.md
@@ -43,19 +43,6 @@ Check out this brief tutorial on how to submit a basic change to our docs.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/2ONgNj8pNLY?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 <details>

--- a/docs/cse/administration/create-cse-actions.md
+++ b/docs/cse/administration/create-cse-actions.md
@@ -46,19 +46,6 @@ Watch this micro lesson to learn how to configure an action.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/uHY-r04edn0?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Insight actions

--- a/docs/cse/administration/create-cse-context-actions.md
+++ b/docs/cse/administration/create-cse-context-actions.md
@@ -52,19 +52,6 @@ Watch this micro lesson to learn more about how to use context actions.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/PrMr3sjaJxA?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Configure a context action

--- a/docs/cse/administration/mitre-coverage.md
+++ b/docs/cse/administration/mitre-coverage.md
@@ -38,19 +38,6 @@ Watch this micro lesson to learn about the MITRE ATT&CK Threat Coverage Explorer
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/O1SmpbL4gos?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 ## User interface 

--- a/docs/cse/get-started-with-cloud-siem/about-cse-insight-ui.md
+++ b/docs/cse/get-started-with-cloud-siem/about-cse-insight-ui.md
@@ -252,19 +252,6 @@ Watch this micro lesson to learn more about the entity relationship graph.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/GTTwjB8y_5k?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 #### Entity details in the right pane

--- a/docs/cse/get-started-with-cloud-siem/insight-generation-process.md
+++ b/docs/cse/get-started-with-cloud-siem/insight-generation-process.md
@@ -27,19 +27,6 @@ Watch this micro lesson to learn how insights are created.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/MjzJlozR6mE?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Entities in messages are mapped to entity-type schema attributes

--- a/docs/cse/ingestion/sumo-logic-ingest-mapping.md
+++ b/docs/cse/ingestion/sumo-logic-ingest-mapping.md
@@ -30,20 +30,6 @@ Watch this micro lesson to learn more about ingest mapping for Cloud SIEM:
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/luPl_IB9b8A?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
-
 Watch this micro lesson to learn about forwarding ingested data to Cloud SIEM:
 
 <Iframe url="https://fast.wistia.net/embed/iframe/krg64dumyv?web_component=true&seo=true&videoFoam=false"
@@ -57,19 +43,6 @@ Watch this micro lesson to learn about forwarding ingested data to Cloud SIEM:
   allow="autoplay; fullscreen"
   allowfullscreen
 />
-
-<!-- old
-<Iframe url="https://www.youtube.com/embed/XCcu-YU9B5U?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 
 :::
 

--- a/docs/cse/records-signals-entities-insights/global-intelligence-security-insights.md
+++ b/docs/cse/records-signals-entities-insights/global-intelligence-security-insights.md
@@ -25,19 +25,6 @@ Watch this micro lesson to learn more about Global Intelligence for insights.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/toAvKsfVbHc?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 ## What is a Global Confidence score?

--- a/docs/cse/records-signals-entities-insights/view-manage-entities.md
+++ b/docs/cse/records-signals-entities-insights/view-manage-entities.md
@@ -33,19 +33,6 @@ Watch this micro lesson to learn more about entities.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/cIpLaDQAOAw?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## About entities

--- a/docs/cse/rules/about-cse-rules.md
+++ b/docs/cse/rules/about-cse-rules.md
@@ -34,19 +34,6 @@ Watch this micro lesson to learn more about rules.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/RVGk2dDeHmk?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## About rule expressions

--- a/docs/cse/rules/insight-trainer.md
+++ b/docs/cse/rules/insight-trainer.md
@@ -30,19 +30,6 @@ Watch this micro lesson to learn how to use the Insight Trainer dashboard.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/I90Wsjp5XPA?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## About Insight Trainer

--- a/docs/cse/rules/rule-tuning-expressions.md
+++ b/docs/cse/rules/rule-tuning-expressions.md
@@ -58,19 +58,6 @@ Watch this micro lesson to learn how to create a rule tuning expression.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/3BUKLtJtPI8?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Create a tuning expression

--- a/docs/cse/rules/write-aggregation-rule.md
+++ b/docs/cse/rules/write-aggregation-rule.md
@@ -54,19 +54,6 @@ Watch this micro lesson to learn how to create an aggregation rule.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/XaqQES5suWQ?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Create an aggregation rule

--- a/docs/cse/rules/write-chain-rule.md
+++ b/docs/cse/rules/write-chain-rule.md
@@ -36,19 +36,6 @@ Watch this micro lesson to learn how to create a chain rule.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/58h2mVnw1oE?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Create a chain rule

--- a/docs/cse/rules/write-first-seen-rule.md
+++ b/docs/cse/rules/write-first-seen-rule.md
@@ -44,19 +44,6 @@ Watch this micro lesson to learn more about first seen rules.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/ssfL_c3j_r8?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Baselines for first seen rules

--- a/docs/cse/rules/write-match-rule.md
+++ b/docs/cse/rules/write-match-rule.md
@@ -45,19 +45,6 @@ Watch this micro lesson to learn how to create a match rule.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/l7xOBls1ROE?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Create a match rule

--- a/docs/cse/rules/write-outlier-rule.md
+++ b/docs/cse/rules/write-outlier-rule.md
@@ -47,19 +47,6 @@ Watch this micro lesson to learn more about outlier rules.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/1HEUPWpDA_o?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Baselines for outlier rules

--- a/docs/cse/rules/write-threshold-rule.md
+++ b/docs/cse/rules/write-threshold-rule.md
@@ -33,19 +33,6 @@ Watch this micro lesson to learn how to create a threshold rule.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/uei_TDOy5QM?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Create a threshold rule

--- a/docs/cse/schema/parser-editor.md
+++ b/docs/cse/schema/parser-editor.md
@@ -37,19 +37,6 @@ Watch the following micro lesson to learn how to apply parsers to Cloud SIEM dat
   allowfullscreen
 />
 
-<!-- 
-<Iframe url="https://www.youtube.com/embed/CVaoD96Mhok?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 ## Check parser code for mapping hints

--- a/docs/dashboards/create-dashboard-new.md
+++ b/docs/dashboards/create-dashboard-new.md
@@ -27,19 +27,6 @@ Rather watch a short micro lesson video?
   allowfullscreen
 />
 
-<!--
-<Iframe url="https://www.youtube.com/embed/A-O_E-NbxN8"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Dashboard AutoSave

--- a/docs/dashboards/explore-view.md
+++ b/docs/dashboards/explore-view.md
@@ -175,19 +175,6 @@ Navigation capabilities allow you to quickly locate the object that needs debugg
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/CEBN4lRp4SU?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ### Step 1: Analyzing the cluster

--- a/docs/dashboards/share-dashboard-new.md
+++ b/docs/dashboards/share-dashboard-new.md
@@ -27,19 +27,6 @@ Share a dashboard inside your organization.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/nQOAYaMad4Q"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Sharing a dashboard within your organization

--- a/docs/get-started/overview.md
+++ b/docs/get-started/overview.md
@@ -32,19 +32,6 @@ Get to know Sumo Logic through our video, "Introduction to Sumo Logic".
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/T4WAZz8-r54?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Benefits of using Sumo Logic
@@ -67,19 +54,6 @@ Get to know more about the benefits of using Sumo Logic.
   allow="autoplay; fullscreen"
   allowfullscreen
 />
-
-<!-- old
-<Iframe url="https://www.youtube.com/embed/D4WO5DlqD6o?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 
 :::
 
@@ -142,18 +116,6 @@ Get to know the collection process through our video, "Data Collection Strategy"
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/Y1UVF4ASm_c?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 :::
 
 ## Account configuration

--- a/docs/get-started/sumo-logic-ui.md
+++ b/docs/get-started/sumo-logic-ui.md
@@ -39,19 +39,7 @@ Watch this quick overview video to explore the key features of the New UI.
   allow="autoplay; fullscreen"
   allowfullscreen
 />
-
-<!-- old
-<Iframe url="https://www.youtube.com/embed/86IJB6JrG_k?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->  
+  
 :::
 
 :::warning Classic UI retirement notice

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -43,20 +43,6 @@ Watch this tutorial to learn how to use our **App Catalog**.
   allowfullscreen
 />
 
-
-<!-- old
-<Iframe url="https://www.youtube.com/embed/5O16kI5UXpM?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 <br/>

--- a/docs/integrations/sumo-apps/cse.md
+++ b/docs/integrations/sumo-apps/cse.md
@@ -26,18 +26,6 @@ Watch this micro lesson to learn more about the Enterprise Audit - Cloud SIEM ap
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/nYX0prIzDGk?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 :::
 
 ## Log types

--- a/docs/integrations/sumo-apps/flex.md
+++ b/docs/integrations/sumo-apps/flex.md
@@ -26,19 +26,6 @@ Learn how to view the Flex app dashboards.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/kn3SVhAIwDk?si=nMQBWvp5Ruo-nOaB"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
     
 ## Log types

--- a/docs/integrations/web-servers/nginx.md
+++ b/docs/integrations/web-servers/nginx.md
@@ -34,19 +34,6 @@ Learn to set up NGINX for non-Kubernetes Sources.
   allowfullscreen
 />
 
-<!--
-<Iframe url="https://www.youtube.com/embed/X_6f0MDVTxo?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 

--- a/docs/manage/field-extractions/create-field-extraction-rule.md
+++ b/docs/manage/field-extractions/create-field-extraction-rule.md
@@ -31,18 +31,6 @@ Learn how to create a FER through our video, "Creating a Field Extraction Rule".
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/QWm8hR7SmxE"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 :::
 
 ## Creating a new Field Extraction Rule

--- a/docs/manage/field-extractions/index.md
+++ b/docs/manage/field-extractions/index.md
@@ -74,19 +74,6 @@ import FerLimit from '../../reuse/fer-limitations.md';
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/Xv3pSwhVCN4"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Edit a Field Extraction Rule

--- a/docs/manage/ingestion-volume/log-ingestion.md
+++ b/docs/manage/ingestion-volume/log-ingestion.md
@@ -56,19 +56,6 @@ Watch this micro lesson to learn more about throttling.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/dlKy9DyS0W8?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 Throttling is enabled across all Collectors in an account. Sumo Logic measures the amount of data already committed to uploading against the number of previous requests and available resources (quota) in an account. In other words, Sumo Logic compares the current ingestion with the rate of ingest using a per minute rate that can be derived from the contracted Daily GB/day rate.

--- a/docs/manage/manage-subscription/create-and-manage-orgs/create-manage-orgs-service-providers.md
+++ b/docs/manage/manage-subscription/create-and-manage-orgs/create-manage-orgs-service-providers.md
@@ -162,19 +162,6 @@ Watch this micro lesson to learn more about managing a child org.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/ni7xMZjHdQM?si=dbMnCgDtNtGLGINs"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 :::info

--- a/docs/manage/manage-subscription/create-and-manage-orgs/create-manage-orgs.md
+++ b/docs/manage/manage-subscription/create-and-manage-orgs/create-manage-orgs.md
@@ -51,19 +51,6 @@ Learn how to create a new child organization.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/omTHPAJ9dIg?si=m5dVp5oXu29wq4Pu"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 :::note
@@ -126,19 +113,6 @@ Watch this micro lesson to learn more about managing a child org.
   allow="autoplay; fullscreen"
   allowfullscreen
 />
-
-<!-- old
-<Iframe url="https://www.youtube.com/embed/ni7xMZjHdQM?si=dbMnCgDtNtGLGINs"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 
 :::
 

--- a/docs/manage/partitions/data-tiers/searching-data-tiers.md
+++ b/docs/manage/partitions/data-tiers/searching-data-tiers.md
@@ -23,19 +23,6 @@ import Iframe from 'react-iframe';
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/w0H8upLpCwU?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## About the _dataTier search modifier

--- a/docs/manage/partitions/index.md
+++ b/docs/manage/partitions/index.md
@@ -46,19 +46,6 @@ You define the data that will reside in a partition by defining a routing expres
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/kpQLFVT4uE8"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Limitations 

--- a/docs/observability/about.md
+++ b/docs/observability/about.md
@@ -27,19 +27,6 @@ This video explains Observability and how it's different from monitoring. It als
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/FJG1zesNJs0?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Why Observability?

--- a/docs/observability/aws/about.md
+++ b/docs/observability/aws/about.md
@@ -28,19 +28,6 @@ Watch the following micro lesson to learn about our AWS Observability solution.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/p_LaUPAer6I?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 #### AWS Observability Solution  

--- a/docs/observability/aws/deploy-use-aws-observability/index.md
+++ b/docs/observability/aws/deploy-use-aws-observability/index.md
@@ -33,17 +33,4 @@ Watch a micro lesson on deploying the AWS Observability Solution. 
   allowfullscreen
 />
 
-<!--
-<Iframe url="https://www.youtube.com/embed/_5JHkxG7ZMo?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::

--- a/docs/observability/kubernetes/quickstart.md
+++ b/docs/observability/kubernetes/quickstart.md
@@ -37,19 +37,6 @@ As an alternative to this quickstart, you can use our in-product onboarding to a
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/lLRtK1FaTgM?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Prerequisites

--- a/docs/observability/kubernetes/troubleshoot-with-explore.md
+++ b/docs/observability/kubernetes/troubleshoot-with-explore.md
@@ -23,19 +23,6 @@ import Iframe from 'react-iframe';
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/CEBN4lRp4SU?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 

--- a/docs/observability/reliability-management-slo/index.md
+++ b/docs/observability/reliability-management-slo/index.md
@@ -30,19 +30,6 @@ This guide provides an overview of Sumo Logic Reliability Management using Servi
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/jCGqfqEDXto?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 

--- a/docs/search/behavior-insights/logreduce/index.md
+++ b/docs/search/behavior-insights/logreduce/index.md
@@ -29,19 +29,6 @@ Watch our video on LogReduce. 
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/NlnIZvfYO2w"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 In this section, we'll introduce the following concepts:

--- a/docs/search/get-started-with-search/index.md
+++ b/docs/search/get-started-with-search/index.md
@@ -24,19 +24,6 @@ Watch this micro lesson to get an introduction to search.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/VbFsfpmP6LY?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 In this section, we'll introduce the following concepts:

--- a/docs/search/get-started-with-search/search-basics/about-search-basics.md
+++ b/docs/search/get-started-with-search/search-basics/about-search-basics.md
@@ -24,19 +24,6 @@ How to search data using the Basic Search Mode in Sumo Logic.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/Ps2YperJyZo?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 In the **Search** tab, a search query is typically formatted something like this:

--- a/docs/search/get-started-with-search/search-basics/built-in-metadata.md
+++ b/docs/search/get-started-with-search/search-basics/built-in-metadata.md
@@ -24,19 +24,6 @@ many ways, such as the user interface when managing Collection, and can be refer
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/HNsXN5RoPwo"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 #### Built-in metadata fields

--- a/docs/search/get-started-with-search/search-page/log-level.md
+++ b/docs/search/get-started-with-search/search-page/log-level.md
@@ -30,19 +30,6 @@ Watch the following micro lesson to learn about log level detection.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/cAQYiVs-PXY?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 <details>

--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -115,19 +115,6 @@ In this micro lesson, learn about the ingestion pipeline and the journey that a 
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/ycaoBEAF8hk?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 ## Partitions and Views

--- a/docs/security/additional-security-features/cloud-infrastructure-security/cloud-infrastructure-security-for-aws.md
+++ b/docs/security/additional-security-features/cloud-infrastructure-security/cloud-infrastructure-security-for-aws.md
@@ -41,19 +41,6 @@ Watch the following micro lesson to learn about Cloud Infrastructure Security fo
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/JD9tNfCW7uo?rel=0"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-     allowfullscreen
-     />
--->
-
 :::
 
 ## Log types

--- a/docs/send-data/best-practices.md
+++ b/docs/send-data/best-practices.md
@@ -48,18 +48,6 @@ While the components at the beginning of the value do not add any obvious value,
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/vkKeJOBVVjk"
-     width="854px"
-     height="480px"
-     id="myId"
-     className="video-container"
-     display="initial"
-     position="relative"
-     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"      allowfullscreen
-     />
--->
-
 :::
 
 ### Define the Scope of Searches

--- a/docs/send-data/choose-collector-source.md
+++ b/docs/send-data/choose-collector-source.md
@@ -176,19 +176,6 @@ Depending on the method you'd like to collect logs, and the types of logs you'd
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/ZcbHoC1jZz4?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 The following table shows the major differences between them.
@@ -227,19 +214,6 @@ The maximum number of Sources allowed on a Collector is 1,000.
   allow="autoplay; fullscreen"
   allowfullscreen
 />
-
-<!-- old
-<Iframe url="https://www.youtube.com/embed/CfWXz6UkpIc"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
 
 :::
 

--- a/docs/send-data/collect-from-other-data-sources/azure-blob-storage/block-blob/collect-logs.md
+++ b/docs/send-data/collect-from-other-data-sources/azure-blob-storage/block-blob/collect-logs.md
@@ -34,19 +34,6 @@ Watch this tutorial to learn how to collect logs from Azure Blob Storage.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/186K2d-FFoc?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Functional overview

--- a/docs/send-data/collect-from-other-data-sources/azure-blob-storage/block-blob/index.md
+++ b/docs/send-data/collect-from-other-data-sources/azure-blob-storage/block-blob/index.md
@@ -34,19 +34,6 @@ Watch this tutorial for an overview of collecting logs from Azure Blob Storage.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/_-N3QGxrn9k?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## Azure information resources

--- a/docs/send-data/hosted-collectors/amazon-aws/aws-cloudtrail-source.md
+++ b/docs/send-data/hosted-collectors/amazon-aws/aws-cloudtrail-source.md
@@ -30,19 +30,6 @@ You need to know where your CloudTrail log files are stored so you can provide 
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/SQMzez_9PiU?rel=0"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 

--- a/docs/send-data/hosted-collectors/index.md
+++ b/docs/send-data/hosted-collectors/index.md
@@ -38,19 +38,6 @@ The maximum number of Collectors allowed per organization is 10,000.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/bjbTm3vR2nA"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 

--- a/docs/send-data/installed-collectors/configuration.md
+++ b/docs/send-data/installed-collectors/configuration.md
@@ -33,19 +33,6 @@ The maximum number of Collectors allowed per organization is 10,000.
   allowfullscreen
 />
 
-<!-- old
-<Iframe url="https://www.youtube.com/embed/QxGCrxbJ1Vs"
-        width="854px"
-        height="480px"
-        id="myId"
-        className="video-container"
-        display="initial"
-        position="relative"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        />
--->
-
 :::
 
 ## CPU usage guidelines


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes old links to micro lessons on YouTube which were hidden in read-only text.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-943](https://sumologic.atlassian.net/browse/DOCS-943)
