### PR TITLE
Change help.sumologic.com to sumologic.com/help

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Please see the [Contributor Guidelines](https://www.sumologic.com/help/docs/contributing) published on our docs site.
+Please see the [Contributor Guidelines](https://www.sumologic.com/help/docs/contributing/) published on our docs site.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-<img src="https://www.sumologic.com/help/img/reuse/sumo-docs-readme.png" width="400"/>
+<img src="https://sumologic.com/help/img/reuse/sumo-docs-readme.png" width="400"/>
 
 <p>
   <a href="https://github.com/SumoLogic/sumologic-documentation/blob/main/.github/workflows/production.yml"><img src="https://github.com/SumoLogic/sumologic-documentation/actions/workflows/production.yml/badge.svg" alt="GitHub Actions status"></a>
-  <a href="https://www.sumologic.com/help/docs/contributing"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
+  <a href="https://sumologic.com/help/docs/contributing"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/sourcerer-io/hall-of-fame.svg?colorB=ff0000"></a>
   <a href="https://x.com/SumoLogic"><img src="https://img.shields.io/twitter/follow/sumologic.svg?style=social" alt="Twitter Follow" /></a>
-  <a href="https://www.sumologic.com/help/release-notes-service"><img src="https://img.shields.io/badge/RSS-FFA500?style=for-the-badge&logo=rss&logoColor=white" alt="RSS Follow" width="50"/></a>
+  <a href="https://sumologic.com/help/release-notes-service"><img src="https://img.shields.io/badge/RSS-FFA500?style=for-the-badge&logo=rss&logoColor=white" alt="RSS Follow" width="50"/></a>
 </p>
 
 Sumo Docs is the open-source documentation site for Sumo Logic, an all-in-one cloud data analytics platform built to support security, operations, and business intelligence use cases. Sumo Logic empowers users to monitor, analyze, troubleshoot, and visualize data from their applications and network environments in real time. Its elastic processing capabilities enable seamless log data collection and management from various sources, regardless of type, volume, or location. Learn more at [sumologic.com](https://www.sumologic.com).
@@ -55,14 +55,14 @@ To contribute to Sumo Docs, ensure you have the following tools installed:
 
 ## Apply your changes
 
-Make edits using [Markdown syntax](https://www.sumologic.com/help/docs/contributing/style-guide/#markdown). Keep contributions concise, informative, and aligned with our guidelines.
+Make edits using [Markdown syntax](https://sumologic.com/help/docs/contributing/style-guide/#markdown). Keep contributions concise, informative, and aligned with our guidelines.
 
-Refer to our [Contributor Guidelines](https://www.sumologic.com/help/docs/contributing/create-edit-doc/#edit-a-doc) for more information on:
+Refer to our [Contributor Guidelines](https://sumologic.com/help/docs/contributing/create-edit-doc/#edit-a-doc) for more information on:
 - Markdown editing
 - Proposing bug fixes
 - Testing your changes
 
-All contributions must follow our [Style Guide](https://www.sumologic.com/help/docs/contributing/style-guide/).
+All contributions must follow our [Style Guide](https://sumologic.com/help/docs/contributing/style-guide/).
 
 ## Building locally
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request changes instances of `help.sumologic.com` to `sumologic.com/help` in preparation for our site move.

Note that the only instance of help.sumologic.com that I will not change is in this file: 
[sumologic-documentation/.github/workflows/production.yml at main · SumoLogic/sumologic-documentation](https://github.com/SumoLogic/sumologic-documentation/blob/main/.github/workflows/production.yml)

This ensures that builds go to the old site address until we are ready to cut over to the new site.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-187](https://sumologic.atlassian.net/browse/DOCS-187)
