### PR TITLE
Add ephemeral staging deployment workflows and /stage-deploy skill

### DIFF
--- a/.claude/commands/jira.md
+++ b/.claude/commands/jira.md
@@ -174,6 +174,53 @@ https://sumologic.atlassian.net/browse/DOCS-[issue number]
 
 ---
 
+## DOCS Project Fields
+
+When creating or updating tickets, these fields are available:
+
+### Required Fields
+- **Summary** (`summary`) - Ticket title
+- **Technical Area** (`customfield_10748`) - Must be set from the allowed values (see Technical Area list above)
+- **Preview Doc Requirement** (`customfield_10796`) - Defaults to "N/A (General Availability)"
+  - Options: "N/A (General Availability)", "Public Preview", "Extended Preview", "Private Preview"
+
+### Optional Fields
+- **Assignee** (`assignee`) - Auto-assign based on Technical Area unless user specifies
+- **Description** (`description`) - Always use markdown format
+- **Priority** (`priority`) - Defaults to "Medium"
+  - Options: " High" (id: 12023), " Medium" (id: 12024), " Low" (id: 12025)
+- **Due Date** (`customfield_10643`) - Date picker (YYYY-MM-DD format)
+- **Github Pull Request** (`customfield_10466`) - URL field, auto-populate after PR creation
+- **Existing Tech Docs Link** (`customfield_10750`) - URL to related existing docs
+- **Product UI Link** (`customfield_14729`) - URL to product feature/UI
+- **Release Note Requirement** (`customfield_14728`) - "Yes" or "No"
+- **Labels** (`labels`) - Array of strings
+- **Parent** (`parent`) - Link to parent Epic/Story
+
+### When creating tickets with context:
+
+**From git changes or file analysis:**
+- Always set Technical Area based on file paths and content
+- Auto-assign to the appropriate writer
+- Default Preview Doc Requirement to "N/A (General Availability)" unless context suggests otherwise
+- Set Priority to "Medium" unless urgent/critical
+- Populate Description with benefit-driven summary of changes
+- **If updating an existing article:** Set "Existing Tech Docs Link" (`customfield_10750`) with the full production URL (e.g., `https://help.sumologic.com/docs/get-started/training-certification-faq`)
+
+**After PR creation:**
+- Always update the Github Pull Request field with the PR URL using `customfield_10466`
+
+**Field IDs reference:**
+- Technical Area: `customfield_10748`
+- Due Date: `customfield_10643`
+- Github Pull Request: `customfield_10466`
+- Existing Tech Docs Link: `customfield_10750`
+- Preview Doc Requirement: `customfield_10796`
+- Release Note Requirement: `customfield_14728`
+- Product UI Link: `customfield_14729`
+
+---
+
 ## Related commands
 
 * **`/doc-from-jira`** — if the goal is to write a doc for a ticket, use this instead. It fetches the ticket and scaffolds the full documentation file from its content.

--- a/.claude/commands/jira.md
+++ b/.claude/commands/jira.md
@@ -192,6 +192,8 @@ When creating or updating tickets, these fields are available:
 - **Due Date** (`customfield_10643`) - Date picker (YYYY-MM-DD format)
 - **Github Pull Request** (`customfield_10466`) - URL field, auto-populate after PR creation
 - **Existing Tech Docs Link** (`customfield_10750`) - URL to related existing docs
+  - **IMPORTANT:** Required when transitioning to Published status
+  - Always populate when creating/updating tickets that touch existing articles
 - **Product UI Link** (`customfield_14729`) - URL to product feature/UI
 - **Release Note Requirement** (`customfield_14728`) - "Yes" or "No"
 - **Labels** (`labels`) - Array of strings
@@ -205,7 +207,8 @@ When creating or updating tickets, these fields are available:
 - Default Preview Doc Requirement to "N/A (General Availability)" unless context suggests otherwise
 - Set Priority to "Medium" unless urgent/critical
 - Populate Description with benefit-driven summary of changes
