### PR TITLE
DOCS-1625 - Add sign-in banner to training FAQ for Skilljar access

### DIFF
--- a/docs/get-started/training-certification-faq.md
+++ b/docs/get-started/training-certification-faq.md
@@ -9,6 +9,10 @@ import Iframe from 'react-iframe';
 
 <img src={useBaseUrl('img/get-started/sumo-academy.png')} alt="sumo logic academy" width="200"/><br/><br/>
 
+:::training Need to Access a Self-Paced Course?
+If you clicked a link to a self-paced course and can't see the content, you need to **[sign in to the learning portal first](#how-do-i-access-the-learning-portal)**.
+:::
+
 Sumo Logic Academy is your hub for training and professional development. All courses (self‑paced eLearning, public hands‑on virtual classes, and workshops) are free, with paid private instruction offerings available.
 
 Certification exams are paid and live‑proctored through our assessment partner, Kryterion. Successful candidates receive industry‑recognized digital badges issued by Credly. Check out our certification catalog [here](https://www.sumologic.com/learn/training).


### PR DESCRIPTION
## Purpose of this pull request

Adds a prominent training admonition banner to the top of the Training and Certifications FAQ page to help learners who land on the page from self-paced course links without being signed in to Skilljar. The banner provides a clear call-to-action with a direct link to sign-in instructions.

### What changed
- Added a purple `:::training` admonition banner at the top of the FAQ page
- Banner text: "Need to Access a Self-Paced Course?"
- Links directly to the existing "How do I access the learning portal?" section
- Addresses user pain point of clicking course links while not signed in

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1625

## Select the type of change

- [x] Documentation content
- [ ] Website configuration
- [ ] Release notes
- [ ] GitHub repository updates (README, templates, CODEOWNERS, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)