### PR TITLE
Convert ChatGPT Compliance app doc to Private Preview

### DIFF
--- a/docs/integrations/saas-cloud/chatgpt-compliance.md
+++ b/docs/integrations/saas-cloud/chatgpt-compliance.md
@@ -3,9 +3,20 @@ id: chatgpt-compliance
 title: ChatGPT Compliance
 sidebar_label: ChatGPT Compliance
 description: The Sumo Logic app for ChatGPT Compliance gives you a unified view of AI usage, enabling transparent oversight, data protection, and adherence to corporate governance standards.
+unlisted: true
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+
+<head>
+  <meta name="robots" content="noindex" />
+</head>
+
+<p><a href={useBaseUrl('docs/preview')}><span className="preview-private">Private Preview</span></a></p>
+
+:::info
+This feature is in Private Preview. For more information, contact your Sumo Logic account representative.
+:::
 
 <img src={useBaseUrl('img/send-data/chatgpt-compliance.png')} alt="Carbon Black Inventory icon" width="50" />
 

--- a/docs/integrations/saas-cloud/index.md
+++ b/docs/integrations/saas-cloud/index.md
@@ -107,12 +107,6 @@ Learn about the Sumo Logic apps for SaaS and Cloud applications.
 </div>
 <div className="box smallbox card">
   <div className="container">
-  <a href={useBaseUrl('docs/integrations/saas-cloud/chatgpt-compliance')}><img src={useBaseUrl('/img/send-data/chatgpt-compliance.png')} alt="ChatGPT Compliance icon" width="50"/><h4>ChatGPT Compliance</h4></a>
-  <p>Monitor how ChatGPT is used across your organization to ensure adherence to corporate governance and data protection standards.</p>
-  </div>
-</div>
-<div className="box smallbox card">
-  <div className="container">
   <a href={useBaseUrl('docs/integrations/saas-cloud/cisco-amp')}><img src={useBaseUrl('img/send-data/cisco-amp.png')} alt="Cisco AMP icon" width="70"/><h4>Cisco AMP</h4></a>
   <p>Monitor and analyze the host activity status and file types implicated in cybersecurity incidents.</p>
   </div>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -2655,7 +2655,6 @@ integrations: [
           'integrations/saas-cloud/box',
           'integrations/saas-cloud/carbon-black-inventory',
           'integrations/saas-cloud/cato-networks',
-          'integrations/saas-cloud/chatgpt-compliance',
           'integrations/saas-cloud/cisco-amp',
           'integrations/saas-cloud/cisco-meraki-c2c',
           'integrations/saas-cloud/cisco-umbrella',


### PR DESCRIPTION
## Purpose of this pull request

Converts the ChatGPT Compliance app doc to Private Preview status:
- Adds `noindex` meta tag to prevent search engine indexing
- Adds Private Preview badge and info admonition
- Adds `unlisted: true` to frontmatter to suppress Docusaurus sidebar warnings
- Removes card from the SaaS/Cloud apps index page
- Removes entry from `sidebars.ts`

## Select the type of change

- [x] Update Content - Revisions, updating sections

## Ticket (if applicable)

N/A