### PR TITLE
DOCS-970 - Fix typo in threatip article

### DIFF
--- a/docs/search/search-query-language/search-operators/threatip.md
+++ b/docs/search/search-query-language/search-operators/threatip.md
@@ -6,13 +6,13 @@ sidebar_label: threatip
 
 The `threatip` operator looks for suspicious IP addresses in your log data. Using the operator provides security analytics that help you to detect threats in your environment, while also protecting against sophisticated and persistent cyber-attacks.
 
-Behind the scenes, the `threatip` operator uses `sumo://threat/cs` in log search queries to correlate data in the `_sumo_global_feed_cs` [threat intelligence source](/docs/security/threat-intelligence/about-threat-intelligence/#sumo-logic-threat-intelligence-sources). The `threatip` operator uses the same lookup as the [Threat Intel Quick Analysis app](/docs/integrations/security-threat-detection/threat-intel-quick-analysis/#threat-intel-optimization) but is simplified for only IP threat lookups. 
+Behind the scenes, the `threatip` operator [uses `sumo://threat/cs` in log search queries](/docs/security/threat-intelligence/find-threats/#use-the-lookup-search-operator) to correlate data in the `_sumo_global_feed_cs` threat intelligence source. The `threatip` operator uses the same lookup as the [Threat Intel Quick Analysis app](/docs/integrations/security-threat-detection/threat-intel-quick-analysis/#threat-intel-optimization) but is simplified for only IP threat lookups. 
 
 <!-- Add this per DOCS-815:
 You can also use the [`threatlookup`](/docs/search/search-query-language/search-operators/threatlookup/) search operator to search threat intelligence indicators.
 -->
 
-The only Indicators of Compromise (IOC)] supported is IP address.
+The only Indicators of Compromise (IOC) supported is IP address.
 
 ## Syntax
 

--- a/docs/security/threat-intelligence/find-threats.md
+++ b/docs/security/threat-intelligence/find-threats.md
@@ -33,7 +33,7 @@ All the dashboards in the [Threat Intel Quick Analysis](/docs/integrations/secur
 
 ## Use the threatip search operator
 
-To find threats using IP addresses, use the `threatip` search operator. This operator uses `sumo://threat/cs` in log search queries to correlate data in the `_sumo_global_feed_cs` [threat intelligence source](/docs/security/threat-intelligence/about-threat-intelligence/#sumo-logic-threat-intelligence-sources).
+To find threats using IP addresses, use the `threatip` search operator. This operator [uses `sumo://threat/cs` in log search queries](#use-the-lookup-search-operator) to correlate data in the `_sumo_global_feed_cs` threat intelligence source.
 
 For more information, see [threatip Search Operator](/docs/search/search-query-language/search-operators/threatip/).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes a typo introduced in #5538 and updates these articles:
https://help.sumologic.com/docs/search/search-query-language/search-operators/threatip/
https://help.sumologic.com/docs/security/threat-intelligence/find-threats/#use-the-threatip-search-operator


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-970](https://sumologic.atlassian.net/browse/DOCS-970)
