### PR TITLE
Add Microsoft Clarity analytics disclosure to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,12 +36,6 @@ module.exports = {
   clientModules: [
     require.resolve('./src/client-modules/trackTrialClick.js'),
   ],
-  scripts: [
-    {
-      src: 'https://www.clarity.ms/tag/v65u3toztl',
-      async: true,
-    },
-  ],
   future: {
     v4: true,
     experimental_faster: true,


### PR DESCRIPTION
## Purpose of this pull request

Adds a one-line disclosure to the footer noting the use of Microsoft Clarity for analytics and linking to the Sumo Logic Privacy Statement. No changes to data collection behavior.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1352