### PR TITLE
Test fix for hub page links

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -19,55 +19,55 @@ Let's get started!
 <div className="box-wrapper" >
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/sign-up"><img src={useBaseUrl('img/icons/general/mail.png')} alt="icon" width="50"/><h4>Sign up</h4></a>
+  <a href={useBaseUrl('/docs/get-started/sign-up')}><img src={useBaseUrl('img/icons/general/mail.png')} alt="icon" width="50"/><h4>Sign up</h4></a>
   <p>Sign up for a free trial and activate your account.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/quickstart"><img src={useBaseUrl('img/icons/business/mission.png')} alt="icon" width="50"/><h4>Sumo Quickstart</h4></a>
+  <a href={useBaseUrl('/docs/get-started/quickstart')}><img src={useBaseUrl('img/icons/business/mission.png')} alt="icon" width="50"/><h4>Sumo Quickstart</h4></a>
   <p>Get up and running quickly with Sumo Logic.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/overview"> <img src={useBaseUrl('img/icons/cloud/core-platform.png')} alt="icon" width="49"/><h4>Sumo Overview</h4></a>
+  <a href={useBaseUrl('/docs/get-started/overview')}> <img src={useBaseUrl('img/icons/cloud/core-platform.png')} alt="icon" width="49"/><h4>Sumo Overview</h4></a>
   <p>Before diving in, check out our Sumo Logic overview and micro lessons.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/onboarding-checklists"><img src={useBaseUrl('img/icons/general/check-mark.png')} alt="icon" width="40"/><h4>Onboarding Tasks</h4></a>
+  <a href={useBaseUrl('/docs/get-started/onboarding-checklists')}><img src={useBaseUrl('img/icons/general/check-mark.png')} alt="icon" width="40"/><h4>Onboarding Tasks</h4></a>
   <p>Must-do onboarding tasks for users and admins.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/account-settings-preferences"><img src={useBaseUrl('img/icons/business/user-permissions.png')} alt="icon" width="40"/><h4>Account Preferences</h4></a>
+  <a href={useBaseUrl('/docs/get-started/account-settings-preferences')}><img src={useBaseUrl('img/icons/business/user-permissions.png')} alt="icon" width="40"/><h4>Account Preferences</h4></a>
   <p>Account settings and credentials.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/system-requirements"><img src={useBaseUrl('img/icons/cloud/machine.png')} alt="icon" width="40"/><h4>System Req.</h4></a>
+  <a href={useBaseUrl('/docs/get-started/system-requirements')}><img src={useBaseUrl('img/icons/cloud/machine.png')} alt="icon" width="40"/><h4>System Req.</h4></a>
   <p>Supported browsers and other requirements.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/apps-integrations"><img src={useBaseUrl('img/icons/cloud/apps.png')} alt="icon" width="50"/><h4>App Installation</h4></a>
+  <a href={useBaseUrl('/docs/get-started/apps-integrations')}><img src={useBaseUrl('img/icons/cloud/apps.png')} alt="icon" width="50"/><h4>App Installation</h4></a>
   <p>How to install Sumo Logic apps and integrations.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/library"><img src={useBaseUrl('img/icons/general/training.png')} alt="icon" width="50"/><img src={useBaseUrl('img/icons/general/certification.png')} alt="icon" width="50"/><h4>Training</h4></a>
+  <a href={useBaseUrl('/docs/get-started/library')}><img src={useBaseUrl('img/icons/general/training.png')} alt="icon" width="50"/><img src={useBaseUrl('img/icons/general/certification.png')} alt="icon" width="50"/><h4>Training</h4></a>
   <p>Sumo Logic Training and Certification offerings.</p>
   </div>
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href="/docs/get-started/help"><img src={useBaseUrl('img/icons/business/support.png')} alt="icon" width="50"/><h4>Help</h4></a>
+  <a href={useBaseUrl('/docs/get-started/help')}><img src={useBaseUrl('img/icons/business/support.png')} alt="icon" width="50"/><h4>Help</h4></a>
   <p>Get help from Sumo Docs, Support, and more.</p>
   </div>
 </div>


### PR DESCRIPTION
## Purpose of this pull request

This PR tests a fix for broken hub page links. It fixes links in this article: https://help.sumologic.com/docs/get-started/

@kimsauce suggested the following in our [site migration testing spreadsheet](https://docs.google.com/spreadsheets/d/1R9r2aViFZfQ4aQGP6VLDrk_sYe8SNBvTUpmsmSzolIA/edit?gid=1446742177#gid=1446742177):
>hub page links are written in HTML, so they may not behave the same as markdown. possible solution (I'll test): change links from <a href="/docs/cloud-soar/overview"> to <a href={useBaseUrl('docs/cloud-soar/overview')}>

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-153](https://sumologic.atlassian.net/browse/DOCS-153)
