### PR TITLE
SUMO-272127:otel edit name issue locally managed collector

### DIFF
--- a/docs/send-data/opentelemetry-collector/troubleshooting.md
+++ b/docs/send-data/opentelemetry-collector/troubleshooting.md
@@ -310,6 +310,7 @@ To apply the new collector name after modifying the configuration:
   ]}>
 
 <TabItem value="Linux">
+  
 ```bash
 sudo systemctl stop otelcol-sumo
 sudo rm /var/lib/otelcol-sumo/credentials/*
@@ -319,6 +320,7 @@ sudo systemctl start otelcol-sumo
 </TabItem>
 
 <TabItem value="Windows">
+  
 ```powershell
 net stop otelcol-sumo
 Remove-Item "C:\ProgramData\Sumo Logic\OpenTelemetry Collector\data\credentials\*" -Force
@@ -328,8 +330,13 @@ net start otelcol-sumo
 </TabItem>
 
 <TabItem value="macOS">
+  
 ```bash
 sudo launchctl unload /Library/LaunchDaemons/com.sumologic.otelcol-sumo.plist
 sudo rm /var/lib/otelcol-sumo/credentials/*
 sudo launchctl load /Library/LaunchDaemons/com.sumologic.otelcol-sumo.plist
 ```
+
+</TabItem>
+
+</Tabs>


### PR DESCRIPTION
## Purpose of this pull request

This pull request... <!-- brief description here -->
Starting from **Sumo Logic OpenTelemetry Collector version `0.137.0-sumo-0`**, changing the `extensions.sumologic.collector.name` property in the configuration file **does not automatically update** the locally managed collector name upon restart.

Put this as known issue and provide resolution for this



## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
