### PR TITLE
CSOAR-3716: One drive integration credential requirement

### DIFF
--- a/docs/platform-services/automation-service/app-central/integrations/microsoft-onedrive.md
+++ b/docs/platform-services/automation-service/app-central/integrations/microsoft-onedrive.md
@@ -6,8 +6,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 <img src={useBaseUrl('/img/platform-services/automation-service/app-central/logos/microsoft-onedrive.png')} alt="microsoft-onedrive" width="100"/>
 
-***Version: 1.6  
-Updated: April 25, 2025***
+***Version: 1.7  
+Updated: August 12, 2025***
 
 Utilize and manipulate files for incident investigation using OneDrive.
 
@@ -73,3 +73,4 @@ For information about Microsoft OneDrive, see [OneDrive documentation](https://l
       - Password (Delegated Context) 
       - Client Credentials (Application Context)
 * April 25, 2025 (v1.6) - Changed required=False for username and password parsers in Integration file.
+* August 12, 2025 (v1.7) - Changed required=False for username and password parsers in all the actions.

--- a/docs/platform-services/automation-service/app-central/integrations/microsoft-onedrive.md
+++ b/docs/platform-services/automation-service/app-central/integrations/microsoft-onedrive.md
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 <img src={useBaseUrl('/img/platform-services/automation-service/app-central/logos/microsoft-onedrive.png')} alt="microsoft-onedrive" width="100"/>
 
 ***Version: 1.7  
-Updated: August 12, 2025***
+Updated: August 14, 2025***
 
 Utilize and manipulate files for incident investigation using OneDrive.
 
@@ -73,4 +73,4 @@ For information about Microsoft OneDrive, see [OneDrive documentation](https://l
       - Password (Delegated Context) 
       - Client Credentials (Application Context)
 * April 25, 2025 (v1.6) - Changed required=False for username and password parsers in Integration file.
-* August 12, 2025 (v1.7) - Changed required=False for username and password parsers in all the actions.
+* August 14, 2025 (v1.7) - Changed required=False for username and password parsers in all the actions.


### PR DESCRIPTION
## Purpose of this pull request
The actions were failing due to username/password fields as these fields were empty.
and the authentication type was client_credentials, this was happening due to the misconfigured parser for these fields.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)
https://sumologic.atlassian.net/browse/CSOAR-3716
