### PR TITLE
DOCS-1585 - Add GCC High non-support notes to source docs

### DIFF
--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/azure-event-hubs-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/azure-event-hubs-source.md
@@ -15,7 +15,8 @@ From April 30, 2025, Sumo Logic will no longer support adding a source using thi
 :::
 
 :::note
-Collecting data from Azure Event Hubs using this Cloud-to-Cloud collection method supports a throughput limit of 1MB/s (86GB/day) per named Event Hub egress rate. If you require higher throughput, we recommend using [Azure Event Hubs Source for Logs](/docs/send-data/collect-from-other-data-sources/azure-monitoring/ms-azure-event-hubs-source).
+* Collecting data from Azure Event Hubs using this Cloud-to-Cloud collection method supports a throughput limit of 1MB/s (86GB/day) per named Event Hub egress rate. If you require higher throughput, we recommend using [Azure Event Hubs Source for Logs](/docs/send-data/collect-from-other-data-sources/azure-monitoring/ms-azure-event-hubs-source).
+* This source does not support Microsoft GCC High environments. For GCC High-compatible log collection, see the [MS Office 365 Audit Source](/docs/send-data/hosted-collectors/microsoft-source/ms-office-audit-source/).
 :::
 
 <img src={useBaseUrl('img/send-data/azure-event-hub.svg')} alt="Azure Event Hub icon" width="40"/>

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-security-api-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/microsoft-graph-security-api-source.md
@@ -16,7 +16,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 The Microsoft Graph Security API Source provides a secure endpoint to receive alerts from the [Microsoft Graph](https://docs.microsoft.com/en-us/graph/overview) Security API endpoint. It securely stores the required authentication, scheduling, and state tracking information. One threat event is reported for each affected device.
 
 :::note
-Upgrade the Microsoft Graph Security API source to the latest version 2.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+* Upgrade the Microsoft Graph Security API source to the latest version 2.x.x for seamless data collection experience. Older versions may be discontinued, so upgrading ensures continued support and the latest improvements. For upgrade instructions, see [Cloud-to-Cloud Source Versions](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cloud-to-cloud-source-versions/)
+* This source does not support Microsoft GCC High environments. For GCC High-compatible log collection, see the [MS Office 365 Audit Source](/docs/send-data/hosted-collectors/microsoft-source/ms-office-audit-source/).
 :::
 
 ## Data collected


### PR DESCRIPTION
## Purpose of this pull request
Adds a note to the Azure Event Hubs and Microsoft Graph Security API C2C source docs clarifying that these sources do not support Microsoft GCC High environments, and directs users to the MS Office 365 Audit Source as a GCC High-compatible alternative.

## Ticket (if applicable)
https://sumologic.atlassian.net/browse/DOCS-1585

## Select the type of change
- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Doc restructure
- [ ] Other (specify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)