### PR TITLE
DOCS-1606 - Expand Style Guide SEO section with AEO/GEO guidance and frontmatter description rules

### DIFF
--- a/.claude/commands/doc.md
+++ b/.claude/commands/doc.md
@@ -113,7 +113,7 @@ keywords:
 * **id**: Required. Use kebab-case, matches filename without `.md`.
 * **title**: Required. Title Case, under 60 characters, includes main keywords.
 * **sidebar_label**: Optional. Use if title is too long for sidebar.
-* **description**: Required for SEO. One or two sentences, under 160 characters.
+* **description**: Required for SEO. 140–160 characters. Plain text only — no backticks or Markdown syntax. Do not start with "This page" or "This doc." Lead with an action verb or the product/feature name.
 * **keywords**: Optional but recommended. 3-5 relevant terms for search.
 
 **Special frontmatter cases:**

--- a/.claude/skills/sumo-style/SKILL.md
+++ b/.claude/skills/sumo-style/SKILL.md
@@ -78,7 +78,7 @@ Every doc should include:
 id: page-slug          # required for content pages; kebab-case, short
 title: Page Title      # required; Title Case; max 60 chars for SEO; include keywords
 sidebar_label: Label   # optional; what appears in sidebar nav
-description: One or two sentences for search engines.
+description: One or two sentences for search engines. 140–160 characters. Plain text only — no backticks or Markdown. Do not start with "This page" or "This doc."
 keywords:              # optional but recommended
   - keyword1
   - keyword2

--- a/docs/contributing/create-edit-doc.md
+++ b/docs/contributing/create-edit-doc.md
@@ -105,7 +105,7 @@ Our docs are GitHub-flavored markdown files containing content like bulleted ins
 
 1. Open your new branch in your IDE and go to the `/docs` folder.
 1. Create a new markdown file in the format `<your-file>.md` and save it to the appropriate subfolder. For example, if you're creating a new metrics doc, you'd save it to the `/docs/metrics` folder.
