### PR TITLE
DOCS-1180 - Remove Root Cause Explorer and Senu from main page

### DIFF
--- a/src/helper/features.js
+++ b/src/helper/features.js
@@ -90,34 +90,6 @@ export const features2 = [
     </Translate>),
     link: 'docs/observability/kubernetes',
   },
-  {
-    title: translate({
-      id: 'landing.feature.rce.title',
-      message: 'Root Cause Explorer',
-      description: 'Title for Root Cause Explorer',
-    }),
-    imageUrl: 'img/icons/observe.png',
-    description: (<Translate
-      id='landing.feature.rce.desc'
-      description='Root Cause Explorer description'>
-      Accelerate app troubleshooting and root cause isolation.
-    </Translate>),
-    link: 'docs/observability/root-cause-explorer',
-  },
-  {
-    title: translate({
-      id: 'landing.feature.sensu.title',
-      message: 'Sensu',
-      description: 'Title for Sensu',
-    }),
-    imageUrl: 'img/icons/observe.png',
-    description: (<Translate
-      id='landing.feature.sensu.desc'
-      description='Root Cause Explorer description'>
-      Visibility into apps, containers, traditional servers, and more.
-    </Translate>),
-    link: 'https://docs.sensu.io/sensu-go/latest',
-  },
 ];
 
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes Root Cause Explorer from the main documentation page.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-1180](https://sumologic.atlassian.net/browse/DOCS-1180)
