### PR TITLE
DOCS-1214 - Move sumobaseurl text

### DIFF
--- a/docs/cse/administration/create-cse-context-actions.md
+++ b/docs/cse/administration/create-cse-context-actions.md
@@ -87,7 +87,7 @@ When you save the action, the URL template will be populated with your Sumo Logi
 
 `{{sumobaseurl}}/ui/#/search/@{{timestamp[ms]-30m}}@_index=sec_record* AND user_username = {{value}}`
 
-The `{{sumobaseurl}}` parameter applies to context actions that run a Sumo Logic log search. Assuming your Cloud SIEM instance is configured to communicate with the Sumo Logic platform, when you create an action that runs a Sumo Logic search, Cloud SIEM will automatically insert this placeholder in your URL template—you don’t need to explicitly insert `{{sumobaseurl}} `placeholder yourself.
+The `{{sumobaseurl}}` parameter applies to context actions that run a Sumo Logic log search. Assuming your Cloud SIEM instance is configured to communicate with the Sumo Logic platform, when you create an action that runs a Sumo Logic search, Cloud SIEM will automatically insert this placeholder in your URL template—you don’t need to explicitly insert `{{sumobaseurl}}` placeholder yourself.
 
 ### Create an URL to an external service
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request moves the explanation of the `sumobaseurl` parameter so that users don't try to manually enter it to create context queries:
https://www.sumologic.com/help/docs/cse/administration/create-cse-context-actions/#create-a-sumo-logic-search-url

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-1214](https://sumologic.atlassian.net/browse/DOCS-1214)