-- **If updating an existing article:** Set "Existing Tech Docs Link" (`customfield_10750`) with the full production URL (e.g., `https://help.sumologic.com/docs/get-started/training-certification-faq`)
+- **If creating/updating a ticket for an existing article:** Always set "Existing Tech Docs Link" (`customfield_10750`) with the full production URL (e.g., `https://help.sumologic.com/docs/get-started/training-certification-faq`)
+  - This field is required before tickets can be transitioned to Published status
 
 **After PR creation:**
 - Always update the Github Pull Request field with the PR URL using `customfield_10466`

--- a/.claude/skills/stage-deploy/SKILL.md
+++ b/.claude/skills/stage-deploy/SKILL.md
@@ -1,0 +1,180 @@
+# Stage Deploy Skill
+
+Deploy PR branches to ephemeral Pantheon staging environments for external review.
+
+## Purpose
+
+Enable external reviewers (legal, compliance, product) to preview documentation changes in a live environment before merge, without requiring local setup or waiting for production deployment.
+
+## Usage
+
+### Deploy a Staging Environment
+
+User provides a PR number or branch name:
+```
+/stage-deploy 6701
+/stage-deploy docs-update-jira-skill-fields
+```
+
+### Tear Down a Staging Environment
+
+User provides a PR number:
+```
+/stage-teardown 6701
+```
+
+## Implementation
+
+### Deploy Flow
+
+1. **Resolve input to PR number**:
+   - If input is numeric: use as PR number
+   - If input is branch name: resolve via `gh pr list --head {branch} --json number -q '.[0].number'`
+   - Validate PR exists and is open
+
+2. **Check for existing environment**:
+   - Look for label `staging-deployed` on PR
+   - If exists, inform user that redeploying will update the existing environment
+
+3. **Dispatch workflow**:
+   ```bash
+   gh workflow run workflow_stage-deploy.yml \
+     --repo SumoLogic/sumologic-documentation \
+     --field pr_number={pr_number}
+   ```
+
+4. **Get run ID and provide feedback**:
+   ```bash
+   gh run list \
+     --repo SumoLogic/sumologic-documentation \
+     --workflow workflow_stage-deploy.yml \
+     --limit 1 \
+     --json databaseId,url
+   ```
+   
+   Tell user:
+   - Deployment started with link to Actions run
+   - Expected URL: `https://pr-{pr_number}-sumo-logic.pantheonsite.io/help/`
+   - Build takes ~5-10 minutes (large Docusaurus site)
+   - Deployment URL will be posted as a PR comment when complete
+   - HTTP basic auth credentials: Share via Slack/email (not posted publicly)
+   - To monitor: watch the Actions run
+
+### Teardown Flow
+
+1. **Resolve PR number**: Same as deploy flow
+
+2. **Confirm teardown**: Ask user to confirm (environment will be deleted)
+
+3. **Dispatch teardown workflow**:
+   ```bash
+   gh workflow run workflow_stage-teardown.yml \
+     --repo SumoLogic/sumologic-documentation \
+     --field pr_number={pr_number}
+   ```
+
+4. **Provide feedback**:
+   - Teardown started
+   - Confirmation comment will be posted to PR when complete
+   - Alternative: User can comment `/stage-teardown` directly on the PR
+
+## Environment Naming Convention
+
+Format: `pr-{number}` (e.g., `pr-6701`)
+- Fits Pantheon's 11-character limit
+- Human-memorable
+- Stable across PR updates
+- URL pattern: `https://pr-{number}-sumo-logic.pantheonsite.io/help/`
+
+## Credentials
+
+HTTP basic auth credentials are **not posted publicly**. Documentation team must:
+- Share credentials with external reviewers via Slack or email
+- Use credentials from repository secrets (`PANTHEON_AUTH_USER` / `PANTHEON_AUTH_PASSWORD`)
+- Same credentials apply to all staging environments
+
+## State Tracking
+
+- **GitHub Deployments API**: Each deployment creates a record visible in PR's "Deployments" sidebar
+- **PR label**: `staging-deployed` indicates an active staging environment
+- **Query active environments**: `gh pr list --label staging-deployed --repo SumoLogic/sumologic-documentation`
+
+## Limitations
+
+- **Pantheon multidev limit**: 10-20 environments per site (plan-dependent)
+- **Build time**: 5-10 minutes for this large Docusaurus site
+- **Manual teardown required**: Environments persist until explicitly torn down
+- **One environment per PR**: Redeploying to same PR updates existing environment
+
+## GitHub Comment Triggers
+
+Users with write access can trigger operations directly from PR comments:
+- Comment `/stage-deploy` to deploy
+- Comment `/stage-teardown` to tear down
+
+This enables review workflows without requiring Claude Code.
+
+## Error Handling
+
+- **PR not found**: Validate PR exists and is open before dispatching
+- **gh CLI not available**: Check for `gh` command and provide clear error if missing
+- **Workflow dispatch fails**: Provide error message and suggest checking GitHub Actions permissions
+- **Environment limit reached**: If deployment fails due to Pantheon multidev limit, suggest tearing down old environments
+
+## Examples
+
+**Deploy PR #6701**:
+```
+User: /stage-deploy 6701
+Claude: ✅ Deploying PR #6701 to staging...
+
+Deployment started: https://github.com/SumoLogic/sumologic-documentation/actions/runs/123456
+
+Expected URL (available in ~5-10 minutes):
+https://pr-6701-sumo-logic.pantheonsite.io/help/
+
+A PR comment will be posted with the URL when deployment completes. Share HTTP basic auth credentials with reviewers via Slack/email.
+```
+
+**Deploy current branch**:
+```
+User: /stage-deploy docs-update-jira-skill-fields
+Claude: Resolving branch to PR number...
+Found PR #6701
+
+✅ Deploying PR #6701 to staging...
+[same output as above]
+```
+
+**Tear down with confirmation**:
+```
+User: /stage-teardown 6701
+Claude: ⚠️ This will delete the staging environment for PR #6701.
+
+Are you sure you want to tear it down? (y/n)
+
+User: y
+Claude: ✅ Tearing down staging environment for PR #6701...
+
+Teardown started: https://github.com/SumoLogic/sumologic-documentation/actions/runs/123457
+
+A confirmation comment will be posted to the PR when teardown completes.
+```
+
+## Testing Checklist
+
+After merging workflows to `main`:
+
+- [ ] Test deploy with PR number: `/stage-deploy {test-pr}`
+- [ ] Test deploy with branch name: `/stage-deploy {test-branch}`
+- [ ] Verify URL is accessible with basic auth
+- [ ] Verify PR comment is posted
+- [ ] Verify GitHub Deployment is created
+- [ ] Verify label is added
+- [ ] Test redeploy to same PR (should update, not create new)
+- [ ] Test teardown: `/stage-teardown {test-pr}`
+- [ ] Verify environment is deleted from Pantheon
+- [ ] Verify deployment status updated to inactive
+- [ ] Verify label removed
+- [ ] Test GitHub comment triggers: `/stage-deploy` and `/stage-teardown` in PR
+- [ ] Test permission denial (non-write user commenting `/stage-teardown`)

