### PR TITLE
DOCS-998 - Remove beta label from "App Management APIs" article

### DIFF
--- a/docs/api/app-management.md
+++ b/docs/api/app-management.md
@@ -1,15 +1,13 @@
 ---
 id: app-management
 title: App Management APIs
-sidebar_label: Apps (Beta)
+sidebar_label: Apps
 description: Use HTTP endpoints to view and install Sumo Logic applications that deliver out-of-the-box dashboards, saved searches, and field extraction for popular data sources.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import ApiIntro from '../reuse/api-intro.md';
 import ApiRoles from '../reuse/api-roles.md';
-
-<p> <a href="/docs/beta"><span className="beta">Beta</span></a> </p>
 
 View and install Sumo Logic applications that deliver out-of-the-box dashboards, saved searches, and field extraction for popular data sources. For more information, see [Sumo Logic Apps](/docs/integrations).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the beta label from this article: https://help.sumologic.com/docs/api/app-management/


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-998](https://sumologic.atlassian.net/browse/DOCS-998)
