### PR TITLE
DOCS-1695 - Revert remote flow changes for apps not yet enabled

### DIFF
--- a/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/linux-opentelemetry.md
+++ b/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/linux-opentelemetry.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Linux.png')} alt="Thumbnail icon" width="100"/>
+<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Linux.png')} alt="Linux icon" width="100"/>
 
 Linux - Cloud Security Monitoring and Analytics - OpenTelemetry is a unified log app that ingests distribution of Linux data to Sumo Logic via OpenTelemetry [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver). The app's preconfigured dashboards provide insight into user, service, systems, login, and privilege activity, providing a better understanding of your production environments and surface relevant insights by tuning out-of-the-box content to align with your security team's focus.
 

--- a/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/linux-opentelemetry.md
+++ b/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/linux-opentelemetry.md
@@ -9,11 +9,11 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Linux.png')} alt="Linux icon" width="100"/>
+<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Linux.png')} alt="Thumbnail icon" width="100"/>
 
 Linux - Cloud Security Monitoring and Analytics - OpenTelemetry is a unified log app that ingests distribution of Linux data to Sumo Logic via OpenTelemetry [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver). The app's preconfigured dashboards provide insight into user, service, systems, login, and privilege activity, providing a better understanding of your production environments and surface relevant insights by tuning out-of-the-box content to align with your security team's focus.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/Linux-Schematics.png' alt="Linux Schematics" style={{border: '1px solid gray'}} />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/Linux-Schematics.png' alt="Linux-Schematics" style={{border: '1px solid gray'}} />
 
 ## Fields created in Sumo Logic for Linux - Security Analytics
 
@@ -50,29 +50,105 @@ import LogsCollectionPrereqisites from '../../../reuse/apps/logs-collection-prer
 You can skip this section if you have already set up the logs collection through [Linux](/docs/integrations/hosts-operating-systems/opentelemetry/linux-opentelemetry/) or [Linux PCI](/docs/integrations/pci-compliance/opentelemetry/linux-opentelemetry) app installation. Additional collection is not required as the logs used by this app are already ingested into Sumo Logic.
 :::
 
-Follow these steps to set up and deploy the source template to collect data in Sumo Logic from a remotely managed OpenTelemetry collector.
+import ConfigAppInstall from '../../../reuse/apps/opentelemetry/config-app-install.md';
 
-### Step 1: Set up remotely managed OpenTelemetry collector
+<ConfigAppInstall/>
 
-import OtelCollectorInstallation from '../../../reuse/apps/opentelemetry/otel-collector-installation.md';
+### Step 1: Set up Collector
+
+import SetupColl from '../../../reuse/apps/opentelemetry/set-up-collector.md';
+
+<SetupColl/>
+
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/Linux-Collector.png' alt="Linux-Collector" style={{border: '1px solid gray'}} />
+
+### Step 2: Configure integration
+
+In this step, you will configure the YAML required for Linux collection. The app requires path for system log file based on the Linux version used.
+
+#### Required Logs for Ubuntu
+
+The following logs, located in the `/var/log` folder, are required for using the Sumo Logic app for Cloud Security Monitoring and Analytics for Linux with Ubuntu.
+
+- auth.log
+- syslog
+- daemon.log
+- dpkg.log
+- kern.log
+
+#### Required Logs for CentOS, Amazon Linux, and Red Hat
+
+The following logs, located in the `/var/log` folder, are required for using the Sumo Logic app for Cloud Security Monitoring and Analytics for Linux with CentOS, Amazon Linux, and Red Hat.
+
+- audit/audit.log
+- secure
+- Messages
+- yum.log
+
+Click on the **Download YAML File** button to get the YAML file.
+
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/PCI-Linux-YAML.png' style={{border:'1px solid gray'}} alt="Linux-YAML.png" style={{border: '1px solid gray'}}/>
 
 :::note