-1. At the top of your file, add your frontmatter, which is the doc metadata. Follow the instructions under [Frontmatter](/docs/contributing/style-guide/#metadata-frontmatter).
+1. At the top of your file, add your frontmatter, which is the doc metadata. Follow the instructions under [Frontmatter](/docs/contributing/style-guide/#metadata-frontmatter), and see [Metadata descriptions](/docs/contributing/style-guide/#metadata-descriptions) for description length and formatting rules.
 
 
 ### Step 3: Write your doc

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -1020,7 +1020,7 @@ tags: [metrics, traces]
 | `slug:` | (Optional) Overrides the `id:` for the canonical link. Best used for index pages for sections. |
 | `title:` | **(Required)** For SEO purposes, include main keywords in your title and keep it under 60 characters. This title is used in navigation if a `sidebar_label` is not included. |
 | `sidebar_label:` | (Optional) Label for the sidebar navigation. Keep it title short. It does not affect the canonical link or page title. |
-| `description:` | (Optional) 1-2 sentences describing the content in the doc. It appears in search engine results. If omitted, search engines will pull the first couple of sentences from the page. |
+| `description:` | (Optional) 1-2 sentences describing the content in the doc. It appears in search engine results. Keep it 140–160 characters. Use plain text only — no Markdown or backtick formatting. If omitted, search engines will pull the first couple of sentences from the page. See [Metadata descriptions](#metadata-descriptions). |
 | `keywords:` | (Optional) List of keywords to enhance SEO. |
 | `tags:` | (Optional) A string or list of tags that adds labels and permalinks to help with sorting. |
 
@@ -1602,6 +1602,43 @@ For clarity and search engine discoverability:
 * If you change a URL, set up a [redirect](/docs/contributing/remove-doc#step-1-create-a-301-redirect) so that users don’t get a 404 page.
 * Use Google Analytics to make data-driven decisions.
 :::
+
+### Metadata descriptions
+
+The `description` frontmatter field controls the snippet shown in search engine results. Follow these rules:
+
+* **Length: 140–160 characters.** Google truncates descriptions at approximately 160 characters. Descriptions under 100 characters are too short to be useful — search engines may generate their own snippet instead.
+* **Plain text only.** Do not use Markdown syntax in the `description` field. Backticks, bold (`**`), and other Markdown formatting render as literal characters in HTML `<meta>` tags and appear as symbols in search results.
+* **Lead with an action verb or the product/feature name.** Do not start with "This page", "This doc", or "This article."
+* **Write for humans.** Describe what the reader will learn or accomplish, not just what the page contains.
+
+Example:
+
+| | Description |
+|--|--|
+| Too long | `Use the accum operator to calculate the cumulative sum of a numeric field in your search results. Track running totals by time interval or across all data points, ideal for monitoring incremental growth in request counts, error rates, or resource consumption.` (366 chars) |
+| Too short | `Learn about the accum operator.` (32 chars) |
+| Correct | `Use the accum operator to calculate the cumulative sum of a numeric field. Track running totals by time interval or across all data points.` (140 chars) |
+
+### AEO (Answer Engine Optimization)
+
+Answer Engine Optimization improves the chances of your content appearing as a direct answer in search results, including Google featured snippets and "People also ask" boxes.
+
+* **Answer the question in the first 1–2 sentences.** The opening paragraph should directly state what the subject is or what the reader will accomplish. Do not bury the answer after several sentences of context.
+* **Use question-format H2 headings where natural.** Headings like "What is X?" or "How do I configure Y?" help search engines match content to user queries.
+   * Example: ~~_Overview_~~ &rarr; _What is the Outlier operator?_
+* **Use structured lists and tables.** Search engines extract lists and tables preferentially for featured snippets. Use them wherever content is enumerable or comparative.
+* **Define key terms explicitly.** Write "X is..." or "X means..." on first use so search engines can extract accurate definitions.
+
+### GEO (Generative Engine Optimization)
+
+Generative Engine Optimization improves the likelihood that AI-powered search tools (such as ChatGPT, Perplexity, and Google AI Overviews) cite your content accurately in generated responses.
+
+* **Make the opening paragraph self-contained.** LLMs pull from the first few sentences to decide whether to cite a page. The opening should be understandable without reading anything else on the page.
+* **State facts as explicit standalone sentences.** Avoid burying key information in subordinate clauses. A fact stated in its own sentence is more likely to be cited verbatim.
+   * Example: ~~_The operator, which supports up to 10,000 events per second depending on instance size, works with both collector types._~~ &rarr; _The operator supports up to 10,000 events per second on large instances. It works with both Hosted and Installed Collectors._
+* **Use specific version numbers and dates.** Avoid "latest", "current", or "recent" without a specific value. AI tools reproduce whatever is on the page — vague references become stale citations.
+* **Add an "At a glance" section for long pages.** For pages over 800 words, add a brief summary section near the top with key facts as short bullet points. This is the most citation-friendly portion of a page for generative AI tools.
 
 
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request expands the SEO section of the style guide with new subsections covering metadata description best practices, Answer Engine Optimization (AEO), and Generative Engine Optimization (GEO). It also updates related Claude Code commands and skills to reflect the same guidance.

Changes:
- `docs/contributing/style-guide.md` — Added three new subsections under SEO: "Metadata descriptions" (140–160 char limit, plain text, no backticks, action-verb openers with before/after examples), "AEO (Answer Engine Optimization)" (question headings, direct answers, structured lists, term definitions), and "GEO (Generative Engine Optimization)" (self-contained openings, factual density, version specificity, "At a glance" sections for long pages). Updated the frontmatter table row for `description` to reference the new subsection.
- `docs/contributing/create-edit-doc.md` — Added link to `#metadata-descriptions` alongside existing frontmatter guidance.
- `.claude/skills/sumo-style/SKILL.md` — Updated description field template comment with 140–160 char and formatting rules.
- `.claude/commands/doc.md` — Updated description field guideline with same rules.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1606