### PR TITLE
SUMO-285918 - Fix timestamp format in Claude Compliance Universal Connector

### DIFF
--- a/docs/integrations/saas-cloud/claude-compliance.md
+++ b/docs/integrations/saas-cloud/claude-compliance.md
@@ -207,7 +207,7 @@ If you do not see the Compliance access keys section, it means that either you a
      |:--|:--|
      | **Logs JPath** | `$.data[*]` |
      | **Timestamp JPath** | `$.created_at` |
-     | **Timestamp Format** | `2006-01-02T15:04:05.000000Z` |
+     | **Timestamp Format** | `2006-01-02T15:04:05Z` |
         <img src={useBaseUrl('img/integrations/saas-cloud/claude-compliance-response-configuration.png')} alt="Universal Connector - HTTP Response Log Ingest Configuration" width="400" style={{border: '1px solid gray'}} />
 1. Configure the **Pagination Configuration**:
    - **Type**. Select **Continuation Token**.


### PR DESCRIPTION
## Purpose of this pull request

Updates the Timestamp Format in the Universal Connector HTTP Response Log Ingest Configuration from `2006-01-02T15:04:05.000000Z` to `2006-01-02T15:04:05Z`. The fractional seconds component caused a parsing error in the Universal Connector when ingesting Claude Compliance logs.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [X] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)
https://sumologic.atlassian.net/browse/SUMO-285918
<!-- enter your Jira, Asana, or GitHub ticket number -->