### PR TITLE
DOCS-1646 - Update C2C sources with version deprecation notes

### DIFF
--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cse-aws-ec-inventory-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cse-aws-ec-inventory-source.md
@@ -18,7 +18,7 @@ The Cloud SIEM AWS EC2 Inventory Source provides a secure endpoint to receive ev
 For information on how inventory data is used in Cloud SIEM, see [Inventory Sources and Data](/docs/cse/administration/inventory-sources-and-data.md).
 
 :::note
-Upgrade the CSE AWS EC2 Inventory source to the latest version 2.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+Upgrade the CSE AWS EC2 Inventory source to the latest version 3.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
 :::
 
 import TerraformLink from '../../../reuse/terraform-link.md';

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-alertcenter.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-alertcenter.md
@@ -15,6 +15,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This topic has information about the Google Workspace AlertCenter Cloud-to-Cloud Source, part of Sumo Logic's [Cloud-to-Cloud Integration Framework](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework).
 
+:::note
+Upgrade the Google Workspace AlertCenter source to the latest version 2.0.13 for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+:::
+
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-alertcenter.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-workspace-alertcenter.md
@@ -16,7 +16,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 This topic has information about the Google Workspace AlertCenter Cloud-to-Cloud Source, part of Sumo Logic's [Cloud-to-Cloud Integration Framework](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework).
 
 :::note
-Upgrade the Google Workspace AlertCenter source to the latest version 2.0.13 for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+Upgrade the Google Workspace AlertCenter source to the latest version 2.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
 :::
 
 ## Data collected

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
@@ -27,6 +27,10 @@ The following event types are available to collect:
 * incident
 * endpoint
 
+:::note
+Upgrade the Netskope source to the latest version 2.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+:::
+
 ## Data collected
 
 | Polling Interval | Data |

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
@@ -28,7 +28,7 @@ The following event types are available to collect:
 * endpoint
 
 :::note
-Upgrade the Netskope source to the latest version 2.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+Upgrade the Netskope source to the latest version 2.0.19 for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
 :::
 
 ## Data collected

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/netskope-source.md
@@ -28,7 +28,7 @@ The following event types are available to collect:
 * endpoint
 
 :::note
-Upgrade the Netskope source to the latest version 2.0.19 for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+Upgrade the Netskope source to the latest version 2.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
 :::
 
 ## Data collected


### PR DESCRIPTION
## Purpose of this pull request

Add version upgrade notes to C2C source docs (CSE AWS EC2 Inventory, Google Workspace AlertCenter, and Netskope) to inform users about upcoming version deprecations and encourage upgrading to the latest versions.

**Ticket:** https://sumologic.atlassian.net/browse/DOCS-1646

## Select the type of change

- [ ] Bug fix
- [x] New content
- [ ] Content update
- [ ] Other (describe below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)