### PR TITLE
Remove instances of 'AI-driven alerting'

### DIFF
--- a/blog-service/2024/12-31.md
+++ b/blog-service/2024/12-31.md
@@ -280,9 +280,9 @@ Explore our technical documentation [here](/docs/integrations/saas-cloud/kandji/
 
 ### November 05, 2024 (Alerts)
 
-#### AI-Driven Alerts for Metrics Anomalies
+#### Alerts for Metrics Anomalies
 
-We're excited to announce the general availability of AI-driven alerts for metrics anomalies, extending our AI-driven alerting capabilities to include metrics-based monitors. This new feature aims to reduce alert fatigue and accelerate incident resolution through the use of automated playbooks. [Learn more](/docs/alerts/monitors/create-monitor).
+We're excited to announce the general availability of alerts for metrics anomalies, extending our alerting capabilities to include metrics-based monitors. This new feature aims to reduce alert fatigue and accelerate incident resolution through the use of automated playbooks. [Learn more](/docs/alerts/monitors/create-monitor).
 
 ##### Key features
 
@@ -373,9 +373,9 @@ We’ve added the **Convert to Anomaly** option, allowing you to convert outlier
 
 ### October 22, 2024 (Alerts)
 
-#### AI-Driven Alerts for Metrics Anomalies
+#### Alerts for Metrics Anomalies
 
-We're excited to announce the preview of AI-driven alerts for metrics anomalies, extending our AI-driven alerting to metrics-based monitors. This preview release helps reduce alert fatigue and enables faster incident resolution with automated playbooks.
+We're excited to announce the preview of alerts for metrics anomalies, extending our alerting to metrics-based monitors. This preview release helps reduce alert fatigue and enables faster incident resolution with automated playbooks.
 
 ##### Key Features
 
@@ -957,7 +957,7 @@ Learn more [here](/docs/integrations/amazon-aws/api-gateway/).
 
 ### March 12, 2024 (Alerts)
 
-#### Monitor Enhancements - AI-Driven Alerting
+#### Monitor Enhancements - Anomaly Alerting
 
 We're happy to announce two new monitoring features that allow you to generate alerts that notify you of suspicious behavior and automatically run playbooks to address it.
 

--- a/docs/alerts/monitors/create-monitor.md
+++ b/docs/alerts/monitors/create-monitor.md
@@ -9,7 +9,7 @@ import Iframe from 'react-iframe';
 
 This guide will walk you through the steps of creating a monitor in Sumo Logic, from setting up trigger conditions to configuring advanced settings, notifications, and playbooks.
 
-Our AI-driven alerts use machine learning to analyze historical data, establish baselines, detect significant deviations, and filter out irrelevant alerts to reduce alert fatigue and help teams focus on critical issues. These capabilities apply to both logs and metrics, providing a comprehensive monitoring solution. With seasonality detection and customizable anomaly clustering, false positives are minimized, enabling faster issue resolution.
+Our alerts use machine learning to analyze historical data, establish baselines, detect significant deviations, and filter out irrelevant alerts to reduce alert fatigue and help teams focus on critical issues. These capabilities apply to both logs and metrics, providing a comprehensive monitoring solution. With seasonality detection and customizable anomaly clustering, false positives are minimized, enabling faster issue resolution.
 
 Integrated playbooks automate incident response by gathering diagnostics, notifying teams, triggering recovery actions, and streamlining workflows to improve response times. You can link playbooks to monitors to automate tasks such as restarting services or scaling infrastructure, ensuring swift and efficient anomaly resolution.
 
@@ -88,7 +88,7 @@ Set specific threshold conditions for well-defined KPIs with constant thresholds
 
 #### Anomaly
 
-Leverage machine learning to identify unusual behavior and suspicious patterns by establishing baselines for normal activity. This *AI-driven alerting* system uses historical data to minimize false positives and alerts you to deviations.
+Leverage machine learning to identify unusual behavior and suspicious patterns by establishing baselines for normal activity. This alerting system uses historical data to minimize false positives and alerts you to deviations.
 
 * **Model-driven detection**. Machine learning models create accurate baselines, eliminating guesswork and noise.
 * **AutoML**. The system self-tunes with seasonality detection, minimizing user intervention and adjusting for recurring patterns to reduce false positives.
@@ -98,7 +98,7 @@ Leverage machine learning to identify unusual behavior and suspicious patterns b
 * **Customizable detection**. Use advanced rules like "Cluster anomalies" to detect multiple data points exceeding thresholds within a set timeframe.
 
 :::sumo Micro Lesson
-Learn about AI-driven alerting.
+Watch this micro lesson to learn about anomaly monitors.
 
 <Iframe url="https://fast.wistia.net/embed/iframe/8z9b2zqtc3?web_component=true&seo=true&videoFoam=false"
   width="854px"

--- a/docs/alerts/scheduled-searches/create-real-time-alert.md
+++ b/docs/alerts/scheduled-searches/create-real-time-alert.md
@@ -29,7 +29,7 @@ Monitors offer significant improvements over Real-Time Scheduled Searches, inclu
 * [Multiple trigger conditions](/docs/alerts/monitors/create-monitor/#step-1-set-trigger-conditions) (Critical, Warning, Missing Data)
 * [Alert grouping](/docs/alerts/monitors/alert-grouping/)
 * [Playbook support](/docs/alerts/monitors/alert-response/#alert-details)
-* [AI-driven alerting](/release-notes-service/2024/12/31/#march-12-2024-alerts)
+* [Anomaly alerting](/release-notes-service/2024/12/31/#march-12-2024-alerts)
 * [Integration with the Alert Response page](/docs/alerts/monitors/alert-response/)
 
 Monitors are the strategic focus for our future alerting development and enhancements.

--- a/docs/get-started/ai-machine-learning.md
+++ b/docs/get-started/ai-machine-learning.md
@@ -55,7 +55,7 @@ LogReduce&reg; utilizes AI-driven algorithms to cluster log messages based on st
 
 LogCompare simplifies log analysis by enabling easy comparison of log data from different time periods to detect changes or anomalies, facilitating troubleshooting and root cause discovery. By automatically running delta analysis, LogCompare streamlines the process, allowing users to identify significant alterations in log patterns efficiently. Utilizing baseline and target queries, LogCompare clusters logs into patterns and compares them based on the significance of change, providing insights into deviations over time. With intuitive actions like promoting, demoting, and splitting signatures, users can refine their analysis and focus on relevant patterns, ultimately enhancing decision-making and threat detection capabilities. Additionally, LogCompare supports alerts and scheduled searches to notify users of new signatures or significant changes, ensuring proactive monitoring and response to evolving log data. [Learn more](/docs/search/behavior-insights/logcompare).
 
-### AI-driven Alerts
+### AI in alerting
 
 #### Anomaly Detection
 

--- a/docs/manage/manage-subscription/sumo-logic-flex-accounts.md
+++ b/docs/manage/manage-subscription/sumo-logic-flex-accounts.md
@@ -65,7 +65,7 @@ The following table provides a summary list of key features by Flex package acco
 | Feature | Free | Trial | Essentials | Enterprise Suite Flex |
 |:------- | :--- | :---- | :------------- | :------------- |
 | Advanced Span Analytics |  | ![check](/img/reuse/check.png) | |![check](/img/reuse/check.png) |
-| AI-driven Alerting |  | ![check](/img/reuse/check.png) | | ![check](/img/reuse/check.png) |
+| Anomaly Alerting |  | ![check](/img/reuse/check.png) | | ![check](/img/reuse/check.png) |
 | Alerting Integrations (Slack, PagerDuty, ServiceNow, etc.) | ![check](/img/reuse/check.png) | ![check](/img/reuse/check.png) | | ![check](/img/reuse/check.png) |
 | Alert Response | ![check](/img/reuse/check.png) | ![check](/img/reuse/check.png) | | ![check](/img/reuse/check.png) |
 | Anomaly Detection |  | ![check](/img/reuse/check.png) | |![check](/img/reuse/check.png) |

--- a/docs/search/copilot.md
+++ b/docs/search/copilot.md
@@ -20,7 +20,7 @@ If you prefer not to use Copilot, you can opt out by contacting [Support](https:
 
 Sumo Logic Copilot is our AI-powered assistant that accelerates investigations and troubleshooting in logs by allowing you to ask questions in plain English and get contextual suggestions, helping first responders get to answers faster.
 
-With its intuitive interface, Copilot automatically generates log searches from natural language queries, helping you quickly investigate performance issues, anomalies, and security threats. It also guides you through investigations step-by-step with AI-driven suggestions to refine your results for faster, more accurate resolutions. Overall, Copilot enhances incident resolution with expert level insights.
+With its intuitive interface, Copilot automatically generates log searches from natural language queries, helping you quickly investigate performance issues, anomalies, and security threats. It also guides you through investigations step-by-step with AI-derived suggestions to refine your results for faster, more accurate resolutions. Overall, Copilot enhances incident resolution with expert level insights.
 
 :::sumo Micro Lesson: Introduction to Copilot
 This short video introduces Copilot and how it can help you with log search and analysis—perfect for getting a quick overview before diving in.
@@ -262,7 +262,7 @@ There are two ways to do this:
 
 In the video, Copilot is used to investigate a security issue involving the potential leak of AWS CloudTrail access keys outside the organization.
 
-The video demonstrates how to use Copilot to analyze AWS CloudTrail data, review AI-curated suggestions, refine searches using natural language prompts, and generate an AI-driven dashboard for root cause analysis and sharing.
+The video demonstrates how to use Copilot to analyze AWS CloudTrail data, review AI-curated suggestions, refine searches using natural language prompts, and generate a dashboard for root cause analysis and sharing.
 
 <Iframe url="https://www.youtube.com/embed/QrRvN2Bg4NY?si=FTbUeCI-xaJrglmm?rel=0"
         width="854px"
@@ -376,7 +376,7 @@ No, customer data or PII is not used for training AI models. Copilot operates us
 
 Certain features may rely on query history stored on a rolling basis for performance optimization. Data is systematically expired to maintain privacy.
 
-For example, our AI-driven alerts feature log anomaly detection and build ML models from 60 days of logs. To accomplish this, we retrain the model once a week. In this example, each week, we add one week of new data while expiring the oldest week of data. Rolling data windows are done to avoid fetching 60 days of data for every training run.
+For example, our alerts feature log anomaly detection and build ML models from 60 days of logs. To accomplish this, we retrain the model once a week. In this example, each week, we add one week of new data while expiring the oldest week of data. Rolling data windows are done to avoid fetching 60 days of data for every training run.
 </details>
 
 <details>
@@ -388,7 +388,7 @@ For Generative AI, Copilot uses a foundation model served by Amazon Bedrock. Cla
 <details>
 <summary>What is the type of AI being used?</summary>
 
-Sumo Logic Copilot is an ensemble of Generative AI (GenAI) and classical machine learning (ML) techniques. For example, classical ML is used for anomaly detection in AI-driven alerts.
+Sumo Logic Copilot is an ensemble of Generative AI (GenAI) and classical machine learning (ML) techniques. For example, classical ML is used for anomaly detection in alerts.
 </details>
 
 <details>

--- a/docs/security/additional-security-features/cloud-infrastructure-security/introduction-to-cloud-infrastructure-security.md
+++ b/docs/security/additional-security-features/cloud-infrastructure-security/introduction-to-cloud-infrastructure-security.md
@@ -27,7 +27,7 @@ We provide built-in threat intelligence correlations on logs for cloud services.
 
 ### Suspicious activity
 
-We surface suspicious user/IAM/network activity using AI-driven anomaly detection. While threat detection capabilities from cloud services may only identify known threats, monitoring suspicious activity helps detect potential threats early. 
+We surface suspicious user/IAM/network activity using anomaly detection. While threat detection capabilities from cloud services may only identify known threats, monitoring suspicious activity helps detect potential threats early. 
 
 <img src={useBaseUrl('img/integrations/amazon-aws/cis-for-aws-suspicious-network-activity.png')} alt="Suspicious Network Activity dashboard" style={{border: '1px solid gray'}} width="700"/>
 
@@ -39,7 +39,7 @@ The apps offer curated saved searches developed by subject matter experts, such 
 
 ### Monitors
 
-The apps provide monitors crafted by subject matter experts such as the Sumo Logic SOC team. Some monitors use our AI-driven alerting capabilities, which apply next-generation anomaly detection capabilities, and some have playbooks. Many of these monitors use the Sumo Logic Alert Grouping feature, where a single monitor will trigger separate alerts based on different criteria. 
+The apps provide monitors crafted by subject matter experts such as the Sumo Logic SOC team. Some monitors use our anomaly detection capabilities, and some have playbooks. Many of these monitors use the Sumo Logic Alert Grouping feature, where a single monitor will trigger separate alerts based on different criteria. 
 
 <img src={useBaseUrl('img/security/cis-for-aws-monitors.png')} alt="Example monitors" style={{border: '1px solid gray'}} width="400"/>
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes instances of the term "AI-driven alerting" from articles because that is not the name of the feature in the UI. In the UI it is simply called the "Anomaly" detection method.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

DOCS-841
