### PR TITLE
CSOAR-3597: Inconsistent "http_url" Encoding Between Manual and Insight Execution of playbook

### DIFF
--- a/docs/platform-services/automation-service/app-central/integrations/virustotal-v3.md
+++ b/docs/platform-services/automation-service/app-central/integrations/virustotal-v3.md
@@ -8,8 +8,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 <img src={useBaseUrl('/img/platform-services/automation-service/app-central/logos/virustotal.png')} alt="virustotal"
 width="100"/>
 
-***Version: 1.0
-Updated: July 03, 2024***
+***Version: 1.1
+Updated: July 22, 2025***
 
 Perform threat intelligence evidence gathering with [VirusTotal V3 API](https://docs.virustotal.com/reference/overview).
 
@@ -68,3 +68,5 @@ For information about VirusTotal v3, see [VirusTotal v3 documentation](https://d
 * July 03, 2024
     + First upload
     + It is an updated version of VirusTotal which works with V3 API.
+* July 22, 2025
+    + Fixed url parsing issue in **URL Reputation** action.


### PR DESCRIPTION
## Purpose of this pull request

The URL reputation action was failing when the input included surrounding quotes (e.g., "https://"), as the quotes were treated as part of the actual URL. This caused the regex match to fail and resulted in incorrect base64 encoding, leading to API Error: URL not found error. It is working during manual testing because we are passing plain URLs. However from the playbook side, the input string included quotes, which caused the failure.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)
https://sumologic.atlassian.net/browse/CSOAR-3597


