### PR TITLE
Remove duplicate H1 in google-workspace-apps-audit-source

### DIFF
--- a/docs/send-data/hosted-collectors/google-source/google-workspace-apps-audit-source.md
+++ b/docs/send-data/hosted-collectors/google-source/google-workspace-apps-audit-source.md
@@ -73,7 +73,7 @@ To configure a Google Workspace Apps Audit Source:
 
 To confirm events are being logged, you can compare the data in Sumo Logic to the data shown in **Reports** in the Google Admin console.
 
-# Google App Audit Known Issues
+## Google App Audit Known Issues
 
 A few known issues are due to limitations of the Google API and cannot be changed by Sumo Logic. 
 


### PR DESCRIPTION
## Purpose of this pull request

Remove extra H1 in google-workspace-apps-audit-source (changed to H2)

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