--- a/.github/workflows/job_build-site.yml
+++ b/.github/workflows/job_build-site.yml
@@ -5,6 +5,11 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: Git ref to checkout (defaults to triggering ref)
+        type: string
+        default: ''
 
 jobs:
   build-helpdocs-site:
@@ -21,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/job_pantheon.yml
+++ b/.github/workflows/job_pantheon.yml
@@ -85,7 +85,7 @@ jobs:
             terminus lock:enable ${{ inputs.PANTHEON_SITE_ID }}.$NORMLIZED_STAGING_ENV_NAME -- "${{ secrets.PANTHEON_AUTH_USER }}" "${{ secrets.PANTHEON_AUTH_PASSWORD }}"
           fi
           terminus connection:set "${{ inputs.PANTHEON_SITE_ID }}.$NORMLIZED_STAGING_ENV_NAME" git
-          echo "PANTHEON_ENV=helpdocs" >> $GITHUB_ENV
+          echo "PANTHEON_ENV=$NORMLIZED_STAGING_ENV_NAME" >> $GITHUB_ENV
           echo "PANTHEON_BRANCH=$NORMLIZED_STAGING_ENV_NAME" >> $GITHUB_ENV
       - name: Commit build and deploy to Pantheon repo
         run: |

--- a/.github/workflows/workflow_stage-deploy.yml
+++ b/.github/workflows/workflow_stage-deploy.yml
@@ -1,0 +1,155 @@
+name: Deploy PR to Staging Environment
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to build and stage
+        required: true
+        type: string
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-comment-trigger:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.triggered }}
+      pr_number: ${{ github.event.issue.number }}
+    steps:
+      - name: Check if comment triggers deployment
+        id: check
+        run: |
+          if [[ "${{ github.event.issue.pull_request }}" != "" ]] && \
+             [[ "${{ github.event.comment.body }}" == "/stage-deploy"* ]]; then
+            echo "triggered=true" >> $GITHUB_OUTPUT
+          else
+            echo "triggered=false" >> $GITHUB_OUTPUT
+          fi
+
+  resolve-pr:
+    needs: [check-comment-trigger]
+    if: |
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.check-comment-trigger.outputs.should_run == 'true'
+      )
+    runs-on: ubuntu-latest
+    outputs:
+      head_branch: ${{ steps.get-branch.outputs.branch }}
+      head_sha: ${{ steps.get-branch.outputs.sha }}
+      env_name: ${{ steps.env-name.outputs.name }}
+      pr_number: ${{ steps.set-pr.outputs.number }}
+    steps:
+      - name: Set PR number
+        id: set-pr
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ needs.check-comment-trigger.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get PR branch and SHA
+        id: get-branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_DATA=$(gh pr view ${{ steps.set-pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --json headRefName,headRefOid)
+
+          BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
+          SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
+
+          if [[ "$BRANCH" == "null" ]] || [[ "$BRANCH" == "" ]]; then
+            echo "Error: Could not find PR #${{ steps.set-pr.outputs.number }}"
+            exit 1
+          fi
+
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+
+      - name: Generate environment name
+        id: env-name
+        run: echo "name=pr-${{ steps.set-pr.outputs.number }}" >> $GITHUB_OUTPUT
+
+  build-site:
+    needs: resolve-pr
+    uses: ./.github/workflows/job_build-site.yml
+    with:
+      ref: ${{ needs.resolve-pr.outputs.head_branch }}
+
+  deploy:
+    needs: [resolve-pr, build-site]
+    uses: ./.github/workflows/job_pantheon.yml
+    with:
+      PANTHEON_DESTINATION: staging
+      SITE_PATH: help/
+      PANTHEON_SITE_ID: ${{ vars.PANTHEON_SITE_ID }}
+      PANTHEON_STAGING_ENV_NAME: ${{ needs.resolve-pr.outputs.env_name }}
+    secrets:
+      PANTHEON_SSH_KEY: ${{ secrets.PANTHEON_SSH_KEY }}
+      PANTHEON_KNOWN_HOSTS: ${{ secrets.PANTHEON_KNOWN_HOSTS }}
+      PANTHEON_MACHINE_TOKEN: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+      PANTHEON_USER_EMAIL: ${{ secrets.PANTHEON_USER_EMAIL }}
+      PANTHEON_AUTH_USER: ${{ secrets.PANTHEON_AUTH_USER }}
+      PANTHEON_AUTH_PASSWORD: ${{ secrets.PANTHEON_AUTH_PASSWORD }}
+
+  notify:
+    needs: [resolve-pr, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Deployment
+        id: create-deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DEPLOYMENT=$(gh api repos/${{ github.repository }}/deployments \
+            -X POST \
+            -f ref="${{ needs.resolve-pr.outputs.head_sha }}" \
+            -f environment="staging/pr-${{ needs.resolve-pr.outputs.pr_number }}" \
+            -f auto_merge=false \
+            -F required_contexts='[]' \
+            -f description="Staging environment for PR #${{ needs.resolve-pr.outputs.pr_number }}")
+
+          DEPLOYMENT_ID=$(echo "$DEPLOYMENT" | jq -r '.id')
+          echo "deployment_id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+
+      - name: Set deployment status to success
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/deployments/${{ steps.create-deployment.outputs.deployment_id }}/statuses \
+            -X POST \
+            -f state="success" \
+            -f environment_url="https://${{ needs.resolve-pr.outputs.env_name }}-${{ vars.PANTHEON_SITE_ID }}.pantheonsite.io/help/" \
+            -f description="Staging environment deployed"
+
+      - name: Add label to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit ${{ needs.resolve-pr.outputs.pr_number }} \
+            --repo ${{ github.repository }} \
+            --add-label "staging-deployed"
+
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ needs.resolve-pr.outputs.pr_number }} \
+            --repo ${{ github.repository }} \
+            --body "🚀 **Staging environment deployed**
+
+**URL**: https://${{ needs.resolve-pr.outputs.env_name }}-${{ vars.PANTHEON_SITE_ID }}.pantheonsite.io/help/
+
+The site is protected with HTTP basic auth. Contact the docs team for credentials.
+
+To tear down this environment, comment \`/stage-teardown\` on this PR."

--- a/.github/workflows/workflow_stage-teardown.yml
+++ b/.github/workflows/workflow_stage-teardown.yml
@@ -1,0 +1,165 @@
+name: Tear Down Staging Environment
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number whose staging environment should be torn down
+        required: true
+        type: string
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-comment-trigger:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.triggered }}
+      pr_number: ${{ github.event.issue.number }}
+      commenter: ${{ github.event.comment.user.login }}
+    steps:
+      - name: Check if comment triggers teardown
+        id: check
+        run: |
+          if [[ "${{ github.event.issue.pull_request }}" != "" ]] && \
+             [[ "${{ github.event.comment.body }}" == "/stage-teardown"* ]]; then
+            echo "triggered=true" >> $GITHUB_OUTPUT
+          else
+            echo "triggered=false" >> $GITHUB_OUTPUT
+          fi
+
+  check-permissions:
+    needs: [check-comment-trigger]
+    if: |
+      always() &&
+      github.event_name == 'issue_comment' &&
+      needs.check-comment-trigger.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      has_permission: ${{ steps.check.outputs.allowed }}
+    steps:
+      - name: Check commenter permissions
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ needs.check-comment-trigger.outputs.commenter }}/permission \
+            --jq '.permission')
+
+          if [[ "$PERMISSION" == "write" ]] || \
+             [[ "$PERMISSION" == "maintain" ]] || \
+             [[ "$PERMISSION" == "admin" ]]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+            echo "Error: User ${{ needs.check-comment-trigger.outputs.commenter }} does not have write access"
+            exit 1
+          fi
+
+  teardown:
+    needs: [check-comment-trigger, check-permissions]
+    if: |
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        (needs.check-comment-trigger.outputs.should_run == 'true' &&
+         needs.check-permissions.outputs.has_permission == 'true')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PR number
+        id: set-pr
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ needs.check-comment-trigger.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate environment name
+        id: env-name
+        run: echo "name=pr-${{ steps.set-pr.outputs.number }}" >> $GITHUB_OUTPUT
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+
+      - name: Install Terminus
+        run: |
+          curl -L https://github.com/pantheon-systems/terminus/releases/download/4.0.3/terminus.phar --output terminus
+          chmod +x terminus
+          sudo mv terminus /usr/local/bin/terminus
+
+      - name: Terminus login
+        run: terminus auth:login --machine-token ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+      - name: Check if environment exists
+        id: check-env
+        run: |
+          if terminus env:list ${{ vars.PANTHEON_SITE_ID }} --format=list | grep -q "^${{ steps.env-name.outputs.name }}$"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Delete multidev environment
+        if: steps.check-env.outputs.exists == 'true'
+        run: |
+          terminus multidev:delete \
+            --delete-branch \
+            --yes \
+            ${{ vars.PANTHEON_SITE_ID }}.${{ steps.env-name.outputs.name }}
+
+      - name: Update deployment status to inactive
+        if: steps.check-env.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get all deployments for this environment
+          DEPLOYMENTS=$(gh api repos/${{ github.repository }}/deployments \
+            --jq "[.[] | select(.environment == \"staging/pr-${{ steps.set-pr.outputs.number }}\") | .id]")
+
+          # Update each deployment status to inactive
+          echo "$DEPLOYMENTS" | jq -r '.[]' | while read DEPLOYMENT_ID; do
+            gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+              -X POST \
+              -f state="inactive" \
+              -f description="Environment torn down" || true
+          done
+
+      - name: Remove label from PR
+        if: steps.check-env.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit ${{ steps.set-pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "staging-deployed" || true
+
+      - name: Post confirmation comment
+        if: steps.check-env.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ steps.set-pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --body "🗑️ Staging environment \`pr-${{ steps.set-pr.outputs.number }}\` has been torn down."
+
+      - name: Post environment not found comment
+        if: steps.check-env.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ steps.set-pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --body "ℹ️ No staging environment found for \`pr-${{ steps.set-pr.outputs.number }}\`. It may have already been torn down."
+
+      - name: Terminus logout
+        if: always()
+        run: terminus auth:logout || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,17 +16,16 @@ Docs live in /docs, written in Markdown. Contributions follow the Sumo Logic sty
 - .claude/skills/pr-template-guide/SKILL.md — PR template structure, formatting examples, and best practices.
 
 ## Pull Requests
-**CRITICAL REQUIREMENT**: ALL pull requests MUST use the official template from `.github/PULL_REQUEST_TEMPLATE.md`. No exceptions.
+**CRITICAL REQUIREMENT**: Before creating ANY PR, MUST read `.github/PULL_REQUEST_TEMPLATE.md` and use EXACT checkbox labels from that file.
 
-### Key Rules
-1. **Template is mandatory** - Use the exact structure above for every PR
-2. **Additional sections** - Any extra sections (Summary, Testing Plan, etc.) go UNDER "Purpose of this pull request" heading, before "Select the type of change"
-3. **Pre-check the appropriate checkbox** - Check the correct box but leave ALL four checkboxes in the list. Never remove unchecked items from the "Select the type of change" section
+**Non-negotiable rules:**
+1. **Read template first** - Get current checkbox labels from `.github/PULL_REQUEST_TEMPLATE.md` (never guess or use old labels)
+2. **Use exact text** - Copy checkbox labels verbatim (never paraphrase: "Documentation content", "Website configuration", etc. DO NOT EXIST)
+3. **Keep all checkboxes** - Pre-check one box, leave all four in the list
 4. **PR title format**: `TICKET - Description` (e.g., `DOCS-1234 - Add PostgreSQL app`)
-5. **Ask for ticket number** - Always ask before creating PRs (optional only for quick typo fixes)
-6. **Use full Jira link** - In the "Ticket (if applicable)" section, use the full URL (e.g., `https://sumologic.atlassian.net/browse/DOCS-1234`) not just the ticket number
+5. **Full Jira URL** - Use `https://sumologic.atlassian.net/browse/DOCS-1234` not ticket number alone
 
-For detailed examples and implementation guidance, see `.claude/skills/pr-template-guide/SKILL.md`.
+See `.claude/skills/pr-template-guide/SKILL.md` for examples and guidance.
 
 ## Git Rules
 **CRITICAL**: Never commit, merge, or push changes without explicit user approval — even if "accept edits" is enabled. Always ask first.
@@ -39,81 +38,45 @@ Before pushing any commit that changes docs content:
 3. Wait for explicit approval before pushing
 
 ## Jira Rules
-- **Assignee**: Assign any newly created Jira ticket to the current user unless otherwise specified
-- **GitHub PR link**: After creating a PR, automatically update the Jira ticket's GitHub field (`customfield_10466`) with the PR URL
+**CRITICAL**: All Jira operations MUST follow the patterns defined in `.claude/commands/jira.md`.
+
+### Field Requirements
+- **Assignee**: Auto-assign newly created tickets based on Technical Area → Writer mappings in `.claude/commands/jira.md`. If no mapping exists, assign to current user unless otherwise specified.
+- **Technical Area**: REQUIRED field. Must be set from allowed values. Use file paths and content keywords to determine the correct area (see `.claude/commands/jira.md` for mappings).
+- **Existing Tech Docs Link** (`customfield_10750`): 
+  - REQUIRED when transitioning to Published status
+  - MUST be populated when creating or updating tickets that touch existing articles
+  - Use full production URL (e.g., `https://help.sumologic.com/docs/get-started/training-certification-faq`)
+- **GitHub PR link** (`customfield_10466`): After creating a PR, automatically update this field with the PR URL
+- **Description**: Always use `contentFormat: markdown`
+
+### Workflow Requirements
+- **Creating tickets**: Follow the three-approach pattern (user description, analyze changes, or file paths) defined in `.claude/commands/jira.md`
+- **Titles**: Sentence case, action verb, specific, under 10 words
+- **Descriptions**: Benefit-driven, active voice, under 150 words unless complex, markdown format
 - **Comment attribution**: Always append `— via Claude Code` to any comment posted to a Jira ticket
+- **Status transitions**: Use workflow states: To Do → In Progress → In Review → Published/Done
+
+### Publishing Checklist
+Before transitioning any ticket to Published:
+1. Verify "Existing Tech Docs Link" field is populated with production URL
+2. Verify "GitHub Pull Request" field has the merged PR URL
+3. Ensure PR has been merged to main branch
 
 ## GitHub Rules
 - **Assignee**: Assign any new PR to the current user unless otherwise specified
 
-## Capability Responses
-When asked about tools, skills, or "what can I do," lead with documentation-focused skills
-(doc creation, release notes, editing/review, Jira). Generic tools (Bash, Read, Write, etc.)
-are secondary — the primary work here is writing and editing docs.
+## Slash Commands
+Primary commands for documentation work (proactively suggest when relevant):
 
-Proactively suggest relevant commands when context fits — for example, suggest `/doc-from-jira` when
-a user mentions a Jira ticket, `/seo-audit` before a PR, or `/geo-optimize` when a doc needs
-discoverability improvements. Do not wait for the user to ask.
+**Content:** `/doc`, `/doc-from-jira`, `/app-doc`, `/c2c-source-doc`, `/remove-doc`
+**Release notes:** `/release-note-service`, `/release-note-collector`, `/release-note-cse`, `/release-note-csoar`, `/release-note-developer`
+**Quality:** `/audit-doc`, `/seo-audit`, `/geo-optimize`, `/tone-check`, `/rewrite-intro`, `/simplify`
+**Workflow:** `/jira`, `/review`
 
-When a user asks "what can I do", "what commands are available", or similar, share this reference:
-
-### Slash commands
-
-**Creating docs**
-
-| Command | What it does |
-|---------|-------------|
-| `/doc` | Create a new feature, how-to, concept, reference, or troubleshooting doc |
-| `/doc-from-jira` | Fetch a DOCS Jira ticket and scaffold a complete doc from it |
-| `/app-doc` | Create a new app integration doc |
-| `/c2c-source-doc` | Create a new Cloud-to-Cloud source integration doc |
-
-**Release notes**
-
-| Command | What it does |
-|---------|-------------|
-| `/release-note-service` | New service release note |
-| `/release-note-collector` | New Collector release note |
-| `/release-note-cse` | New Cloud SIEM release note |
-| `/release-note-csoar` | New Cloud SOAR release note |
-| `/release-note-developer` | New developer/API release note |
-
-**Editing and reviewing**
-
-| Command | What it does |
-|---------|-------------|
-| `/audit-doc` | Full quality audit: structure, style, links, frontmatter, completeness |
-| `/seo-audit` | Discoverability audit: SEO, AEO, and GEO signals — run this before a PR |
-| `/geo-optimize` | Rewrite a doc to improve AI citation and generative engine visibility |
-| `/tone-check` | Check voice and tone against Sumo Logic style rules |
-| `/rewrite-intro` | Rewrite a doc's opening paragraph |
-| `/simplify` | Simplify overly complex content |
-| `/review` | Review a pull request |
-
-**Jira**
-
-| Command | What it does |
-|---------|-------------|
-| `/jira` | Create, update, search, or transition DOCS Jira tickets |
-| `/doc-from-jira` | Start a new doc from a Jira ticket (use this instead of `/jira` when the goal is to write a doc) |
-
-**Removing docs**
-
-| Command | What it does |
-|---------|-------------|
-| `/remove-doc` | Safely deprecate or move a doc with redirects |
-
-### Which audit command to use
-
-Run both for a thorough pre-PR check — they cover different things:
-
-- **`/audit-doc`** — structure, required sections, broken links, frontmatter completeness, style guide
-- **`/seo-audit`** — SEO/AEO/GEO signals: title length, description quality, question headings, direct answers, GEO patterns
-
-### `/jira` vs `/doc-from-jira`
-
-- Use **`/jira`** to manage tickets: create, search, update fields, change status, view your queue
-- Use **`/doc-from-jira`** when you have a ticket and want to start writing the doc it describes — it fetches the ticket and scaffolds the file
+**Key distinctions:**
+- `/jira` = manage tickets | `/doc-from-jira` = scaffold doc from ticket
+- `/audit-doc` = structure/style/links | `/seo-audit` = discoverability signals (run both before PRs)
 
 ## Commands
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds infrastructure for deploying PRs to ephemeral Pantheon staging environments for external review. Enables reviewers (legal, compliance, product) to preview changes in a live environment without local setup.

## Key Features

- Deploy any PR to `https://pr-{number}-sumo-logic.pantheonsite.io/help/`
- Tear down via PR comment `/stage-teardown` (no Claude Code required)
- All credentials stay in GitHub Actions secrets
- Audit trail via GitHub Deployments API
- Permission model prevents unauthorized deletions

## Changes

### Bug Fixes (Prerequisites)
- **Fix PANTHEON_ENV hardcoding** in `job_pantheon.yml` line 88 — was hardcoded to `helpdocs` for all staging deployments, causing `terminus workflow:wait` to target wrong environment for custom multidev names
- **Add ref input** to `job_build-site.yml` — enables building from arbitrary git refs (PR branches) when triggered via workflow_dispatch

### New Workflows
- **workflow_stage-deploy.yml** — Deploys PR to Pantheon multidev, posts URL to PR comment, creates GitHub Deployment, adds label
- **workflow_stage-teardown.yml** — Deletes multidev environment, updates deployment status, removes label, posts confirmation

### Claude Code Skill
- **.claude/skills/stage-deploy/SKILL.md** — User interface for `/stage-deploy` and `/stage-teardown` commands

## Testing Plan

**⚠️ Critical**: Workflows must be merged to `main` before they can be triggered via `workflow_dispatch`. Cannot fully test until merged.

After merge:
1. Test deploy: `/stage-deploy {test-pr-number}`
2. Verify URL accessible with basic auth
3. Verify PR comment, deployment, and label
4. Test redeploy to same PR (should update existing)
5. Test teardown: `/stage-teardown {test-pr-number}`
6. Test PR comment triggers: `/stage-deploy` and `/stage-teardown` in PR
7. Test permission denial (non-write user)

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

N/A — Infrastructure enhancement

## Limitations & Considerations

- **Pantheon multidev limit**: 10-20 environments per site (plan-dependent)
- **Manual teardown required**: No auto-cleanup (deferred to Phase 2)
- **Build time**: 5-10 minutes for this large Docusaurus site
- **Credentials**: NOT posted publicly; team shares via Slack/email
- **One environment per PR**: Redeploying updates existing environment

## Documentation

See implementation plan: `/Users/mark.fulton/.claude/plans/i-need-a-new-quirky-pie.md`