### PR TITLE
DOCS-1628 - Update auto resolution documentation for logs monitors

### DIFF
--- a/docs/alerts/monitors/overview.md
+++ b/docs/alerts/monitors/overview.md
@@ -39,10 +39,9 @@ See [Trigger Type (Logs)](/docs/alerts/monitors/create-monitor/#trigger-type-log
 
 Log monitors in a triggered state can auto-resolve.
 
-- **Static Fields** log monitors will trigger/resolve based on the value of a field returned by their search. If no data is returned by the query, then chart data is not ingested. If it has been a full detection window or more since a trigger condition was matched, then no data results in the monitor/group getting resolved.
-- **Missing Data** monitors will auto-resolve if they have not seen any data for the last 24 consecutive hours.
-  - Non-grouped monitors will trigger again after auto-resolving if there is still no data.
-  - Grouped monitors will be removed and no longer considered after being auto-resolved, unless data for this group is seen again.
+**Missing Data** monitors will auto-resolve if they have not seen any data for the last 24 consecutive hours.
+- Non-grouped monitors will trigger again after auto-resolving if there is still no data.
+- Grouped monitors will be removed and no longer considered after being auto-resolved, unless data for this group is seen again.
 
 ### Metrics monitors
 


### PR DESCRIPTION
## Purpose of this pull request
Updates the auto resolution documentation for logs monitors by removing the Static Fields section and reformatting the Missing Data section for clarity.

## Ticket (if applicable)
https://sumologic.atlassian.net/browse/DOCS-1628

## Select the type of change
- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Doc restructure
- [ ] Other (specify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)