### PR TITLE
DOCS-62 - Fix sidebar chevron direction (UX)

### DIFF
--- a/src/css/sumo.scss
+++ b/src/css/sumo.scss
@@ -449,8 +449,7 @@ html[data-theme='light'] {
     background: var(--ifm-menu-link-sublist-icon) 50% / 2rem 2rem;
     filter: var(--ifm-menu-link-sublist-icon-filter);
     height: 1.25rem;
-    transform: rotate(
-180deg);
+    // Default chevron is already right/left — no extra rotation needed (was: transform: rotate(180deg);)
     width: 1.25rem;
     transition: transform var(--ifm-transition-fast) linear;
 }


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes sidebar chevron direction (UX) to point right when in a collapsed state (and points down when expanded).

before
<img width="350" height="342" alt="Screenshot 2025-07-13 at 5 55 11 PM" src="https://github.com/user-attachments/assets/0d90ae4e-1571-4a41-b889-093e64a6e8ec" />

after
<img width="350" height="386" alt="Screenshot 2025-07-13 at 5 55 38 PM" src="https://github.com/user-attachments/assets/a7454dbf-2f03-4b12-bda5-76878cc52d88" />


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-62