### PR TITLE
DOCS-1698 - Update cardinality docs for GA and improved source pausing logic

### DIFF
--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -86,5 +86,11 @@ To interact with other Sumo Logic users, post feedback, or ask a question about 
   <p>Kubernetes metrics are collected when you deploy our Kubernetes collection.</p>
   </div>
 </div>
+<div className="box smallbox card">
+  <div className="container">
+  <a href={useBaseUrl('docs/metrics/source-and-collector-cardinality')}><img src={useBaseUrl('img/icons/metrics.png')} alt="Metrics icon" width="40"/><h4>Source and Collector Wise Cardinality</h4></a>
+  <p>Identify and analyze source and collector-level cardinality to pinpoint high-cardinality sources.</p>
+  </div>
+</div>
 </div>
 

--- a/docs/metrics/manage-metric-volume/disabled-metrics-sources.md
+++ b/docs/metrics/manage-metric-volume/disabled-metrics-sources.md
@@ -43,9 +43,7 @@ Following is an example of the message written to the system event index:
 
 ### Sources are disabled when you reach the global limits
 
-When you reach the global limits, Sumo Logic starts disabling your metric sources based on cardinality growth. Rather than targeting the sources with the highest current cardinality, Sumo Logic compares each source's cardinality over the most recent 7-day period against the prior 7-day period, and pauses sources in descending order of cardinality increase. Sources that have recently grown and contributed to the breach are paused first, while stable high-volume sources are left unaffected.
-
-Sumo Logic continues disabling metric sources until your metric ingestion drops below the global limit.
+When you reach the global limits, Sumo Logic starts disabling your metric sources, starting with the one that is ingesting metrics with the highest cardinality, and continues disabled metric sources in that order, until your metric ingestion is reduced to a volume that is lower than the limit.
 
 For each source it disabled, Sumo Logic generates a health event and writes a message with level “error” to the [system event index](/docs/manage/security/audit-indexes/system-event-index/). Enter a query to `_index=sumologic_system_events` to see events in the system event index.
 

--- a/docs/metrics/manage-metric-volume/disabled-metrics-sources.md
+++ b/docs/metrics/manage-metric-volume/disabled-metrics-sources.md
@@ -43,7 +43,9 @@ Following is an example of the message written to the system event index:
 
 ### Sources are disabled when you reach the global limits
 
-When you reach the global limits, Sumo Logic starts disabling your metric sources, starting with the one that is ingesting metrics with the highest cardinality, and continues disabled metric sources in that order, until your metric ingestion is reduced to a volume that is lower than the limit.
+When you reach the global limits, Sumo Logic starts disabling your metric sources based on cardinality growth. Rather than targeting the sources with the highest current cardinality, Sumo Logic compares each source's cardinality over the most recent 7-day period against the prior 7-day period, and pauses sources in descending order of cardinality increase. Sources that have recently grown and contributed to the breach are paused first, while stable high-volume sources are left unaffected.
+
+Sumo Logic continues disabling metric sources until your metric ingestion drops below the global limit.
 
 For each source it disabled, Sumo Logic generates a health event and writes a message with level “error” to the [system event index](/docs/manage/security/audit-indexes/system-event-index/). Enter a query to `_index=sumologic_system_events` to see events in the system event index.
 

--- a/docs/metrics/manage-metric-volume/index.md
+++ b/docs/metrics/manage-metric-volume/index.md
@@ -36,4 +36,10 @@ In this section, we'll introduce the following concepts:
   <p>Get information on how Sumo Logic throttles metric when metrics ingestion exceeds your DPM limit.</p>
   </div>
 </div>
+<div className="box smallbox card">
+  <div className="container">
+  <a href={useBaseUrl('docs/metrics/source-and-collector-cardinality')}><img src={useBaseUrl('img/icons/metrics.png')} alt="Metrics icon" width="40"/><h4>Source and Collector Wise Cardinality</h4></a>
+  <p>Identify and analyze source and collector-level cardinality to pinpoint high-cardinality sources.</p>
+  </div>
+</div>
 </div>

--- a/docs/metrics/source-and-collector-cardinality.md
+++ b/docs/metrics/source-and-collector-cardinality.md
@@ -4,21 +4,9 @@ title: Source and Collector Wise Cardinality
 sidebar_label: Source and Collector Wise Cardinality
 description: Identify and analyze source and collector-level cardinality using audit logs to pinpoint high-cardinality sources.
 ---
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
-<head>
- <meta name="robots" content="noindex" />
-</head>
-
-<p><a href={useBaseUrl('docs/preview')}><span className="preview-private">Private Preview</span></a></p>
-
-:::info
-This feature is in Private Preview. For more information, contact your Sumo Logic account representative.
-:::
-
 This document explains how to identify and analyze cardinality ingested per source and collector, helping you pinpoint high-cardinality sources and manage ingestion limits more effectively.
 
-Previously, there was no direct visibility into the contribution of cardinality from individual sources. When limits were exceeded, there was limited control over which sources were paused. As a result, [sources that were not significant contributors could be paused](/docs/metrics/manage-metric-volume/disabled-metrics-sources/), while the actual high-cardinality sources remained active. This lack of source-level visibility made it difficult to accurately identify and address the root cause of high cardinality.
+Previously, there was no direct visibility into the contribution of cardinality from individual sources. When limits were exceeded, [sources were paused based on total cardinality](/docs/metrics/manage-metric-volume/disabled-metrics-sources/), which could affect stable high-volume sources that were not responsible for the breach. This lack of source-level visibility made it difficult to accurately identify and address the root cause of high cardinality.
 
 To address this, you can now run a query to identify total cardinality and cardinality at the source level and analyze which sources contribute the most within a given collector. This enables more targeted actions and helps avoid unnecessary impact on other sources.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1824,6 +1824,7 @@ module.exports = {
         'metrics/manage-metric-volume/disabled-metrics-sources',
         'metrics/manage-metric-volume/metric-ingestion-and-storage',
         'metrics/manage-metric-volume/metric-throttling',
+        'metrics/source-and-collector-cardinality',
       ],
     },
     'metrics/metric-rules-editor',


### PR DESCRIPTION
## Purpose of this pull request

Updates the metrics cardinality documentation to reflect two changes shipped in SUMO-279244:

1. **Improved source pausing logic** (`disabled-metrics-sources.md`) — Updated the "Sources are disabled when you reach the global limits" section to describe the new growth-rate-based ranking. Sources are now paused in descending order of cardinality growth (last 7 days vs. prior 7 days) rather than by highest current cardinality. Stable high-volume sources are no longer unnecessarily targeted.

2. **GA promotion** (`source-and-collector-cardinality.md`) — Removed the Private Preview badge, `noindex` meta tag, and Private Preview info callout. Updated the intro paragraph to align with the new pausing behavior.

3. **Navigation wiring** — Added the Source and Collector Wise Cardinality page to `sidebars.ts` (under Managing Metrics Volume), `manage-metric-volume/index.md`, and `metrics/index.md`.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1698