### PR TITLE
DOCS-1323 - Clean up dates in 2025 archived collector release notes

### DIFF
--- a/blog-collector/2025/12-31.md
+++ b/blog-collector/2025/12-31.md
@@ -13,13 +13,13 @@ This is an archive of 2025 Collector Release Notes. To view the full archive, [c
 
 ---
 
-### December 15, 2024 (OpenTelemetry Collector)
+### December 15, 2025 (OpenTelemetry Collector)
 
 #### New Log Severity Fields
 
 We’ve added two new severity fields, `SeverityNumber` and `SeverityText`, to the OpenTelemetry Collector. These fields provide more comprehensive log data with minimal operational risk, enabling deeper insights and more accurate workflows.
 
-### December 11, 2024 (Installed Collector)
+### December 11, 2025 (Installed Collector)
 
 #### Version 19.534-2
 
@@ -27,7 +27,7 @@ In this release, we've enhanced the security and stability of the Collector with
 
 - Upgraded collector JRE to **Amazon Corretto Version 17.0.17.10.1**.
 - Upgraded `com.tanuki:wrapper` to version 3.6.3.
-- Upgraded `org.bouncycastle:bc-fips` to version 1.0.2.6 to address known security vulnerabilities (CVE-2025-8885).
+- Upgraded `org.bouncycastle:bc-fips` to version 1.0.2.6 to address known security vulnerabilities (CVE-2024-8885).
 - Known issues when upgrading to this version:
   - **Collector running as non-root user**. Collector running as non-root user (run as mode) cannot be upgraded through the API/Web UI. It displays an error message indicating that the upgrade is not possible. The upgrade must be performed manually on your machine. Follow the [steps to upgrade manually](/docs/send-data/collection/upgrade-collectors/#upgrade-collectors-using-the-command-line).
   - **Collector running on Mac**. Collector running on a Mac operating system cannot be upgraded through the API/Web UI. The process will stop, and the collector will need to be restarted manually on your machine if upgraded using API or Web UI. Use the below code to manually restart.
@@ -35,7 +35,7 @@ In this release, we've enhanced the security and stability of the Collector with
     sudo ./collector start
     ```
 
-### December 03, 2024 (OpenTelemetry Collector)
+### December 03, 2025 (OpenTelemetry Collector)
 
 #### OpenTelemetry Collector
 
@@ -43,13 +43,13 @@ We’re pleased to announce the following updates for OpenTelemetry collectors:
 - Collectors can now be installed on Windows using [Ansible](/docs/send-data/opentelemetry-collector/install-collector/ansible/), [Chef](/docs/send-data/opentelemetry-collector/install-collector/chef/), and [Puppet](/docs/send-data/opentelemetry-collector/install-collector/puppet/).
 - Remote management is now supported for Ansible, Chef, and Puppet collectors, offering improved flexibility and customization.
 
-### November 20, 2024 (OpenTelemetry Collector)
+### November 20, 2025 (OpenTelemetry Collector)
 
 #### Remote Management for OpenTelemetry Collector
 
 We're happy to announce that Sumo Logic now enables you to remotely update the collector name for OpenTelemetry collectors through the UI in the OpenTelemetry collector edit flow. [Learn more](/docs/send-data/opentelemetry-collector/remote-management/source-templates/manage-source-templates/#collector-name).
 
-### October 20, 2024 (Installed Collector)
+### October 20, 2025 (Installed Collector)
 
 #### Version 19.533-5
 
@@ -76,7 +76,7 @@ To maintain support and access to the latest features, migrate your collectors t
 
 [Learn more](/docs/send-data/collection/upgrade-collectors/#upgradecollectors-to-the-latest-build).
 
-### October 03, 2024 (OpenTelemetry Collector)
+### October 03, 2025 (OpenTelemetry Collector)
 
 #### Download a collector using the CDN URL
 
@@ -86,14 +86,14 @@ We’re pleased to announce a new method for downloading the latest version of o
 This change does not affect the UI itself. The download process looks the same, but the underlying URL now uses a CDN to improve reliability and speed.
 :::
 
-### September 30, 2024 (Installed Collector)
+### September 30, 2025 (Installed Collector)
 
 #### Version 19.525-63
 
 In this release, we've resolved the JRE upgrade issue that occurred during [collector upgrades](/docs/send-data/collection/upgrade-collectors/).
 
 
-### September 10, 2024 (OpenTelemetry Collector)
+### September 10, 2025 (OpenTelemetry Collector)
 
 #### Remote Management for OpenTelemetry Collector
 
@@ -101,7 +101,7 @@ We're happy to announce that Sumo Logic now enables you to remotely update the c
 
 [Learn more](/docs/send-data/opentelemetry-collector/remote-management/source-templates/otrm-time-reference/#specifying-a-custom-timestamp-format-and-time-zone).
 
-### September 09, 2024 (OpenTelemetry Collector)
+### September 09, 2025 (OpenTelemetry Collector)
 
 #### Remote Management for OpenTelemetry Collector
 
@@ -109,13 +109,13 @@ We're happy to announce that Sumo Logic now enables you to add the collector tim
 
 [Learn more](/docs/send-data/opentelemetry-collector/install-collector/linux).
 
-### September 02, 2024 (Installed Collector)
+### September 02, 2025 (Installed Collector)
 
 #### Version 19.525-59
 
 In this release, we've upgraded the collector JRE to **Amazon Corretto Version `8.462.08.1`** to enhance security and optimize performance for faster execution.
 
-### September 02, 2024 (OpenTelemetry Collector)
+### September 02, 2025 (OpenTelemetry Collector)
 
 #### Download a collector using the CDN URL
 
@@ -125,7 +125,7 @@ We’re pleased to announce a new method for downloading the latest version of o
 This change does not affect the UI itself. The download process looks the same, but the underlying URL now uses a CDN to improve reliability and speed.
 :::
 
-### July 02, 2024 (Installed Collector)
+### July 02, 2025 (Installed Collector)
 
 #### Version 19.525-44
 
@@ -139,7 +139,7 @@ In this release, we've enhanced the security and stability of the Collector with
 
 - Fixed the collector crash issue due to *sigar-amd64-winnt.dll* after Windows update.
 
-### May 14, 2024 (Installed Collector)
+### May 14, 2025 (Installed Collector)
 
 #### Version 19.525-42
 
@@ -153,13 +153,13 @@ In this release, we've enhanced the security and stability of the Collector with
 
 - Fixed the improper filtering of `AD` objects when `Exclude Distinguished Name Suffixes` filter is configured.
 
-### February 18, 2024 (Installed Collector)
+### February 18, 2025 (Installed Collector)
 
 #### Version 19.525-1
 
 In this release, we've upgraded the collector JRE to **Amazon Corretto Version `8.442.06.1`** to enhance stability and optimize performance for faster execution.
 
-### January 08, 2024 (OpenTelemetry Collector)
+### January 08, 2025 (OpenTelemetry Collector)
 
 #### Remote Management for OpenTelemetry Collector
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request changes "2024" to "2025" on dates for 2025 archived collector release notes here: 
https://www.sumologic.com/help/release-notes-collector/2025/12/31/

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[DOCS-1323](https://sumologic.atlassian.net/browse/DOCS-1323)
