### PR TITLE
DOCS-1687 - Fix Algolia search input text overlap with "Clear the query" button

### DIFF
--- a/src/css/sumo.scss
+++ b/src/css/sumo.scss
@@ -248,6 +248,11 @@ html[data-theme='dark'] .DocSearch-Search-Icon {
   color: #6b6f78 !important;
 }
 
+/* Prevent search input text from overlapping the "Clear the query" button */
+.DocSearch-Input {
+  padding-right: 65px !important;
+}
+
 //GitHub icon
 .header-github-link:hover {
   opacity: 0.6;


### PR DESCRIPTION
## Purpose of this pull request

Fixes a visual bug where typed search query text overlaps with the "Clear the query" button in the Algolia search modal. Added `padding-right` to `.DocSearch-Input` to reserve space for the button.

<img width="500" alt="Screenshot 2026-06-05 at 1 09 02 PM" src="https://github.com/user-attachments/assets/6e385be2-8a8c-4714-ab59-55bbb6dacd8b" />


## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1687