-If you want to configure your source locally, you can do so by downloading the YAML file. For details, see [Configure OpenTelemetry collectors locally](/docs/integrations/sumo-apps/opentelemetry-collector-insights/#configure-opentelemetry-collectors-locally).
+By default, the path for Linux log files required for all the distros are pre-populated in the UI. (Optional) Unwanted file paths can be removed from the list if the files are not available on your Linux distribution. The collection will work even if not all the files are present in your system.
 :::
 
-<OtelCollectorInstallation/>
+### Step 3: Send logs to Sumo Logic
 
-### Step 2: Configure the source template
+import LogsIntro from '../../../reuse/apps/opentelemetry/send-logs-intro.md';
 
-import LinuxConfigureSourceTemplate from '../../../reuse/send-data/linux-configure-source-template.md';
+<LogsIntro/>
 
-<LinuxConfigureSourceTemplate/>
+<Tabs
+  className="unique-tabs"
+  defaultValue="Linux"
+  values={[
+    {label: 'Linux', value: 'Linux'},
+    {label: 'Chef', value: 'Chef'},
+    {label: 'Ansible', value: 'Ansible'},
+    {label: 'Puppet', value: 'Puppet'},
+  ]}>
 
-### Step 3: Push the source template to the desired remotely managed collectors
+<TabItem value="Linux">
 
-import DataConfiguration from '../../../reuse/apps/opentelemetry/data-configuration.md';
+1. Copy the yaml file to `/etc/otelcol-sumo/conf.d/` folder in the Artifactory instance that needs to be monitored.
+2. Restart the collector using:
+  ```sh
+  sudo systemctl restart otelcol-sumo
+  ```
 
-<DataConfiguration/>
+</TabItem>
+
+<TabItem value="Chef">
+
+import ChefNoEnv from '../../../reuse/apps/opentelemetry/chef-without-env.md';
+
+<ChefNoEnv/>
+
+</TabItem>
+
+<TabItem value="Ansible">
+
+import AnsibleNoEnv from '../../../reuse/apps/opentelemetry/ansible-without-env.md';
+
+<AnsibleNoEnv/>
+
+</TabItem>
+
+<TabItem value="Puppet">
+
+import PuppetNoEnv from '../../../reuse/apps/opentelemetry/puppet-without-env.md';
+
+<PuppetNoEnv/>
+
+</TabItem>
+
+</Tabs>
+
+
+import LogsOutro from '../../../reuse/apps/opentelemetry/send-logs-outro.md';
+
+<LogsOutro/>
 
 ## Sample log messages
 
@@ -82,7 +158,7 @@ Dec 13 04:44:00 <1> [zypper++] Summary.cc(readPool):133 I_TsU(27372)Mesa-libGL1-
 
 ## Sample queries
 
-```sumo
+```sql
 sumo.datasource=linux deployment.environment=* host.group=* host.name=*
 | parse regex "\S*\s+\d+\s+\d+:\d+:\d+\s+(?<dest_host>\S*)\s+(?<process>\w*)(?:\[\d+\]:|:)\s*(?<message>.+)$" nodrop
 | if (isEmpty(dest_host), _sourceHost, dest_host) as dest_host
@@ -115,7 +191,7 @@ Use this dashboard to:
 - Verify the status of critical systems.
 - Monitor excessive failed login attempts and detect total number of attempts to break into the system.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Monitoring-Overview.png' style={{border: '1px solid gray'}} alt="Linux Security Monitoring Overview" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Monitoring-Overview.png' style={{border: '1px solid gray'}} alt="Linux-Security-Monitoring-Overview" />
 
 ### Login Activity
 
@@ -125,7 +201,7 @@ Use this dashboard to:
 - Monitor access to the Linux computing environment.
 - Monitor failed and successful user logins.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Analytics-Login-Activity.png' style={{border: '1px solid gray'}} alt="Linux Security Analytics Login Activity" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Analytics-Login-Activity.png' style={{border: '1px solid gray'}} alt="Linux-Security-Analytics-Login-Activity" />
 
 ### Privileged Activity
 
@@ -135,7 +211,7 @@ Use this dashboard to:
 - Monitor successful and failed access attempts to systemswith administrative privileges.
 - Monitor actions performed by users with administrative privileges.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Analytics-Privileged-Activity.png' style={{border: '1px solid gray'}} alt="Linux Security Analytics Privileged Activity" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Analytics-Privileged-Activity.png' style={{border: '1px solid gray'}} alt="Linux-Security-Analytics-Privileged-Activity" />
 
 
 ### User, Service, and System Monitoring
@@ -146,7 +222,7 @@ Use this dashboard to:
 - Monitor accounts created and deleted.
 - Monitor service usage and other system activity.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Analytics-User-Service-and-System-Monitoring.png' style={{border: '1px solid gray'}} alt="Linux Security Analytics User Service and System Monitoring" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Linux-Cloud-Security-Monitoring-and-Analytics/Opentelemetry/Linux-Security-Analytics-User-Service-and-System-Monitoring.png' style={{border: '1px solid gray'}} alt="Linux-Security-Analytics-User-Service-and-System-Monitoring" />
 
 
 ## Create monitors for Linux - Cloud Security Monitoring and Analytics app

--- a/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/windows-opentelemetry.md
+++ b/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/windows-opentelemetry.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Windows.png')} alt="Thumbnail icon" width="85"/>
+<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Windows.png')} alt="Windows icon" width="85"/>
 
 Windows - Cloud Security Monitoring and Analytics - OpenTelemetry is a unified log app that ingests distribution of Windows data to Sumo Logic via OpenTelemetry [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver). The app's preconfigured dashboards provide insight into user accounts, login activity, and Windows updates.
 

--- a/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/windows-opentelemetry.md
+++ b/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/windows-opentelemetry.md
@@ -9,11 +9,11 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Windows.png')} alt="Windows icon" width="85"/>
+<img src={useBaseUrl('img/integrations/cloud-security-monitoring-analytics/SecMon_Windows.png')} alt="Thumbnail icon" width="85"/>
 
 Windows - Cloud Security Monitoring and Analytics - OpenTelemetry is a unified log app that ingests distribution of Windows data to Sumo Logic via OpenTelemetry [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver). The app's preconfigured dashboards provide insight into user accounts, login activity, and Windows updates.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Windows-JSON/OpenTelemetry/PCI-WIndows-JSON-Schematics.png' alt="PCI Windows JSON Schematics" style={{border: '1px solid gray'}} />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Windows-JSON/OpenTelemetry/PCI-WIndows-JSON-Schematics.png' alt="PCI-Windows-JSON-Schematics" style={{border: '1px solid gray'}} />
 
 ## Fields created in Sumo Logic for Windows
 
@@ -37,29 +37,82 @@ Standard Windows event channels include:
 - You can skip this section if you have already set up the logs collection through [Windows PCI](/docs/integrations/pci-compliance/opentelemetry/windows-json-opentelemetry) or  [Windows](/docs/integrations/hosts-operating-systems/opentelemetry/windows-opentelemetry) or [Active Directory](/docs/integrations/microsoft-azure/opentelemetry/active-directory-json-opentelemetry) app installation. Additional collection is not required as the logs used by this app are already ingested into Sumo Logic.
 :::
 
-Follow these steps to set up and deploy the source template to collect data in Sumo Logic from a remotely managed OpenTelemetry collector.
+import ConfigAppInstall from '../../../reuse/apps/opentelemetry/config-app-install.md';
 
-### Step 1: Set up remotely managed OpenTelemetry collector
+<ConfigAppInstall/>
 
-import OtelCollectorInstallation from '../../../reuse/apps/opentelemetry/otel-collector-installation.md';
+### Step 1: Set up Collector
 
-:::note
-If you want to configure your source locally, you can do so by downloading the YAML file. For details, see [Configure OpenTelemetry collectors locally](/docs/integrations/sumo-apps/opentelemetry-collector-insights/#configure-opentelemetry-collectors-locally).
-:::
+import SetupColl from '../../../reuse/apps/opentelemetry/set-up-collector.md';
 
-<OtelCollectorInstallation/>
+<SetupColl/>
 
-### Step 2: Configure the source template
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/Linux-Collector.png' alt="Linux-Collector" style={{border: '1px solid gray'}} />
 
-import WindowsConfigureSourceTemplate from '../../../reuse/send-data/windows-configure-source-template.md';
+### Step 2: Configure integration
 
-<WindowsConfigureSourceTemplate/>
+In this step, you will configure the YAML file required for Windows event logs and metrics Collection.
 
-### Step 3: Push the source template to the desired remotely managed collectors
+Any custom fields can be tagged along with the data in this step.
 
-import DataConfiguration from '../../../reuse/apps/opentelemetry/data-configuration.md';
+Once the details are filled in, click on the **Download YAML File** button to get the yaml file.
 
-<DataConfiguration/>
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Windows-JSON/OpenTelemetry/PCI-Windows-YAML.png' style={{border: '1px solid gray'}} alt="YAML" />
+
+### Step 3: Send logs to Sumo Logic
+
+import LogsIntro from '../../../reuse/apps/opentelemetry/send-logs-intro.md';
+
+<LogsIntro/>
+
+<Tabs
+  className="unique-tabs"
+  defaultValue="Windows"
+  values={[
+    {label: 'Windows', value: 'Windows'},
+    {label: 'Chef', value: 'Chef'},
+    {label: 'Ansible', value: 'Ansible'},
+    {label: 'Puppet', value: 'Puppet'},
+  ]}>
+
+<TabItem value="Windows">
+
+1. Copy the yaml file to `C:\ProgramData\Sumo Logic\OpenTelemetry Collector\config\conf.d` folder in the machine that needs to be monitored.
+2. Restart the collector using:
+  ```sh
+  Restart-Service -Name OtelcolSumo
+  ```
+
+</TabItem>
+
+<TabItem value="Chef">
+
+import ChefNoEnv from '../../../reuse/apps/opentelemetry/chef-without-env.md';
+
+<ChefNoEnv/>
+
+</TabItem>
+
+<TabItem value="Ansible">
+
+import AnsibleNoEnv from '../../../reuse/apps/opentelemetry/ansible-without-env.md';
+
+<AnsibleNoEnv/>
+
+</TabItem>
+
+<TabItem value="Puppet">
+
+import PuppetNoEnv from '../../../reuse/apps/opentelemetry/puppet-without-env.md';
+
+<PuppetNoEnv/>
+
+</TabItem>
+</Tabs>
+
+import LogsOutro from '../../../reuse/apps/opentelemetry/send-logs-outro.md';
+
+<LogsOutro/>
 
 ## Sample log messages
 
@@ -161,7 +214,7 @@ import DataConfiguration from '../../../reuse/apps/opentelemetry/data-configurat
 
 This sample log query is from the **Windows - Security Analytics - User Account Changes** dashboard > **Failed Logins Summary** panel.
 
-```sumo
+```sql
 sumo.datasource=windows "Microsoft-Windows-Security-Auditing" ("4770" OR "4771" OR "4772" OR "4776" OR "4777" OR "4768" OR "4769" OR "4820" OR "4625" OR "4624" OR "4647" OR "4778" OR "4779" OR "4800" OR "4801" OR "4802" OR "4803") "Audit Failure" * * * * *
 | json "channel", "provider", "event_id", "computer","task","keywords","event_data","message" as Channel, Provider, EventID, Computer, Task, Keywords, Event_Data, Message  nodrop
 | json field=EventID "qualifiers","id" as  qualifiers, EventID
@@ -197,61 +250,61 @@ import FilterDashboards from '../../../reuse/filter-dashboards.md';
 
 The **Windows - Security Analytics - Default Accounts Usage** dashboard displays analytics of default account usage including Administrator, Guest, System, and Root accounts.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Default-Accounts-Usage.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics Default Accounts Usage" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Default-Accounts-Usage.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-Default-Accounts-Usage" />
 
 ### TLS Certificates and Secure Channels​
 
 The **Windows - Security Analytics - TLS Certificates and Secure Channels** dashboard provides security analytics on TLS and Schannel events.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-TLS-Certificates-and-Secure-Channels.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics TLS Certificates and Secure Channels" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-TLS-Certificates-and-Secure-Channels.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-TLS-Certificates-and-Secure-Channels" />
 
 ### User Account Changes​
 
 The **Windows - Security Analytics - User Account Changes** dashboard provides analytics on user account changes and events.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-User-Account-Changes.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics User Account Changes" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-User-Account-Changes.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-User-Account-Changes" />
 
 ### User Authentication​
 
 The **Windows - Security Analytics - User Authentication** dashboard provides security analytics on successful and failed account logins.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-User-Authentication.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics User Authentication" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-User-Authentication.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-User-Authentication" />
 
 ### User Group Updates
 
 The **Windows - Security Analytics - User Group Updates** dashboard provides security analytics on user group updates.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-User-Group-Updates.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics User Group Updates" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-User-Group-Updates.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-User-Group-Updates" />
 
 ### Windows Defender
 
 The **Windows - Security Analytics - User Authentication** dashboard provides security analytics on Windows Defender events.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Windows-Defender.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics Windows Defender" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Windows-Defender.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-Windows-Defender" />
 
 ### Windows Firewall
 
 The **Windows - Security Analytics - Windows Firewall** dashboard provides security analytics on Windows Firewall events.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Windows-Firewall.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics Windows Firewall" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Windows-Firewall.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-Windows-Firewall" />
 
 ### Windows Updates
 
 The **Windows - Security Analytics - Windows Updates** dashboard provides security Windows Updates events.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Windows-Updates.png' style={{border: '1px solid gray'}} alt="Windows Security Analytics Windows Updates" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Analytics-Windows-Updates.png' style={{border: '1px solid gray'}} alt="Windows-Security-Analytics-Windows-Updates" />
 
 ### Critical Events​
 
 The **WWindows - Security Monitoring - Critical Events** dashboard provides analysis of critical security events related to services stopped, audit logs tampered, and logging ingestion delays.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Monitoring-Critical-Events.png' style={{border: '1px solid gray'}} alt="Windows Security Monitoring Critical Events" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Monitoring-Critical-Events.png' style={{border: '1px solid gray'}} alt="Windows-Security-Monitoring-Critical-Events" />
 
 ### Inventory​
 
 The **Windows - Security Monitoring - Inventory** dashboard helps you to monitor windows events provided by computer, channel, and provider. This dashboard also provides additional information on computer reboots.
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Monitoring-Inventory.png' style={{border: '1px solid gray'}} alt="Windows Security Monitoring Inventory" />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/Windows-Cloud-Security-Monitoring-and-Analytics/OpenTelemetry/Windows-Security-Monitoring-Inventory.png' style={{border: '1px solid gray'}} alt="Windows-Security-Monitoring-Inventory" />
 
 
 ## Create monitors for Windows - Cloud Security Monitoring and Analytics app

--- a/docs/integrations/pci-compliance/opentelemetry/linux-opentelemetry.md
+++ b/docs/integrations/pci-compliance/opentelemetry/linux-opentelemetry.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="Thumbnail icon" width="90"/>
+<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="PCI icon" width="90"/>
 
 The PCI Compliance for Linux - OpenTelemetry is a unified log app that sends Linux log data to Sumo Logic via OpenTelemetry [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver). The app's preconfigured dashboards help you to monitor system, account, and user activity to ensure that login activity and privileged users are within the expected ranges.
 

--- a/docs/integrations/pci-compliance/opentelemetry/linux-opentelemetry.md
+++ b/docs/integrations/pci-compliance/opentelemetry/linux-opentelemetry.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="PCI icon" width="90"/>
+<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="Thumbnail icon" width="90"/>
 
 The PCI Compliance for Linux - OpenTelemetry is a unified log app that sends Linux log data to Sumo Logic via OpenTelemetry [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver). The app's preconfigured dashboards help you to monitor system, account, and user activity to ensure that login activity and privileged users are within the expected ranges.
 
@@ -17,7 +17,7 @@ The PCI Compliance for Linux - OpenTelemetry is a unified log app that sends Lin
 The PCI Compliance for Linux app covers PCI requirements 02, 07, 08, and 10.
 :::
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/Linux-Schematics.png' alt="Linux Schematics" style={{border: '1px solid gray'}} />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/Linux-Schematics.png' alt="Linux-Schematics" style={{border: '1px solid gray'}} />
 
 ## Fields created in Sumo Logic for Linux PCI Compliance
 
@@ -53,32 +53,107 @@ import LogsCollectionPrereqisites from '../../../reuse/apps/logs-collection-prer
 ## Collection configuration and app installation
 
 :::note
-You can skip this section if you have already set up the logs collection through [Linux](/docs/integrations/hosts-operating-systems/opentelemetry/linux-opentelemetry/) or [Linux - Cloud Security Monitoring and Analytics](/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/linux-opentelemetry/) app installation. Additional collection is not required as the logs used by this app are already ingested into Sumo Logic.
+You can skip this section if you have already set up the logs collection through [Linux](/docs/integrations/hosts-operating-systems/opentelemetry/linux-opentelemetry/) or [Linux - Cloud Security Monitoring and Analytics](/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/linux-opentelemetry) app installation. Additional collection is not required as the logs used by this app are already ingested into Sumo Logic.
 :::
 
-Follow these steps to set up and deploy the source template to collect data in Sumo Logic from a remotely managed OpenTelemetry collector.
+import ConfigAppInstall from '../../../reuse/apps/opentelemetry/config-app-install.md';
 
-### Step 1: Set up remotely managed OpenTelemetry collector
+<ConfigAppInstall/>
 
-import OtelCollectorInstallation from '../../../reuse/apps/opentelemetry/otel-collector-installation.md';
+### Step 1: Set up Collector
+
+import SetupColl from '../../../reuse/apps/opentelemetry/set-up-collector.md';
+
+<SetupColl/>
+
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/Linux-Collector.png' alt="Linux-Collector" style={{border: '1px solid gray'}} />
+
+### Step 2: Configure integration
+
+In this step, you will configure the yaml required for Linux Collection. The app requires path for system log file based on the Linux version used.
+
+#### Required Logs for Ubuntu
+
+The following logs, located in the `/var/log` folder, are required for using the Sumo Logic app for PCI compliance for Linux with Ubuntu.
+
+- auth.log
+- syslog
+- daemon.log
+- dpkg.log
+- kern.log
+
+#### Required Logs for CentOS, Amazon Linux, and Red Hat
+
+The following logs, located in the `/var/log` folder, are required for using the Sumo Logic app for PCI compliance for Linux with CentOS, Amazon Linux, and Red Hat.
+
+- audit/audit.log
+- secure
+- Messages
+- yum.log
+
+Click on the **Download YAML File** button to get the yaml file.
+
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Linux/OpenTelemetry/PCI-Linux-YAML.png' alt="Linux-YAML.png" style={{border: '1px solid gray'}}/>
 
 :::note
-If you want to configure your source locally, you can do so by downloading the YAML file. For details, see [Configure OpenTelemetry collectors locally](/docs/integrations/sumo-apps/opentelemetry-collector-insights/#configure-opentelemetry-collectors-locally).
+By default, the path for Linux log files required for all the distros are pre-populated in the UI. (Optional) Unwanted file paths can be removed from the list if the files are not available on your Linux distribution. The collection will work even if not all the files are present in your system.
 :::
 
-<OtelCollectorInstallation/>
+### Step 3: Send logs to Sumo Logic
 
-### Step 2: Configure the source template
+import LogsIntro from '../../../reuse/apps/opentelemetry/send-logs-intro.md';
 
-import LinuxConfigureSourceTemplate from '../../../reuse/send-data/linux-configure-source-template.md';
+<LogsIntro/>
 
-<LinuxConfigureSourceTemplate/>
+<Tabs
+  className="unique-tabs"
+  defaultValue="Linux"
+  values={[
+    {label: 'Linux', value: 'Linux'},
+    {label: 'Chef', value: 'Chef'},
+    {label: 'Ansible', value: 'Ansible'},
+    {label: 'Puppet', value: 'Puppet'},
+  ]}>
 
-### Step 3: Push the source template to the desired remotely managed collectors
+<TabItem value="Linux">
 
-import DataConfiguration from '../../../reuse/apps/opentelemetry/data-configuration.md';
+1.  Copy the YAML file to `/etc/otelcol-sumo/conf.d/` folder in the Linux instance which needs to be monitored.
+2.  Restart the collector using:
+    ```sh
+    sudo systemctl restart otelcol-sumo
+    ```
 
-<DataConfiguration/>
+</TabItem>
+
+<TabItem value="Chef">
+
+import ChefNoEnv from '../../../reuse/apps/opentelemetry/chef-without-env.md';
+
+<ChefNoEnv/>
+
+</TabItem>
+
+<TabItem value="Ansible">
+
+import AnsibleNoEnv from '../../../reuse/apps/opentelemetry/ansible-without-env.md';
+
+<AnsibleNoEnv/>
+
+</TabItem>
+
+<TabItem value="Puppet">
+
+import PuppetNoEnv from '../../../reuse/apps/opentelemetry/puppet-without-env.md';
+
+<PuppetNoEnv/>
+
+</TabItem>
+
+</Tabs>
+
+import LogsOutro from '../../../reuse/apps/opentelemetry/send-logs-outro.md';
+
+<LogsOutro/>
 
 ## Sample log messages
 
@@ -88,7 +163,7 @@ Jun 28 07:46:03 bruno-supercomputer useradd[1602]: new account added - account=r
 
 ## Sample queries
 
-```sumo
+```sql
 sumo.datasource=linux deployment.environment=* host.group=* host.name=* "useradd" and ("new user" or "new account")
 | parse regex "\S*\s+\d+\s+\d+:\d+:\d+\s+(?<_sourceHost>\S+)\s+\w*" nodrop
 | parse regex "\S*\s+\d+\s+\d+:\d+:\d+\s+(?<dest_host>\S*)\s+(?<process>\w*)(?:\[\d+\]:|:)\s*(?<msg>.+)$" nodrop

--- a/docs/integrations/pci-compliance/opentelemetry/windows-json-opentelemetry.md
+++ b/docs/integrations/pci-compliance/opentelemetry/windows-json-opentelemetry.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="Thumbnail icon" width="90"/>
+<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="PCI icon" width="90"/>
 
 The PCI Compliance for Windows JSON - OpenTelemetry is a log app that sends Windows log data to Sumo Logic via OpenTelemetry [windows event log receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver#readme). The app's preconfigured dashboards help you to monitor system, account, and user activity to ensure that login activity and privileged users are within the expected ranges.
 

--- a/docs/integrations/pci-compliance/opentelemetry/windows-json-opentelemetry.md
+++ b/docs/integrations/pci-compliance/opentelemetry/windows-json-opentelemetry.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="PCI icon" width="90"/>
+<img src={useBaseUrl('img/integrations/pci-compliance/pci-logo.png')} alt="Thumbnail icon" width="90"/>
 
 The PCI Compliance for Windows JSON - OpenTelemetry is a log app that sends Windows log data to Sumo Logic via OpenTelemetry [windows event log receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver#readme). The app's preconfigured dashboards help you to monitor system, account, and user activity to ensure that login activity and privileged users are within the expected ranges.
 
@@ -17,7 +17,7 @@ The PCI Compliance for Windows JSON - OpenTelemetry is a log app that sends Wind
 The PCI Compliance for Windows JSON app covers PCI requirements 02, 06, 08, and 10.
 :::
 
-<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Windows-JSON/OpenTelemetry/PCI-WIndows-JSON-Schematics.png' alt="PCI Windows JSON Schematics" style={{border: '1px solid gray'}} />
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Windows-JSON/OpenTelemetry/PCI-WIndows-JSON-Schematics.png' alt="PCI-Windows-JSON-Schematics" style={{border: '1px solid gray'}} />
 
 ## Fields created in Sumo Logic for PCI Compliance Windows JSON App
 
@@ -42,35 +42,94 @@ Standard Windows event channels include:
 You can skip this section if you have already set up the logs collection through [Windows](/docs/integrations/hosts-operating-systems/opentelemetry/windows-opentelemetry), [Windows - Cloud Security Monitoring and Analytics](/docs/integrations/cloud-security-monitoring-analytics/opentelemetry/windows-opentelemetry), or [Active Directory](/docs/integrations/microsoft-azure/opentelemetry/active-directory-json-opentelemetry) app installation. Additional collection is not required as the logs used by this app are already ingested into Sumo Logic.
 :::
 
-Follow these steps to set up and deploy the source template to collect data in Sumo Logic from a remotely managed OpenTelemetry collector.
+import ConfigAppInstall from '../../../reuse/apps/opentelemetry/config-app-install.md';
 
-### Step 1: Set up remotely managed OpenTelemetry collector
+<ConfigAppInstall/>
 
-import OtelCollectorInstallation from '../../../reuse/apps/opentelemetry/otel-collector-installation.md';
+### Step 1: Set up Collector
 
 :::note
-If you want to configure your source locally, you can do so by downloading the YAML file. For details, see [Configure OpenTelemetry collectors locally](/docs/integrations/sumo-apps/opentelemetry-collector-insights/#configure-opentelemetry-collectors-locally).
+If you want to use an existing OpenTelemetry Collector, you can skip this step by selecting the **Use an existing Collector** option.
 :::
 
-<OtelCollectorInstallation/>
+To create a new Collector:
+1. Select the **Add a new Collector** option.
+2. Select the platform where you want to install the Sumo Logic OpenTelemetry Collector.
 
-### Step 2: Configure the source template
+This will generate a command that you can execute in the machine environment you need to monitor. Once executed, it will install the Sumo Logic OpenTelemetry Collector.
 
-import WindowsConfigureSourceTemplate from '../../../reuse/send-data/windows-configure-source-template.md';
+<img src="https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Windows-JSON/OpenTelemetry/PCI-Windows-Collector.png" style={{border:'1px solid gray'}} alt="collector"/>
 
-<WindowsConfigureSourceTemplate/>
+### Step 2: Configure integration
 
-### Step 3: Push the source template to the desired remotely managed collectors
+In this step, you will configure the yaml file required for Windows event logs collection.
 
-import DataConfiguration from '../../../reuse/apps/opentelemetry/data-configuration.md';
+Any custom fields can be tagged along with the data in this step.
 
-<DataConfiguration/>
+Once the details are filled in, click on the **Download YAML File** button to get the yaml file.
+
+<img src='https://sumologic-app-data-v2.s3.amazonaws.com/dashboards/PCI-Compliance-For-Windows-JSON/OpenTelemetry/PCI-Windows-YAML.png' style={{border:'1px solid gray'}} alt="YAML" />
+
+### Step 3: Send logs to Sumo Logic
+
+import LogsIntro from '../../../reuse/apps/opentelemetry/send-logs-intro.md';
+
+<LogsIntro/>
+
+<Tabs
+  className="unique-tabs"
+  defaultValue="Windows"
+  values={[
+    {label: 'Windows', value: 'Windows'},
+    {label: 'Chef', value: 'Chef'},
+    {label: 'Ansible', value: 'Ansible'},
+    {label: 'Puppet', value: 'Puppet'},
+  ]}>
+
+<TabItem value="Windows">
+
+1. Copy the yaml file to `C:\ProgramData\Sumo Logic\OpenTelemetry Collector\config\conf.d` folder in the machine which needs to be monitored.
+2. Restart the collector using:
+  ```sh
+  Restart-Service -Name OtelcolSumo
+  ```
+
+</TabItem>
+
+<TabItem value="Chef">
+
+import ChefNoEnv from '../../../reuse/apps/opentelemetry/chef-without-env.md';
+
+<ChefNoEnv/>
+
+</TabItem>
+
+<TabItem value="Ansible">
+
+import AnsibleNoEnv from '../../../reuse/apps/opentelemetry/ansible-without-env.md';
+
+<AnsibleNoEnv/>
+
+</TabItem>
+
+<TabItem value="Puppet">
+
+import PuppetNoEnv from '../../../reuse/apps/opentelemetry/puppet-without-env.md';
+
+<PuppetNoEnv/>
+
+</TabItem>
+</Tabs>
+
+import LogsOutro from '../../../reuse/apps/opentelemetry/send-logs-outro.md';
+
+<LogsOutro/>
 
 ## Sample queries
 
 This sample log query is from the **Windows - PCI Req 02, 08, 10 - Account, User, System Monitoring** dashboard > **User Account Created** panel.
 
-```sumo title="Log Query String"
+```sql title="Log Query String"
 sumo.datasource=windows deployment.environment={{deployment.environment}} host.group={{host.group}} "\"channel\":\"Security\"" 4720
 | json "event_id.id", "computer", "message", "event_data.SubjectUserName",  "event_data.SubjectDomainName", "event_data.TargetUserName", "event_data.TargetDomainName" as event_id, host, msg_summary, src_user, src_domain, dest_user, dest_domain nodrop
 | if(isBlank(src_user), "Unknown", src_user) as src_user

--- a/docs/integrations/sumo-apps/opentelemetry-collector-insights.md
+++ b/docs/integrations/sumo-apps/opentelemetry-collector-insights.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/send-data/otel-color.svg')} alt="Thumbnail icon" width="45"/>
+<img src={useBaseUrl('img/send-data/otel-color.svg')} alt="OpenTelemetry color icon" width="45"/>
 
 The Sumo Logic OpenTelemetry Collector Insights app provides comprehensive monitoring and observability for your OpenTelemetry Collector instances. Monitor collector performance, telemetry data flow, resource utilization, and troubleshoot data collection issues with preconfigured dashboards and alerts. Track metrics and logs to ensure your telemetry pipeline is running smoothly and efficiently.
 
@@ -208,7 +208,7 @@ You can now remotely configure and manage OpenTelemetry Collectors for the follo
 - [Linux](/docs/send-data/opentelemetry-collector/remote-management/source-templates/linux/)
 - [Mac](/docs/send-data/opentelemetry-collector/remote-management/source-templates/mac/)
 - [MySql](/docs/send-data/opentelemetry-collector/remote-management/source-templates/mysql/)
-- [Nginix](/docs/send-data/opentelemetry-collector/remote-management/source-templates/nginx/)
+- [Nginx](/docs/send-data/opentelemetry-collector/remote-management/source-templates/nginx/)
 - [PostgreSql](/docs/send-data/opentelemetry-collector/remote-management/source-templates/postgresql/)
 - [RabbitMQ](/docs/send-data/opentelemetry-collector/remote-management/source-templates/rabbitmq/)
 - [Redis](/docs/send-data/opentelemetry-collector/remote-management/source-templates/redis/)
@@ -220,7 +220,7 @@ If you want to configure your source locally, you can do so by downloading the Y
 
 ### Step 1: Set up OpenTelemetry collector
 
-To get started, set up a remotely managed collector on your system by following the.instructions in [Step 1: Set up collector](#step-1-set-up-collector).<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/install-otel-collector.png')} alt="learn-more-button-warning" style={{border:'1px solid gray'}} width="700"/>
+To get started, set up a remotely managed collector on your system by following the instructions in [Step 1: Set up collector](#step-1-set-up-collector).<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/install-otel-collector.png')} alt="learn-more-button-warning" style={{border:'1px solid gray'}} width="700"/>
 
 For the apps listed above, the installation commands now include a `--remotely-managed` flag. When this flag is used, a remotely managed collector is installed automatically instead of a locally managed one. If you prefer to use a locally managed collector, simply remove the flag from the installation command.
 

--- a/docs/integrations/sumo-apps/opentelemetry-collector-insights.md
+++ b/docs/integrations/sumo-apps/opentelemetry-collector-insights.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<img src={useBaseUrl('img/send-data/otel-color.svg')} alt="OpenTelemetry color icon" width="45"/>
+<img src={useBaseUrl('img/send-data/otel-color.svg')} alt="Thumbnail icon" width="45"/>
 
 The Sumo Logic OpenTelemetry Collector Insights app provides comprehensive monitoring and observability for your OpenTelemetry Collector instances. Monitor collector performance, telemetry data flow, resource utilization, and troubleshoot data collection issues with preconfigured dashboards and alerts. Track metrics and logs to ensure your telemetry pipeline is running smoothly and efficiently.
 
@@ -208,7 +208,7 @@ You can now remotely configure and manage OpenTelemetry Collectors for the follo
 - [Linux](/docs/send-data/opentelemetry-collector/remote-management/source-templates/linux/)
 - [Mac](/docs/send-data/opentelemetry-collector/remote-management/source-templates/mac/)
 - [MySql](/docs/send-data/opentelemetry-collector/remote-management/source-templates/mysql/)
-- [Nginx](/docs/send-data/opentelemetry-collector/remote-management/source-templates/nginx/)
+- [Nginix](/docs/send-data/opentelemetry-collector/remote-management/source-templates/nginx/)
 - [PostgreSql](/docs/send-data/opentelemetry-collector/remote-management/source-templates/postgresql/)
 - [RabbitMQ](/docs/send-data/opentelemetry-collector/remote-management/source-templates/rabbitmq/)
 - [Redis](/docs/send-data/opentelemetry-collector/remote-management/source-templates/redis/)
@@ -220,18 +220,18 @@ If you want to configure your source locally, you can do so by downloading the Y
 
 ### Step 1: Set up OpenTelemetry collector
 
-To get started, set up a remotely managed collector on your system by following the.instructions in [Step 1: Set up collector](#step-1-set-up-collector).<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/install-otel-collector.png')} alt="Learn more button warning" style={{border:'1px solid gray'}} width="700"/>
+To get started, set up a remotely managed collector on your system by following the.instructions in [Step 1: Set up collector](#step-1-set-up-collector).<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/install-otel-collector.png')} alt="learn-more-button-warning" style={{border:'1px solid gray'}} width="700"/>
 
 For the apps listed above, the installation commands now include a `--remotely-managed` flag. When this flag is used, a remotely managed collector is installed automatically instead of a locally managed one. If you prefer to use a locally managed collector, simply remove the flag from the installation command.
 
 ### Step 2: Configure app integration
 
-Configure the source template for the above mentioned apps to ingest logs or metrics, or both. [Learn more](/docs/send-data/opentelemetry-collector/remote-management/source-templates/).<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/configure-app.png')} alt="Learn more button warning" style={{border:'1px solid gray'}} width="700"/>
+Configure the source template for the above mentioned apps to ingest logs or metrics, or both. [Learn more](/docs/send-data/opentelemetry-collector/remote-management/source-templates/).<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/configure-app.png')} alt="learn-more-button-warning" style={{border:'1px solid gray'}} width="700"/>
 
 ### Step 3: Link Collectors
 
-1. Link the remotely managed OpenTelemetry collector by name or tags to associate it with the configured source template. If you already provided tags in [Step 1](#step-1-set-up-opentelemetry-collector), they will be automatically populated at this stage.<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/link-collectors.png')} alt="Learn more button warning" style={{border:'1px solid gray'}} width="700"/>
-2. Once the source template is created, you can [edit](/docs/send-data/opentelemetry-collector/remote-management/source-templates/manage-source-templates/#edit-a-source-template) it anytime as needed.<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/st-created-successfully.png')} alt="Learn more button warning" style={{border:'1px solid gray'}} width="700"/>
+1. Link the remotely managed OpenTelemetry collector by name or tags to associate it with the configured source template. If you already provided tags in [Step 1](#step-1-set-up-opentelemetry-collector), they will be automatically populated at this stage.<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/link-collectors.png')} alt="learn-more-button-warning" style={{border:'1px solid gray'}} width="700"/>
+2. Once the source template is created, you can [edit](/docs/send-data/opentelemetry-collector/remote-management/source-templates/manage-source-templates/#edit-a-source-template) it anytime as needed.<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/st-created-successfully.png')} alt="learn-more-button-warning" style={{border:'1px solid gray'}} width="700"/>
 
 ### Configure OpenTelemetry collectors locally
 
@@ -240,7 +240,7 @@ You can configure your source locally by downloading the YAML file.
 To download the YAML file, follow the steps below:
 1. [**New UI**](/docs/get-started/sumo-logic-ui). Go to the main Sumo Logic menu and select **Data Management**, and under **Data Collection** select **Source Template**.<br/>[**Classic UI**](/docs/get-started/sumo-logic-ui-classic). In the main Sumo Logic menu, select **Manage Data > Collection > Source Template**.
 1. Select the source template whose YAML configuration you want to download. If the required source template is not available, create a new one by clicking **+ Add Source**.
-1. In the right pane, under **Source Configuration**, click **Copy** or **Download YAML File** to download and manage the configuration locally.<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/copy-yaml.png')} alt="Learn more button warning" style={{border:'1px solid gray'}} width="400"/>
+1. In the right pane, under **Source Configuration**, click **Copy** or **Download YAML File** to download and manage the configuration locally.<br/><img src={useBaseUrl('img/send-data/opentelemetry-collector/copy-yaml.png')} alt="learn-more-button-warning" style={{border:'1px solid gray'}} width="400"/>
 
 ## Sample log messages
 
@@ -298,7 +298,7 @@ The OpenTelemetry Collector emits comprehensive internal metrics categorized by 
 
 This sample query is from the **Pipeline Health Overview** panel.
 
-```sumo
+```sql
 sumo.datasource=otel_collector
 | json auto maxdepth 1 nodrop
 | if (isEmpty(log), _raw, log) as _raw


### PR DESCRIPTION
## Purpose of this pull request

Reverts the remote management flow (source template based) changes introduced in PR #6292 for the following apps that do not yet have remote flow enabled:

- PCI Compliance for Linux - OpenTelemetry
- PCI Compliance For Windows JSON - OpenTelemetry
- Windows - Cloud Security Monitoring and Analytics - OpenTelemetry
- Linux - Cloud Security Monitoring and Analytics - OpenTelemetry
- OpenTelemetry Collector Insights

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1695