### PR TITLE
CSOAR-4012: Microsoft OneDrive

### DIFF
--- a/docs/platform-services/automation-service/app-central/integrations/microsoft-onedrive.md
+++ b/docs/platform-services/automation-service/app-central/integrations/microsoft-onedrive.md
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 <img src={useBaseUrl('/img/platform-services/automation-service/app-central/logos/microsoft-onedrive.png')} alt="microsoft-onedrive" width="100"/>
 
 ***Version: 1.8
-Updated: October 8, 2025***
+Updated: October 10, 2025***
 
 Utilize and manipulate files for incident investigation using OneDrive.
 
@@ -74,6 +74,6 @@ For information about Microsoft OneDrive, see [OneDrive documentation](https://l
       - Client Credentials (Application Context)
 * April 25, 2025 (v1.6) - Changed required=False for username and password parsers in Integration file.
 * August 14, 2025 (v1.7) - Changed required=False for username and password parsers in all the actions.
-* October 8, 2025 (v1.8)
+* October 10, 2025 (v1.8)
     - Added support for listing files from site document library using hostname and site name parameters.
     - Added support for listing files from specific user accounts via user principal name parameter


### PR DESCRIPTION
## Purpose of this pull request

This PR adds SharePoint integration support to the Microsoft OneDrive integration by extending the "List Files" action to support SharePoint sites and specific user accounts, with the version bumped to 1.8.

Added support for SharePoint site document library access via hostname and site name parameters
Added support for listing files from specific user accounts via user principal name parameter
Enhanced the list files functionality with new helper functions for drive ID retrieval


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/CSOAR-4012
