### PR TITLE
DOCS-1591 - Update CODEOWNERS for team member changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,18 @@
 # More details: https://help.github.com/articles/about-codeowners
 
 # Default owners for everything in the repo.
-* @kimsauce @jpipkin1 @JV0812 @mafsumo @amee-sumo
+* @kimsauce @JV0812 @mafsumo @amee-sumo
 
 # Owners of all files in the `/docs/integrations` directory.
-/docs/integrations/ @SumoLogic/sumoappdev @kimsauce @jpipkin1 @JV0812 @mafsumo @amee-sumo
+/docs/integrations/ @SumoLogic/sumoappdev @kimsauce @JV0812 @mafsumo @amee-sumo
 
 # Owners of all files in the `/docs/send-data/kubernetes` directory.
-/docs/send-data/kubernetes/ @SumoLogic/open-source-collection-team @SumoLogic/k8s-developers @kimsauce @jpipkin1 @JV0812 @mafsumo @amee-sumo
+/docs/send-data/kubernetes/ @SumoLogic/open-source-collection-team @SumoLogic/k8s-developers @kimsauce @JV0812 @mafsumo @amee-sumo
 
 # Owners of all files in the `/docs/send-data/opentelemetry-collector` directory and its subdirectories.
-/docs/send-data/opentelemetry-collector/ @SumoLogic/open-source-collection-team @kimsauce @jpipkin1 @mafsumo @JV0812 @amee-sumo
+/docs/send-data/opentelemetry-collector/ @SumoLogic/open-source-collection-team @kimsauce @mafsumo @JV0812 @amee-sumo
 
-# GitHub workflow owners
-/.github/workflows/ @kimsauce
+# Owners of all files in /.github and /.claude directories.
+/.github/ @kimsauce @vfalconisumo
+/.github/workflows/ @kimsauce @vfalconisumo
+/.claude/ @kimsauce @vfalconisumo


### PR DESCRIPTION
## Purpose of this pull request

Updates `.github/CODEOWNERS` to reflect team member changes:

- Remove `@jpipkin1` from all entries (retiring)
- Add `@vfalconisumo` as co-owner of `/.github/`, `/.github/workflows/`, and `/.claude/`
- Add `@kimsauce` as co-owner of `/.claude/`

**Ticket:** https://sumologic.atlassian.net/browse/DOCS-1591

## Select the type of change

- [ ] New topic
- [ ] Update to existing topic
- [x] Repo maintenance (not a documentation update)
- [ ] Other