### PR TITLE
docs: Add a note about the compatibility between helm chart versions and Prometheus 3.0

### DIFF
--- a/docs/send-data/kubernetes/v4/important-changes.md
+++ b/docs/send-data/kubernetes/v4/important-changes.md
@@ -11,6 +11,12 @@ This page describes the major changes and the necessary migration steps.
 
 ## Important changes
 
+## Prometheus 3.0
+
+There are a number of breaking changes in Prometheus 3.0. Learn more about those changes and migration guide in the [documentation](https://prometheus.io/docs/prometheus/latest/migration/)
+
+Please use Helm chart [v4.14.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/tag/v4.14.0) or later for compatibility with scrapers in Prometheus 3.0
+
 ### Kubernetes Attributes Processor support (v4.13)
 
 The [Kubernetes Attributes Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md) is now supported for logs and metrics metadata enrichment. This processor is disabled by default. To enable this processor for logs, set `metadata.logs.useSumoK8sProcessor` to `false`. To enable this processor for metrics, set `metadata.metrics.useSumoK8sProcessor` to `false`.


### PR DESCRIPTION
## Purpose of this pull request

Add a note about the compatibility between helm chart versions and Prometheus 3.0

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)
https://sumologic.atlassian.net/browse/OSC-1129
