### PR TITLE
DOCS-1634 - Fix MCP server and OAuth docs

### DIFF
--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -42,6 +42,15 @@ The Sumo Logic MCP server lets MCP clients (external AI models) securely query l
 * **An MCP-compatible client that supports OAuth 2.0 Authorization Code flow**. Any MCP client that supports OAuth 2.0 Authorization Code flow with a client ID and secret will work.
    * We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or Anthropic Console account).
 
+## Known limitations
+
+* **Cursor**. Cursor requires redirect URLs starting with `cursor://`, which is not yet supported by the Sumo Logic authorization server.
+* **VS Code**. Recent VS Code releases do not work with the authorization code flow when an explicit client ID and secret are provided.
+
+:::note
+If you have questions about client compatibility, [contact Sumo Logic Support](https://support.sumologic.com/support/s).
+:::
+
 ## Configure in Claude Code CLI
 
 ### Authentication

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 id: mcp-server
 title: Sumo Logic MCP Server
-description: Connect your AI tools to Sumo Logic via MCP to query logs, manage insights, and investigate security incidents from VS Code, ChatGPT, and Claude Code CLI.
+description: Connect your AI tools to Sumo Logic via MCP to query logs, manage insights, and investigate security incidents using Claude Code CLI.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -24,8 +24,8 @@ The Sumo Logic MCP server lets MCP clients (external AI models) securely query l
 
 ## Prerequisites
 
-* **Sumo Logic Administrator role**. Required to create OAuth clients. If you're unsure whether you are an administrator, you can find your role in your [Preferences](/docs/get-started/onboarding-checklists/).
-* **Sumo Logic OAuth credentials**. You'll create these during the setup process for your chosen client below ([learn more](/docs/manage/security/oauth)).
+* **Sumo Logic Administrator role**. You'll need this to create OAuth clients. If you're unsure whether you have this role, check your [Preferences](/docs/get-started/onboarding-checklists/).
+* **Sumo Logic OAuth client credentials**. The MCP client uses [OAuth client credentials](/docs/manage/security/oauth) to authenticate with Sumo Logic. For Claude Code CLI, you'll create them during the setup steps below.
 * **MCP server URL for your deployment**. OAuth tokens are deployment-bound, so you must use the correct URL for your Sumo Logic deployment:
    | Deployment | MCP Server URL |
    | :--- | :--- |
@@ -39,41 +39,8 @@ The Sumo Logic MCP server lets MCP clients (external AI models) securely query l
    | US East (N. Virginia) | `https://mcp.sumologic.com/mcp` |
    | US East (N. Virginia) - FedRAMP | `https://mcp.fed.sumologic.com/mcp` |
    | US West (Oregon) | `https://mcp.us2.sumologic.com/mcp` |
-* **An MCP-compatible client**. Currently, we support the following clients:
-   * **[ChatGPT](https://chatgpt.com/)**.
-   * **[Claude Code CLI](https://code.claude.com/docs/en/quickstart)**. You'll need a paid Claude subscription or Anthropic Console account.
-   * **[VS Code](https://code.visualstudio.com/docs/copilot/chat/copilot-chat)**. You'll need a GitHub account with GitHub Copilot access. A free GitHub Copilot plan is available with limited monthly requests.
-
-## Configure in ChatGPT
-
-### Authentication
-
-ChatGPT uses OAuth 2.0 Authorization Code flow for authentication. You'll create an OAuth client in Sumo Logic during the setup process.
-
-### Setup
-
-1. In ChatGPT, go to **Settings** > **Advanced Settings**.
-1. Enable **Developer Mode**.
-1. Go to **Settings** > **Advanced Settings** > **Create App**.
-1. Copy the **Redirect URL** shown in the dialog. You'll use this when [creating your OAuth client in Sumo Logic](/docs/manage/security/oauth#authorization-code-flow).
-1. In Sumo Logic, [create an OAuth client using the Authorization Code flow](/docs/manage/security/oauth#authorization-code-flow) with the redirect URL from ChatGPT.
-1. Return to ChatGPT's Create App dialog and enter:
-   * **MCP Server URL**. Your deployment's MCP server URL from the [Prerequisites table](#prerequisites) above.
-   * **OAuth Client ID**. Your Client ID from Sumo Logic.
-   * **OAuth Client Secret**. Your Client Secret from Sumo Logic.
-1. Check **I understand and want to Continue**.
-1. Click **Create**.
-1. ChatGPT will open a browser window to authenticate with Sumo Logic. Log in to complete the OAuth flow.
-1. Once connected, you can start using Sumo Logic MCP tools in your ChatGPT conversations.
-
-### Using MCP tools in ChatGPT
-
-To use Sumo Logic MCP tools in ChatGPT:
-1. Start a new chat.
-1. Ask ChatGPT to use your Sumo Logic MCP server (for example, "List my available Sumo Logic MCP tools" or "Search my logs for errors in the last hour").
-1. ChatGPT will automatically invoke the appropriate MCP tools to fulfill your request.
-
-See [Available MCP Tools](#available-mcp-tools) for a full list of capabilities.
+* **An MCP-compatible client that supports OAuth 2.0 Authorization Code flow**. Any MCP client that supports OAuth 2.0 Authorization Code flow with a client ID and secret will work.
+   * We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or Anthropic Console account).
 
 ## Configure in Claude Code CLI
 
@@ -83,24 +50,31 @@ Claude Code CLI uses OAuth 2.0 Authorization Code flow for authentication. Brows
 
 ### Setup
 
-1. In Sumo Logic, [create an OAuth client using the Authorization Code flow](/docs/manage/security/oauth#authorization-code-flow) with redirect URI: `http://localhost:8888/callback`.
-1. In a Terminal window (not in Claude Code), register the MCP server. Replace `<client-id>` and `<client-secret>` with your values from Sumo Logic, and replace `<MCP-server-URL>` with your deployment's MCP server URL from the [Prerequisites table](#prerequisites) above. Choose a scope:
+1. In Sumo Logic, create an OAuth client for Claude Code:
+   1. Go to **Administration** > **Security** > **OAuth Clients**.
+   1. Click **+ Add Client**.
+   1. For **Type**, select **Authorization Code**.
+   1. Enter a **Name** and optional **Description**.
+   1. For **Redirect URI**, enter:
+      ```
+      http://localhost:8888/callback
+      ```
+   1. Click **Save**.
+   1. Copy the **Client ID** and **Client Secret**. You'll use these in the next step.
+   For more details about OAuth clients, see [OAuth Client Setup](/docs/manage/security/oauth#authorization-code-flow).
+1. In a Terminal window, not in Claude Code, register the MCP server. Replace `<client-id>` with your value from Sumo Logic, and replace `<MCP-server-URL>` with your deployment's MCP server URL from the [Prerequisites table](#prerequisites) above. When you run the command, Claude Code prompts you to enter the client secret securely. Choose a scope:
    * **User scope** (available in all directories, recommended).
      ```bash
      claude mcp add --transport http \
        --scope user \
-       --client-id "<client-id>" \
-       --callback-port 8888 \
-       --client-secret \
+       --client-id "<client-id>" --client-secret --callback-port 8888 \
        sumo-logic "<MCP-server-URL>"
      ```
    * **Project scope** (available only in the current directory, writes to `.mcp.json`).
      ```bash
      claude mcp add --transport http \
        --scope project \
-       --client-id "<client-id>" \
-       --callback-port 8888 \
-       --client-secret \
+       --client-id "<client-id>" --client-secret --callback-port 8888 \
        sumo-logic "<MCP-server-URL>"
      ```
 1. Launch Claude Code. With **user scope**, run `claude` from any directory. With **project scope**, run it from the directory where you registered the server.
@@ -112,64 +86,6 @@ Claude Code CLI uses OAuth 2.0 Authorization Code flow for authentication. Brows
 1. Claude Code will open a browser window to authenticate with Sumo Logic. Log in to complete the OAuth flow.
 1. Verify the connection with `/mcp` to confirm the server is connected.<br/><img src={useBaseUrl('img/api/mcp/claude-mcp-connected.png')} alt="Claude Code CLI showing Sumo Logic MCP server connected" width="600"/>
 1. Prompt Claude Code to `List my available MCP tools` to see what you can do. You can also refer to [Available MCP Tools](#available-mcp-tools).
-
-## Configure in VS Code
-
-### Authentication
-
-VS Code with GitHub Copilot Chat uses OAuth 2.0 Client Credentials flow for authentication.
-
-Before you begin, [create an OAuth client using Client Credentials flow](/docs/manage/security/oauth#client-credentials-flow) and [generate an access token](/docs/manage/security/oauth#generate-an-access-token). You'll need your access token for the setup below.
-
-### Setup
-
-1. Open VS Code and install the GitHub Copilot Chat extension, if you don't have it.
-1. Click in the VS Code command palette and run a search for **> MCP: Open User Configuration**.<br/><img src={useBaseUrl('img/api/mcp/vscode-config-command.png')} alt="VS Code command palette search with MCP: Open User Configuration highlighted" width="600"/>
-1. Add the following configuration to the **mcp.json** file. Replace `<MCP-server-URL>` with your deployment's MCP server URL from the [Prerequisites table](#prerequisites) above.
-   ```json title="mcp.json"
-   {
-     "servers": {
-       "Sumo Logic MCP server": {
-         "type": "http",
-         "url": "<MCP-server-URL>",
-         "headers": {
-           "Authorization": "Bearer ${input:oauthToken}"
-         },
-         "gallery": "https://sanyaku.github.io/sumologic-mcp-gateway",
-         "version": "Original"
-       }
-     },
-     "inputs": [
-       {
-         "id": "oauthToken",
-         "type": "promptString",
-         "description": "Enter your OAuth access token for Sumo Logic MCP server",
-         "password": true
-       }
-     ]
-   }
-   ```
-   If you've previously configured other MCP servers here, this should be an additive process (that is, do not delete existing ones you still intend to use).
-1. In the **mcp.json** file, click the **Start** button just above `"Sumo Logic MCP server": {`.<br/><img src={useBaseUrl('img/api/mcp/vscode-mcp-start.png')} alt="VS Code Start button in mcp.json configuration file" width="700"/>
-1. You'll be prompted in the command palette for an OAuth access token. Enter your [access token from Sumo Logic](/docs/manage/security/oauth#generate-an-access-token) there.<br/><img src={useBaseUrl('img/api/mcp/vscode-oauth-input.png')} alt="prompt in command palette for OAuth access token" width="700"/>
-1. Confirm that the server shows as **Running**.<br/><img src={useBaseUrl('img/api/mcp/vscode-running.png')} alt="prompt in command palette for OAuth access token" width="700"/>
-1. Open GitHub Copilot Chat and ensure it's set to **Agent** mode.
-1. You should now be connected to the Sumo Logic MCP server. Verify by asking `List my available MCP tools` to see what you can do. You can also refer to [Available MCP Tools](#available-mcp-tools).
-
-### Reconnecting
-
-Access tokens expire after 12 hours and may also expire after quitting and restarting VS Code. When this occurs:
-
-:::note
-If you see a `403` error with message `insufficient_scope - The request requires higher privileges than provided by the access token`, the cause may be a **deployment mismatch**. This happens when the OAuth token was generated for one deployment but the MCP server URL in **mcp.json** points to a different one. Verify that both use the same deployment.
-:::
-
-1. You'll see a **Dynamic Client Registration not supported** popup asking for an OAuth client ID. Do NOT provide this. Click **Cancel**.<br/><img src={useBaseUrl('img/api/mcp/vscode-dynamic-reg-popup.png')} alt="Dynamic Client Registration not supported popup asking for an OAuth client ID with Cancel button highlighted" width="500"/>
-1. You'll be prompted again for an OAuth client ID in your command palette. Tap **Escape** on your keyboard.<br/><img src={useBaseUrl('img/api/mcp/vscode-esc-clientid.png')} alt="VS Code command palette search with MCP: Open User Configuration highlighted" width="600"/>
-1. [Generate a new access token in Sumo Logic](/docs/manage/security/oauth#generate-an-access-token).
-1. Reopen your **mcp.json** file.
-1. Hover your mouse over the redacted access token until the **Edit | Clear | Clear All** options appear, then click **Edit**.<br/><img src={useBaseUrl('img/api/mcp/vscode-oauth-edit.png')} alt="edit VS Code OAuth access token" width="600"/>
-1. Enter your new access token in the command palette and then restart the Sumo Logic MCP server.
 
 ## Available MCP tools
 

--- a/docs/manage/security/oauth.md
+++ b/docs/manage/security/oauth.md
@@ -30,7 +30,7 @@ Sumo Logic supports two OAuth 2.0 authentication flows:
 
 ## Prerequisites
 
-* **Sumo Logic Administrator role**. Required to create OAuth clients and service accounts.
+* **Sumo Logic Administrator role**. You'll need this to create OAuth clients and service accounts. If you're unsure whether you have this role, check your [Preferences](/docs/get-started/onboarding-checklists/).
 
 ## How permissions work
 
@@ -59,15 +59,7 @@ This flow uses interactive browser-based authentication. Users authorize an exte
 
 ### Step 2: Complete the OAuth flow
 
-Sumo Logic's Authorization Code flow follows the [OAuth 2.1 specification](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1). Your OAuth library or client handles the authorization, token exchange, and token refresh steps automatically by following the standard protocol.
-
-To discover the authorization and token endpoints for your deployment, query the Authorization Server Metadata. Replace `[deployment-endpoint]` with your [deployment endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) (for example, `service.sumologic.com`, `service.us2.sumologic.com`, `service.eu.sumologic.com`):
-
-```bash
-curl https://[deployment-endpoint]/.well-known/oauth-authorization-server
-```
-
-The response includes `authorization_endpoint`, `token_endpoint`, and other supported OAuth parameters.
+Configure your OAuth library or client with the client ID, secret, and redirect URI from Step 1. Sumo Logic follows the [OAuth 2.1 specification](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1), so any compliant library handles authorization, token exchange, and token refresh automatically.
 
 ## Client Credentials flow
 
@@ -82,55 +74,46 @@ Create a Sumo Logic service account to represent your application or service. Yo
 1. Get the service account ID. You'll use this ID in the next step.
    * **Via UI**. Go to **Administration** > **Security** > **Service Accounts**, click on your service account, and copy the ID from the browser URL (appears as `selectedId=00000000076D28F9`).
    * **Via API**. Alternatively, [get a list of all service accounts](https://api.sumologic.com/docs/#operation/listServiceAccounts) and find the `id` field in the response.
-
-<details>
-<summary>Example API request for listing service accounts</summary>
-
-<Tabs
-  className="unique-tabs"
-  defaultValue="request"
-  values={[
-    {label: 'Example request', value: 'request'},
-    {label: 'Example response', value: 'response'},
-  ]}>
-
-<TabItem value="request">
-
-Replace `<accessId>` and `<accessKey>` with your personal access key credentials. Replace `service.sumologic.com` with your [deployment endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) if different.
-
-```bash
-curl -u "<accessId>:<accessKey>" \
-  https://service.sumologic.com/api/v1/serviceAccounts
-```
-
-</TabItem>
-<TabItem value="response">
-
-```json title="Example response highlighting service account ID" {14}
-{
-  "data": [
-    {
-      "name": "My Service Account",
-      "email": "service@example.com",
-      "roleIds": [
-        "00000000000001DF",
-        "00000000000002D2"
-      ],
-      "createdAt": "2025-10-16T09:10:00.000Z",
-      "createdBy": "0000000006743FDD",
-      "modifiedAt": "2025-10-16T09:10:00.000Z",
-      "modifiedBy": "0000000006743FE8",
-      "id": "0000000000C4661B",
-      "isActive": true
-    }
-  ]
-}
-```
-
-</TabItem>
-</Tabs>
-
-</details>
+     <details>
+     <summary>Example API request for listing service accounts</summary>
+     <Tabs
+       className="unique-tabs"
+       defaultValue="request"
+       values={[
+         {label: 'Example request', value: 'request'},
+         {label: 'Example response', value: 'response'},
+       ]}>
+     <TabItem value="request">
+     Replace `<accessId>` and `<accessKey>` with your personal access key credentials. Replace  `service.sumologic.com` with your [deployment endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) if different.
+     ```bash
+     curl -u "<accessId>:<accessKey>" \
+       https://service.sumologic.com/api/v1/serviceAccounts
+     ```
+     </TabItem>
+     <TabItem value="response">
+     ```json title="Example response highlighting service account ID" {14}
+     {
+       "data": [
+         {
+           "name": "My Service Account",
+           "email": "service@example.com",
+           "roleIds": [
+             "00000000000001DF",
+             "00000000000002D2"
+           ],
+           "createdAt": "2025-10-16T09:10:00.000Z",
+           "createdBy": "0000000006743FDD",
+           "modifiedAt": "2025-10-16T09:10:00.000Z",
+           "modifiedBy": "0000000006743FE8",
+           "id": "0000000000C4661B",
+           "isActive": true
+         }
+       ]
+     }
+     ```
+     </TabItem>
+     </Tabs>
+     </details>
 
 ### Step 2: Create an OAuth client
 
@@ -224,20 +207,16 @@ Copy the `clientId` and `clientSecret` from the response. These are your OAuth c
 
 </details>
 
-### Step 3: Generate an access token {#generate-an-access-token}
+### Step 3: Generate an access token
 
-Request an OAuth access token from the token endpoint using your client credentials.
-
-:::note Deployment endpoints
-The examples below use `service.sumologic.com`. If your Sumo Logic instance uses a different deployment, replace this with your [deployment endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) (for example, `service.us2.sumologic.com`, `service.eu.sumologic.com`).
-:::
+Request an OAuth access token from the token endpoint using your client credentials. Replace `<token-endpoint-URL>` with your deployment's token endpoint — see [How do I find the authorization or token endpoint?](#how-do-i-find-the-authorization-or-token-endpoint-for-my-deployment).
 
 **Option A: Request all available permissions**
 
 Omit the `scope` parameter to assign all of the OAuth client's effective scopes to the access token.
 
 ```bash
-curl -X POST https://service.sumologic.com/oauth2/token \
+curl -X POST <token-endpoint-URL> \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "<clientId>:<clientSecret>" \
   -d "grant_type=client_credentials"
@@ -248,7 +227,7 @@ curl -X POST https://service.sumologic.com/oauth2/token \
 Use the `scope` parameter to request specific scopes. Separate multiple scopes with spaces, not commas.
 
 ```bash
-curl -X POST https://service.sumologic.com/oauth2/token \
+curl -X POST <token-endpoint-URL> \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "<clientId>:<clientSecret>" \
   -d "grant_type=client_credentials" \
@@ -266,30 +245,16 @@ The response includes an access token:
 }
 ```
 
-Use this access token as a Bearer token in the `Authorization` header when making API requests:
+Use this access token as a Bearer token in the `Authorization` header when making API requests. Replace `<api-endpoint>` with your [deployment-specific API endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) (for example, `api.sumologic.com` for US1, `api.us2.sumologic.com` for US2):
 
 ```bash
-curl https://api.sumologic.com/api/v1/search/jobs \
+curl <api-endpoint>/api/v1/search/jobs \
   -H "Authorization: Bearer eyJhbGc..."
 ```
 
-:::note Deployment endpoints
-`api.sumologic.com` defaults to the us1 deployment. Replace with your [deployment-specific endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) if your org is on a different deployment (for example, `api.us2.sumologic.com`, `api.eu.sumologic.com`).
-:::
-
 ### Token expiration
 
-Access tokens generated with Client Credentials flow expire after 12 hours. When a token expires, generate a new one by repeating the token request. Unlike Authorization Code flow, Client Credentials flow does not provide refresh tokens.
-
-:::note Discovering endpoints programmatically
-The token endpoint URL varies by deployment. To discover it programmatically (for example, in automation scripts), query the Authorization Server Metadata. Replace `[deployment-endpoint]` with your [deployment endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) (for example, `service.sumologic.com`, `service.us2.sumologic.com`):
-
-```bash
-curl https://[deployment-endpoint]/.well-known/oauth-authorization-server
-```
-
-The response includes the `token_endpoint` and other supported OAuth parameters.
-:::
+Access tokens generated with Client Credentials flow expire after 12 hours. When a token expires, generate a new one by repeating the [token request](#step-3-generate-an-access-token). Unlike Authorization Code flow, Client Credentials flow does not provide refresh tokens.
 
 ## Security best practices
 
@@ -343,31 +308,36 @@ For Client Credentials flow, [effective permissions are the intersection of the 
 
 For Authorization Code flow, [effective permissions are the intersection of the user's roles, the OAuth client's scopes, and the requested scopes](#how-permissions-work). If a user's roles are restricted, their effective OAuth permissions are reduced at the next token refresh. If roles are expanded, the new permissions become available at the next token refresh.
 
-### How do I find the token endpoint for my deployment?
+### How do I find the authorization or token endpoint for my deployment?
 
-The token endpoint URL varies by [deployment](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security). Replace `[deployment-endpoint]` with your deployment's service endpoint. The pattern is:
+Token endpoint URLs vary by deployment:
 
-```
-https://[deployment-endpoint]/oauth/token
-```
+| Deployment | Token endpoint |
+| :--- | :--- |
+| Asia Pacific (Seoul) | `https://service.kr.sumologic.com/oauth2/token` |
+| Asia Pacific (Sydney) | `https://service.au.sumologic.com/oauth2/token` |
+| Asia Pacific (Tokyo) | `https://service.jp.sumologic.com/oauth2/token` |
+| Canada (Central) | `https://service.ca.sumologic.com/oauth2/token` |
+| Europe (Frankfurt) | `https://service.de.sumologic.com/oauth2/token` |
+| Europe (Ireland) | `https://service.eu.sumologic.com/oauth2/token` |
+| Europe (Zurich) | `https://service.ch.sumologic.com/oauth2/token` |
+| US East (N. Virginia) | `https://service.sumologic.com/oauth2/token` |
+| US East (N. Virginia) - FedRAMP | `https://service.fed.sumologic.com/oauth2/token` |
+| US West (Oregon) | `https://service.us2.sumologic.com/oauth2/token` |
 
-For example:
-* US1: `https://service.sumologic.com/oauth/token`
-* US2: `https://service.us2.sumologic.com/oauth/token`
-* EU: `https://service.eu.sumologic.com/oauth/token`
+To find the `authorization_endpoint` for your deployment (used in [Authorization Code flow](#authorization-code-flow)), query the Authorization Server Metadata:
 
-To discover the endpoint programmatically, replace `[deployment-endpoint]` with your service endpoint (e.g., `service.sumologic.com`) and query:
 ```bash
 curl https://[deployment-endpoint]/.well-known/oauth-authorization-server
 ```
 
+The response includes `authorization_endpoint`, `token_endpoint`, and other supported OAuth parameters.
+
 ### Can I use OAuth with the Sumo Logic APIs?
 
-Yes. OAuth access tokens work with all Sumo Logic APIs. Include the access token in the `Authorization` header as a Bearer token:
+Yes. OAuth access tokens work with all Sumo Logic APIs. Include the access token in the `Authorization` header as a Bearer token. Replace `<api-endpoint>` with your [deployment-specific API endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) (for example, `api.sumologic.com` for US1, `api.us2.sumologic.com` for US2):
 
 ```bash
-curl https://api.sumologic.com/api/v1/users \
+curl <api-endpoint>/api/v1/users \
   -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
 ```
-
-Replace `api.sumologic.com` with your [deployment-specific endpoint](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) if your org is on a different deployment.


### PR DESCRIPTION
## Purpose of this pull request

Fixes to the MCP server and OAuth documentation based on Slack feedback.

**MCP server doc (`docs/api/mcp-server.md`)**:
- Removed VS Code and ChatGPT sections (VS Code uses Client Credentials flow which is broken; ChatGPT support is uncertain)
- Reframed prerequisites: any MCP client supporting OAuth 2.0 Authorization Code flow works; documented Claude Code CLI as the primary example
- Expanded OAuth client creation steps inline (previously just a link)
- Fixed `claude mcp add` command: `--client-secret` is a boolean flag that prompts for the secret interactively, clarified in step text
- Softened prerequisite language ("Required to" → "You'll need this to")

**OAuth doc (`docs/manage/security/oauth.md`)**:
- Softened prerequisite language to match MCP doc
- Rewrote Auth Code flow Step 2 to be actionable ("Configure your OAuth library with the client ID, secret, and redirect URI...")
- Replaced hardcoded deployment URLs in Client Credentials Step 3 with `<token-endpoint-URL>` and `<api-endpoint>` placeholders linking to the FAQ
- Added deployment token endpoint table to FAQ (mirrors MCP server prerequisites table style)
- Fixed `/oauth/token` typo → `/oauth2/token` throughout
- Cleaned up redundant `:::note` blocks in Step 3 and Token expiration

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1634