### PR TITLE
DOCS-1336 - Enable threat intel C2Cs

### DIFF
--- a/docs/reuse/threat-intel-c2c.md
+++ b/docs/reuse/threat-intel-c2c.md
@@ -1,0 +1,3 @@
+:::tip
+This source is automatically installed for Cloud SIEM customers.
+:::

--- a/docs/security/threat-intelligence/about-threat-intelligence.md
+++ b/docs/security/threat-intelligence/about-threat-intelligence.md
@@ -60,11 +60,14 @@ A Cloud SIEM administrator must first ingest the indicators before they can be u
 * **A collector**. See:
    * [CrowdStrike Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-threat-intel-source)
    * [Google Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-threat-intel-source/)
-   * [Intel471 Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/intel471-threat-intel-source)
+   * [Intel 471 Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/intel471-threat-intel-source)
    * [Mandiant Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mandiant-threat-intel-source)
    * [STIX/TAXII 1 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source)  
    * [STIX/TAXII 2 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source)
    * [ZeroFox Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/zerofox-intel-source)
+      :::tip
+      These cloud-to-cloud collectors are automatically installed for Cloud SIEM customers.
+      :::
 * **The API**. See the following APIs in the [Threat Intel Ingest Management](https://api.sumologic.com/docs/#tag/threatIntelIngest) API resource:
    * [uploadNormalizedIndicators API](https://api.sumologic.com/docs/#operation/uploadNormalizedIndicators)
    * [uploadStixIndicators API](https://api.sumologic.com/docs/#operation/uploadStixIndicators)

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-threat-intel-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-threat-intel-source.md
@@ -14,6 +14,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 CrowdStrike is the leader in next-generation endpoint protection, threat intelligence, and response services. CrowdStrike’s core technology, the Falcon platform, stops breaches by preventing and responding to all types of attacks — both malware and malware-free. The CrowdStrike Threat Intel integration ingests the indicator data from CrowdStrike Combined API and sends it to Sumo Logic as normalized threat indicator information. For more information, see [About Sumo Logic Threat Intelligence](/docs/security/threat-intelligence/about-threat-intelligence/).
 
+import ThreatIntelC2C from '../../../reuse/threat-intel-c2c.md';
+
+<ThreatIntelC2C/>
+
 :::important
 The CrowdStrike API documentation is not public and can only be accessed by partners or customers.
 :::

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-threat-intel-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-threat-intel-source.md
@@ -15,6 +15,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Sumo Logic source for Google Threat Intel enables you to ingest the indicator data from the Google Threat Intelligence API and send it to Sumo Logic as STIX threat indicators. For more information, see [About Sumo Logic Threat Intelligence](/docs/security/threat-intelligence/about-threat-intelligence/).This integration elevates the value of threat hunting by providing tailored risk profiles, including actors, campaigns, and malware families, to enable proactive threat tracking and mitigation.
 
+import ThreatIntelC2C from '../../../reuse/threat-intel-c2c.md';
+
+<ThreatIntelC2C/>
+
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/intel-471-threat-intel-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/intel-471-threat-intel-source.md
@@ -16,6 +16,10 @@ The Intel 471 Threat Intel source collects threat intelligence indicators using
 
 Intel 471 is a cybersecurity firm specializing in providing cyber threat intelligence services. Their focus is primarily on delivering information about threats originating from the criminal underground, including malware, malicious actors, and their tactics, techniques, and procedures (TTPs). Intel 471 provides these insights to help organizations protect themselves against cyber threats. Their intelligence-gathering efforts often involve monitoring and analyzing underground marketplaces, forums, and other communication channels used by cyber criminals.
 
+import ThreatIntelC2C from '../../../reuse/threat-intel-c2c.md';
+
+<ThreatIntelC2C/>
+
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mandiant-threat-intel-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mandiant-threat-intel-source.md
@@ -16,6 +16,10 @@ The Mandiant Threat Intel source ingests threat intelligence indicators using th
 
 Mandiant is a recognized leader in dynamic cyber defense, threat intelligence, and incident response services. By scaling decades of frontline experience, Mandiant helps organizations to be confident in their readiness to defend against and respond to cyber threats. Mandiant is part of Google Cloud.
 
+import ThreatIntelC2C from '../../../reuse/threat-intel-c2c.md';
+
+<ThreatIntelC2C/>
+
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source.md
@@ -15,6 +15,10 @@ The STIX/TAXII 1 Client source supports collecting threat intelligence indicator
 
 [STIX/TAXII](https://oasis-open.github.io/cti-documentation/) are two standards used together to exchange threat intelligence information between systems. STIX defines the format and structure of the data. TAXII defines how the API endpoints are served and accessed by clients.
 
+import ThreatIntelC2C from '../../../reuse/threat-intel-c2c.md';
+
+<ThreatIntelC2C/>
+
 :::sumo Best Practice
 This source only supports STIX/TAXII 1.x. Sumo Logic recommends using our [STIX/TAXII 2.x source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source/) instead as it is the current version of STIX/TAXII.
 :::

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source.md
@@ -17,6 +17,10 @@ The legacy STIX/TAXII 1.x versions are not supported with this source. Use [STIX
 
 [STIX/TAXII](https://oasis-open.github.io/cti-documentation/) are two standards used together to exchange threat intelligence information between systems. STIX defines the format and structure of the data. TAXII defines how the API endpoints are served and accessed by clients.
 
+import ThreatIntelC2C from '../../../reuse/threat-intel-c2c.md';
+
+<ThreatIntelC2C/>
+
 ## Data collected
 
 This source collects threat intelligence indicators from a vendor's STIX/TAXII 2.x endpoints. This means the specific endpoints we collect data from are the endpoints defined in the [TAXII standard](https://oasis-open.github.io/cti-documentation/taxii/intro). Vendor APIs must follow the standard. The source will collect all indicators from the TAXII server when it runs for the first time and it will check for updates once an hour. This one-hour polling interval can be adjusted in the source configuration.

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/zerofox-intel-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/zerofox-intel-source.md
@@ -16,6 +16,10 @@ ZeroFox is a cybersecurity firm specializing in providing cyber threat intellige
 
 The ZeroFox source collects threat indicators using the [ZeroFox CTI API](https://api.zerofox.com/cti/docs/) and sends them to Sumo Logic as normalized threat indicators for analysis. For more information, see [About Sumo Logic Threat Intelligence](/docs/security/threat-intelligence/about-threat-intelligence/).
 
+import ThreatIntelC2C from '../../../reuse/threat-intel-c2c.md';
+
+<ThreatIntelC2C/>
+
 ## Data collected
 
 | Polling Interval | API Endpoint              |


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds notes stating that threat intel cloud-to-cloud sources are automatically installed for Cloud SIEM customers.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-1336](https://sumologic.atlassian.net/browse/DOCS-1336)
