### PR TITLE
Enhance alert response documentation with audit log info

### DIFF
--- a/docs/alerts/monitors/alert-response.md
+++ b/docs/alerts/monitors/alert-response.md
@@ -68,6 +68,10 @@ The following is an example Slack payload with the variable:
 
 The Alert List shows all alerts triggered by your monitors within the past 30 days. By default, the list is sorted by status (showing **Active** on top, followed by **Resolved**), and then chronologically by creation time. The list displays up to 1,000 alerts.
 
+:::info
+Sumo Logic records an audit log entry each time an alert is triggered. Using these audit logs, you can retrieve a list of alerts for any selected time range.
+:::
+
 To get to your Alert List:
 * From the [**New UI**](/docs/get-started/sumo-logic-ui/), select **Alerts**.
 * From the [**Classic UI**](/docs/get-started/sumo-logic-ui-classic), click the bell icon in the top menu.


### PR DESCRIPTION

## Purpose of this pull request

This pull request is to add information about audit log entries for alerts.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[Update Alert list retrieval information](https://sumologic.atlassian.net/browse/DOCS-1370)
