### PR TITLE
CSOAR-4380: Make optional "has_attachements" & "un_read" fields in search email action

### DIFF
--- a/docs/platform-services/automation-service/app-central/integrations/microsoft-ews-graph.md
+++ b/docs/platform-services/automation-service/app-central/integrations/microsoft-ews-graph.md
@@ -142,4 +142,4 @@ Email Gateway
   + Fixed issue in the **Search Emails Extended** action.
   + Converted `has_attachments` and `is_unread` from text fields to list fields with true/false options.
 * December 10, 2025 (v1.3) - Added a dynamic Mailbox override option to all actions, enabling multi-user execution without requiring resource updates.
-* December 30, 2025 (v1.4) - Removed the default values for the has_attachments and un_read fields in the Search Emails Extended action. The change allows users to search for emails without being forced to filter by attachment status or read/unread status.
+* December 30, 2025 (v1.4) - Removed the default values for the `has_attachments` and `un_read` fields in the **Search Emails Extended** action. The change allows users to search for emails without being forced to filter by attachment status or read/unread status.


### PR DESCRIPTION
## Purpose of this pull request

Currently, the Search Email Extended action has fields has_attachments and un_read fields which have the default values “false“. This creates unnecessary constraints. To improve flexibility and usability, these fields should be made optional.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

JIRA: https://sumologic.atlassian.net/browse/CSOAR-4380
