### PR TITLE
Create deploy-to-pantheon.yml

### DIFF
--- a/.github/workflows/deploy-to-pantheon.yml
+++ b/.github/workflows/deploy-to-pantheon.yml
@@ -1,0 +1,71 @@
+name: deploy-to-pantheon
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy-to-pantheon:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://www.sumologic.com/
+    env:
+      CI: true
+      NODE_ENV: production
+      NODE_OPTIONS: "--max-old-space-size=8192 --max-http-header-size=8192"
+      HOSTNAME: https://www.sumologic.com
+      BASE_URL: /help/
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.PANTHEON_SSH_KEY }}
+          config: |
+            Host *.drush.in
+               StrictHostKeyChecking no
+          known_hosts: ${{ secrets.PANTHEON_KNOWN_HOSTS }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+      - name: Install Terminus
+        uses: pantheon-systems/terminus-github-actions@v1
+        with:
+          pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          cache: 'yarn'
+      - name: Docusaurus Webpack cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules/.cache
+          key: ${{ runner.os }}-webpack-cache-${{ hashFiles('yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build the Docusaurus site
+        run: yarn build
+      - name: Pantheon, check environment and deploy helpdocs
+        run: |
+          # Check for helpdocs environment in Pantheon, create one if not found
+          PANTHEON_ENV_LIST="$(terminus env:list "${{ vars.PANTHEON_SITE_ID }}" --format=list | xargs)"
+          DEV_SITE_EXISTS="$(echo "$PANTHEON_ENV_LIST" | grep "helpdocs" | wc -l | xargs)"
+          if [ "$DEV_SITE_EXISTS" -eq "0" ]; then
+            terminus multidev:create --no-interaction --no-ansi ${{ vars.PANTHEON_SITE_ID }}.dev helpdocs
+            terminus lock:enable ${{ vars.PANTHEON_SITE_ID }}.helpdocs -- "${{ secrets.PANTHEON_AUTH_USER }}" "${{ secrets.PANTHEON_AUTH_PASSWORD }}"
+          fi
+          # Put environment in SFTP mode, because we're using rsync to move files up
+          terminus connection:set ${{ vars.PANTHEON_SITE_ID }}.helpdocs sftp
+          terminus self:plugin:install terminus-rsync-plugin
+          mv ./build ./help          
+          terminus rsync ./help ${{ vars.PANTHEON_SITE_ID }}.helpdocs:code
+          terminus env:commit --message "Production build of helpdocs" --force -- ${{ vars.PANTHEON_SITE_ID }}.helpdocs


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds an additional, parallel GitHub workflow that builds and deploys the docs site to Sumo's marketing site. The purpose of this workflow is to QA deploying the site to Marketing's environment without disrupting the current process.

The workflow will fail without the following repo vars:

- Secret: `PANTHEON_SSH_KEY`
- Secret: `PANTHEON_KNOWN_HOSTS`
- Secret: `PANTHEON_MACHINE_TOKEN`
- Secret: `PANTHEON_AUTH_USER`
- Secret: `PANTHEON_AUTH_PASSWORD`
- Variable: `PANTHEON_SITE_ID`

I have these ready to add to the repo in GitHub, but I won't add them until an owner gives me the OK. :)

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[Asana task](https://app.asana.com/1/144190854636/project/1210702047641089/task/1210641819553087)

