### PR TITLE
DOCS-1169 - Clarify using threat intelligence indicators in log search

### DIFF
--- a/docs/security/threat-intelligence/find-threats.md
+++ b/docs/security/threat-intelligence/find-threats.md
@@ -27,8 +27,12 @@ _sourceCategory=cylance "IP Address"
 
 For more information, see [Threat Intel optimization](/docs/integrations/security-threat-detection/threat-intel-quick-analysis/#threat-intel-optimization) in the *Threat Intel Quick Analysis* article.
 
+:::note
+You can only use the `lookup` operator to search using the [Sumo Logic threat intelligence sources](/docs/security/threat-intelligence/about-threat-intelligence/#sumo-logic-threat-intelligence-sources). You cannot use the operator with other threat intelligence sources in your datastore.
+:::
+
 :::tip
-All the dashboards in the [Threat Intel Quick Analysis](/docs/integrations/security-threat-detection/threat-intel-quick-analysis) app use threat intelligence sources to find threats. To see the queries, open a dashboard in the app, click the three-dot kebab in the upper-right corner of the dashboard panel, and select **Open in Log Search**. You can copy these queries and use them as templates for your own queries to find threats.
+All the dashboards in the [Threat Intel Quick Analysis](/docs/integrations/security-threat-detection/threat-intel-quick-analysis) app use the Sumo Logic threat intelligence sources to find threats. To see the queries, open a dashboard in the app, click the three-dot kebab in the upper-right corner of the dashboard panel, and select **Open in Log Search**. You can copy these queries and use them as templates for your own queries to find threats.
 :::
 
 ## Use the threatip search operator

--- a/docs/security/threat-intelligence/threat-intelligence-indicators.md
+++ b/docs/security/threat-intelligence/threat-intelligence-indicators.md
@@ -68,7 +68,7 @@ When you remove indicators, the event is recorded in the Audit Event Index. See 
 
 Indicators are deemed valid until they reach the date set by their "valid until" attribute (`validUntil` for [normalized JSON](/docs/security/threat-intelligence/upload-formats/#normalized-json-format) and [CSV](/docs/security/threat-intelligence/upload-formats/#csv-format), and `valid_until` for [STIX](/docs/security/threat-intelligence/upload-formats/#stix-2x-json-format)). After that date, they are considered expired.
 
-Expired indicators are retained until they reach the end of the retention period. At the end of the retention period, expired indicators are automatically deleted. Between the time they expire and are deleted, the indicators are still in the system, and you can search against them if you want.
+Expired indicators are retained until they reach the end of the retention period. At the end of the retention period, expired indicators are automatically deleted. Between the time they expire and are deleted, the indicators are still in the system, and you can still use them to find threats.
 
 By default, expired indicators are retained for 180 days. To change the retention period:
 1. [**New UI**](/docs/get-started/sumo-logic-ui/). In the main Sumo Logic menu select **Data Management**, and then under **Logs** select **Threat Intelligence**. You can also click the **Go To...** menu at the top of the screen and select **Threat Intelligence**.  <br/>[**Classic UI**](/docs/get-started/sumo-logic-ui-classic/).In the main Sumo Logic menu, select **Manage Data > Logs > Threat Intelligence**. 


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates these articles:
- https://help.sumologic.com/docs/security/threat-intelligence/find-threats/
- https://help.sumologic.com/docs/security/threat-intelligence/threat-intelligence-indicators/#change-the-retention-period-for-expired-indicators

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-1169](https://sumologic.atlassian.net/browse/DOCS-1169)
