### PR TITLE
DOCS-1240 - Remove Google Translate widget from the header

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -259,7 +259,8 @@ module.exports = {
     ],
     announcementBar: {
       id: 'domain',
-      content: '🚀 <a href="https://www.sumologic.com/events/aws-reinvent">Join us at AWS re:Invent 2025 in Las Vegas, Dec 1-5</a>! Stop by Booth #1329 to see Sumo Logic Dojo AI in action and connect with our experts.',
+      content: 'Google Translate is down for maintenance.',
+      // content: '🚀 <a href="https://www.sumologic.com/events/aws-reinvent">Join us at AWS re:Invent 2025 in Las Vegas, Dec 1-5</a>! Stop by Booth #1329 to see Sumo Logic Dojo AI in action and connect with our experts.',
       backgroundColor: '#e4b0d1',
       textColor: '#000',
     },


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the Google Translate widget from the header. We're doing this as an experiment to see if it resolves the Search break problem.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-1240](https://sumologic.atlassian.net/browse/DOCS-1240)
