### PR TITLE
Pin baseline-browser-mapping via Yarn resolutions to solve stale warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,9 @@
     "prettier": "^2.4.1",
     "typescript": "^5.2.2"
   },
+  "resolutions": {
+    "baseline-browser-mapping": "^2.9.15"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4948,10 +4948,10 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-baseline-browser-mapping@^2.8.9:
-  version "2.8.13"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.13.tgz#3d49a18ee27114765401f4985bdc27018603854e"
-  integrity sha512-7s16KR8io8nIBWQyCYhmFhd+ebIzb9VKTzki+wOJXHTxTnV6+mFGH3+Jwn1zoKaY9/H9T/0BcKCZnzXljPnpSQ==
+baseline-browser-mapping@^2.8.9, baseline-browser-mapping@^2.9.15:
+  version "2.9.17"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz#9d6019766cd7eba738cb5f32c84b9f937cc87780"
+  integrity sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==
 
 basic-ftp@^5.0.2:
   version "5.0.5"


### PR DESCRIPTION
## Purpose of this pull request

Pins the transitive `baseline-browser-mapping` dependency via Yarn `resolutions` to prevent stale dataset warnings during Docusaurus builds: `Warning: [baseline-browser-mapping] The data in this module is over two months old. To ensure accurate Baseline data, please update: npm i baseline-browser-mapping@latest -D`

### What changed

* Added a Yarn `resolutions` entry for `baseline-browser-mapping`:
  ```json
  "baseline-browser-mapping": "^2.9.15"
  ```
* Dependency currently resolves to **2.9.17** via Yarn.
* Updated `yarn.lock` accordingly.

#### Prior actions that failed:
* `npm i baseline-browser-mapping@latest -D`. Returned a ton of errors and didn't work.
* `yarn upgrade browserslist` and `npx update-browserslist-db@latest`. No impact; Browserslist latest is 4.28.1 right now.

### Why

`baseline-browser-mapping` is a transitive dependency of Browserslist (via Webpack/Docusaurus). Older versions emit a time-based warning about outdated baseline data even when builds succeed. Pinning the dependency ensures the repo consistently uses a modern dataset while remaining patch-upgrade safe.

### Notes

* This does not introduce a new direct dependency.
* The caret range allows future patch updates without manual intervention.
* Build output no longer includes the baseline-browser-mapping warning.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1340