### PR TITLE
DOCS-1223 - Fix typo in compareCIDRPrefix function doc

### DIFF
--- a/docs/cse/rules/cse-rules-syntax.md
+++ b/docs/cse/rules/cse-rules-syntax.md
@@ -511,7 +511,7 @@ Compares two IPv4 addresses and returns true if the network prefixes match.
 
 The following expression returns "true":
 
-`compareCIDRPprefix("10.10.1.35", "10.10.1.100", "24")`
+`compareCIDRPrefix("10.10.1.35", "10.10.1.100", "24")`
 
 ### concat
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes a typo here:
https://www.sumologic.com/help/docs/cse/rules/cse-rules-syntax/#comparecidrprefix

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-1223](https://sumologic.atlassian.net/browse/DOCS-1223)
