### PR TITLE
Add 'max-age=0' to Cache-Control

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -38,7 +38,7 @@ module.exports = {
       tagName: 'meta',
       attributes: {
         'http-equiv': 'Cache-control',
-        content: 'no-store',
+        content: 'no-store, max-age=0',
       },
     },
   ],


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the [docusaurus.config.js](https://github.com/SumoLogic/sumologic-documentation/blob/main/docusaurus.config.js) file by adding `max-age=0` to cache control.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

See [comment on DOCS-1262](https://sumologic.atlassian.net/browse/DOCS-1262?focusedCommentId=820196).
