### PR TITLE
Add information about the field= operator

### DIFF
--- a/docs/search/search-query-language/search-operators/fields.md
+++ b/docs/search/search-query-language/search-operators/fields.md
@@ -6,6 +6,10 @@ sidebar_label: fields
 
 The `fields` operator allows you to specify which fields to display and their order in the results of a query. Use a fields operator to reduce the "clutter" of a search output that contains fields that aren't completely relevant to your query.
 
+:::info
+Using the `fields` operator includes both the specified fields and the default fields (from built-in sources and FERs). However, when `fields =` is used, only the specified fields are included in the query results.
+:::
+
 There are two fields operator modes:
 
 * Allowlist - only the fields included are kept in the search output.


### PR DESCRIPTION
## Purpose of this pull request

This pull request is to add the difference between using the `field` and `field=` operator.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[Update documentation with difference between fields and fields = operator syntax](https://sumologic.atlassian.net/browse/DOCS-1152)
