### PR TITLE
DOCS-1098 - Docs templates - standardize app/source intros with Sumo Logic naming

### DIFF
--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -1085,7 +1085,17 @@ tags: [metrics, traces]
 
 For a full list of options, see [Docusaurus Markdown front matter](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter).
 
+### Branding and naming in app/source docs
 
+To ensure consistency between our UI and our documentation, every App and Source doc must begin by clearly identifying it as a Sumo Logic integration. The UI often shows only the vendor name (for example, "Slack", "Amazon S3"), so the documentation must reinforce that Sumo Logic is delivering the integration.
+
+* **App docs**. The `description:` frontmatter and intro paragraph must start with: "The Sumo Logic app for <vendor>..." (see [template](/docs/contributing/templates/app-template-v2)).
+* **Source docs**. The `description:` frontmatter and intro paragraph must start with: "The Sumo Logic source for <vendor>..." (see [template](/docs/contributing/templates/c2c-source)).
+
+This rule helps:
+* Align docs with UI naming ("<vendor> by Sumo Logic”)  
+* Reinforce Sumo Logic as the provider of the integration  
+* Prevent ambiguity that suggests the vendor is the owner of the app/source
 
 ## Navigation menus
 

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -1089,13 +1089,13 @@ For a full list of options, see [Docusaurus Markdown front matter](https://docus
 
 To ensure consistency between our UI and our documentation, every App and Source doc must begin by clearly identifying it as a Sumo Logic integration. The UI often shows only the vendor name (for example, "Slack", "Amazon S3"), so the documentation must reinforce that Sumo Logic is delivering the integration.
 
-* **App docs**. The `description:` frontmatter and intro paragraph must start with: "The Sumo Logic app for <vendor>..." (see [template](/docs/contributing/templates/app-template-v2)).
-* **Source docs**. The `description:` frontmatter and intro paragraph must start with: "The Sumo Logic source for <vendor>..." (see [template](/docs/contributing/templates/c2c-source)).
+* **App docs**. The `description:` frontmatter and intro paragraph must start with: "The Sumo Logic app for [vendor]..." (see [template](/docs/contributing/templates/app-template-v2)).
+* **Source docs**. The `description:` frontmatter and intro paragraph must start with: "The Sumo Logic source for [vendor]..." (see [template](/docs/contributing/templates/c2c-source)).
 
 This rule helps:
-* Align docs with UI naming ("<vendor> by Sumo Logic”)  
-* Reinforce Sumo Logic as the provider of the integration  
-* Prevent ambiguity that suggests the vendor is the owner of the app/source
+* Align docs with UI naming ("[vendor] by Sumo Logic”).
+* Reinforce Sumo Logic as the provider of the integration.
+* Prevent ambiguity that suggests the vendor is the owner of the app/source.
 
 ## Navigation menus
 

--- a/docs/contributing/templates/app-template-v2.md
+++ b/docs/contributing/templates/app-template-v2.md
@@ -17,7 +17,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 \Introduction\
 
-<!-- RULE: Always start with "The Sumo Logic app for [vendor"] in both the description (frontmatter) and the intro paragraph to ensure brand visibility and consistency with "[vendor] by Sumo Logic" in the UI. The exact wording after that can be adapted. This example shows a common structure, but you may rephrase to fit the use case. -->
+<!-- RULE: Always start with "The Sumo Logic app for [vendor]" in both the description (frontmatter) and the intro paragraph to ensure brand visibility and consistency with "[vendor] by Sumo Logic" in the UI. The exact wording after that can be adapted. This example shows a common structure, but you may rephrase to fit the use case. -->
 
 The Sumo Logic app for [vendor] enables you to [monitor/analyze/collect/etc.] [data type] from [vendor]. This integration helps you [business value/security/performance outcome], providing visibility into [specific activities, events, or metrics]. With this data in Sumo Logic, you can [identify/respond to/optimize/etc.] [key use cases].
 

--- a/docs/contributing/templates/app-template-v2.md
+++ b/docs/contributing/templates/app-template-v2.md
@@ -11,7 +11,15 @@ description: Description goes here. #example: The Sumo Logic App for Split enabl
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-/Introduction/
+<head>
+  <meta name="robots" content="noindex" />
+</head>
+
+\Introduction\
+
+<!-- RULE: Always start with "The Sumo Logic app for [vendor"] in both the description (frontmatter) and the intro paragraph to ensure brand visibility and consistency with "[vendor] by Sumo Logic" in the UI. The exact wording after that can be adapted. This example shows a common structure, but you may rephrase to fit the use case. -->
+
+The Sumo Logic app for [vendor] enables you to [monitor/analyze/collect/etc.] [data type] from [vendor]. This integration helps you [business value/security/performance outcome], providing visibility into [specific activities, events, or metrics]. With this data in Sumo Logic, you can [identify/respond to/optimize/etc.] [key use cases].
 
 ## Data collected
 

--- a/docs/contributing/templates/c2c-source.md
+++ b/docs/contributing/templates/c2c-source.md
@@ -20,9 +20,9 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 \Introduction\
 
-The `{{source name}}` collects `{{data/event types}}` from `{{source of origin}}`. `{{What the app does}}`.
+<!-- RULE: Always start with "The Sumo Logic source for <vendor>" in both the description (frontmatter) and the intro paragraph. This ensures brand clarity since the UI shows only the vendor name. The exact wording after that can be adapted. This example shows a common structure, but you may rephrase to fit the use case. -->
 
-Example: The Microsoft Graph Security API Source provides a secure endpoint to consume alerts from the Microsoft Graph Security API endpoint. It securely stores the required authentication, scheduling, and state tracking information. One threat event is reported for each affected device.
+Example: The Sumo Logic source for [vendor] enables you to [collect/ingest/stream/etc.] [data type] from [vendor] into Sumo Logic. This integration helps you [business value/security/observability outcome], providing visibility into [specific activities, events, or metrics]. With this data in Sumo Logic, you can [detect/respond/optimize/etc.] [key use cases].
 
 \Depending on the availability in the Fed, add the below note.\
 

--- a/docs/contributing/templates/c2c-source.md
+++ b/docs/contributing/templates/c2c-source.md
@@ -20,9 +20,9 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 \Introduction\
 
-<!-- RULE: Always start with "The Sumo Logic source for <vendor>" in both the description (frontmatter) and the intro paragraph. This ensures brand clarity since the UI shows only the vendor name. The exact wording after that can be adapted. This example shows a common structure, but you may rephrase to fit the use case. -->
+<!-- RULE: Always start with "The Sumo Logic source for [vendor]" in both the description (frontmatter) and the intro paragraph. This ensures brand clarity since the UI shows only the vendor name. The exact wording after that can be adapted. This example shows a common structure, but you may rephrase to fit the use case. -->
 
-Example: The Sumo Logic source for [vendor] enables you to [collect/ingest/stream/etc.] [data type] from [vendor] into Sumo Logic. This integration helps you [business value/security/observability outcome], providing visibility into [specific activities, events, or metrics]. With this data in Sumo Logic, you can [detect/respond/optimize/etc.] [key use cases].
+The Sumo Logic source for [vendor] enables you to [collect/ingest/stream/etc.] [data type] from [vendor] into Sumo Logic. This integration helps you [business value/security/observability outcome], providing visibility into [specific activities, events, or metrics]. With this data in Sumo Logic, you can [detect/respond/optimize/etc.] [key use cases].
 
 \Depending on the availability in the Fed, add the below note.\
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request edits the app/source docs templates to reflect that intros must lead with _Sumo Logic_

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1098