### PR TITLE
DOCS-1649 - Fix broken Configuring log forwarding link in Fortigate Firewall doc

### DIFF
--- a/docs/cse/ingestion/ingestion-sources-for-cloud-siem/fortigate-firewall.md
+++ b/docs/cse/ingestion/ingestion-sources-for-cloud-siem/fortigate-firewall.md
@@ -12,7 +12,7 @@ To ingest Fortigate Firewall data into Cloud SIEM:
     1. Click the **+Add Field** link, and add a field whose name is `_siemForward` and value is *true*. This will ensure all logs for this source are forwarded to Cloud SIEM.
     1. Add another field named `_parser` with value */Parsers/System/Fortinet/Fortigate/Fortigate-Syslog*. This ensures that the Fortigate Firewall logs are parsed and normalized into structured records in Cloud SIEM.
 1. Configure forwarding to the syslog source:
-    * If your FortiGate logs are aggregated by FortiAnalyzer, you can forward them to Sumo Logic  as described in [Configuring log forwarding](https://help.fortinet.com/fa/faz50hlp/56/5-6-1/FMG-FAZ/2400_System_Settings/1600_Log%20Forwarding/0400_Configuring.htm?Highlight=syslog) in FortiAnalyzer help.
+    * If your FortiGate logs are aggregated by FortiAnalyzer, you can forward them to Sumo Logic  as described in [Configuring log forwarding](https://docs.fortinet.com/document/fortianalyzer/8.0.0/administration-guide/19991/configuring-log-forwarding) in FortiAnalyzer help.
     * If your FortiGate logs are not aggregated by FortiAnalyzer, you can forward them to Sumo Logic directly from FortiGate as described in [FortiOS documentation for syslog forwarding](https://docs.fortinet.com/document/fortigate/6.4.0/administration-guide/610676/configuring-multiple-fortianalyzers-or-syslog-servers-per-vdom).
     :::note
     Cloud SIEM supports standard syslog, CEF, or JSON log formats from FortiGate. Different parsers are required for CEF and JSON format logs.


### PR DESCRIPTION
## Purpose of this pull request

Updates the broken "Configuring log forwarding" link in the Fortigate Firewall ingestion doc. The old help.fortinet.com URL is no longer valid and has been replaced with the current docs.fortinet.com equivalent.

## Select the type of change

- [x] Minor Changes - Typos, formatting, slight revisions

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1649