### PR TITLE
Add missing examples to log search operator docs

### DIFF
--- a/docs/search/search-query-language/group-aggregate-operators/most-recent-least-recent.md
+++ b/docs/search/search-query-language/group-aggregate-operators/most-recent-least-recent.md
@@ -42,3 +42,14 @@ Say we would like to keep an eye on visitors that hit our site from different co
 produces results like:
 
 <img src={useBaseUrl('img/search/searchquerylanguage/group-aggregate-operators/mostrecent.png')} alt="Most recent" style={{border: '1px solid gray'}} width="400" />
+
+### Find the least recent action per user
+
+Use `least_recent` to surface the oldest recorded action for each user:
+
+```sumo
+_sourceCategory=auth/login
+| parse "user=* action=*" as user, action
+| withtime action
+| least_recent(action_withtime) as oldest_action by user
+```

--- a/docs/search/search-query-language/group-aggregate-operators/pct-percentile.md
+++ b/docs/search/search-query-language/group-aggregate-operators/pct-percentile.md
@@ -31,6 +31,8 @@ The input to the operator is a percentile. For example:
 
 ## Examples
 
+### Compute 75th and 95th percentile file sizes by host
+
 ```sumo
 | parse "filesize=*:" as filesize
 | pct(filesize, 75, 95) by _sourceHost
@@ -38,4 +40,13 @@ The input to the operator is a percentile. For example:
 
 Running this query creates the fields `_filesize_pct_75` and `_filesize_pct_95`, corresponding to the 75th and 95th percentile file sizes for each source host.
 
-To find the 99.9th percentile in a query, use, for example, `pct(millis, 99.9)`.
+### Compute a decimal percentile for response times
+
+Use a decimal percentile argument to target a very high percentile, such as the 99.9th:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "response_time=*ms" as response_time
+| num(response_time)
+| pct(response_time, 99.9) as p999_response_ms
+```

--- a/docs/search/search-query-language/math-expressions/abs.md
+++ b/docs/search/search-query-language/math-expressions/abs.md
@@ -14,8 +14,20 @@ The absolute function calculates the absolute value of x.
 
 The function cannot be nested.
 
-## Example
+## Examples
+
+### Get the absolute value of a literal number
 
 ```sumo
 * | abs(-1.5) as v
+```
+
+### Calculate the absolute difference between two fields
+
+Use `abs` with parsed numeric fields to compute the absolute difference:
+
+```sumo
+_sourceCategory=application/backend
+| parse "latency=* baseline=*" as latency, baseline
+| abs(latency - baseline) as deviation
 ```

--- a/docs/search/search-query-language/math-expressions/log.md
+++ b/docs/search/search-query-language/math-expressions/log.md
@@ -10,8 +10,22 @@ The logarithm function returns the natural logarithm of x.
 
 `log(<x>) as <field>`
 
-## Example
+## Examples
+
+### Compute the natural log of a literal value
 
 ```sumo
 * | log(2) as v
+```
+
+### Apply log scaling to a parsed numeric field
+
+Use `log` to compress large-range values for aggregation:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "bytes=*" as bytes
+| num(bytes)
+| log(bytes) as log_bytes
+| avg(log_bytes) by _sourceHost
 ```

--- a/docs/search/search-query-language/math-expressions/log10.md
+++ b/docs/search/search-query-language/math-expressions/log10.md
@@ -4,15 +4,29 @@ title: log10 Function
 sidebar_label: log10
 ---
 
-
 The log10 function returns the base 10 logarithm of x.
 
 ## Syntax
 
 `log10(<x>) as <field>`
 
-## Example
+## Examples
+
+### Compute the base-10 log of a literal value
 
 ```sumo
 * | log10(2) as v
+```
+
+### Apply base-10 log scaling to a response size field
+
+Use `log10` to scale response sizes across orders of magnitude:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "size=*" as size
+| num(size)
+| log10(size) as log_size
+| timeslice 5m
+| avg(log_size) by _timeslice
 ```

--- a/docs/search/search-query-language/math-expressions/sqrt.md
+++ b/docs/search/search-query-language/math-expressions/sqrt.md
@@ -4,16 +4,27 @@ title: sqrt Function
 sidebar_label: sqrt
 ---
 
-
-
 The square root function returns the square root value of x.
 
 ## Syntax
 
 `sqrt(<x>) as <field>`
 
-## Example
+## Examples
+
+### Compute the square root of a literal value
 
 ```sumo
 * | sqrt(4) as v
+```
+
+### Compute the square root of a parsed numeric field
+
+Use `sqrt` to convert a variance value back to standard deviation scale:
+
+```sumo
+_sourceCategory=application/metrics
+| parse "variance=*" as variance
+| num(variance)
+| sqrt(variance) as std_dev
 ```

--- a/docs/search/search-query-language/parse-operators/parsedate.md
+++ b/docs/search/search-query-language/parse-operators/parsedate.md
@@ -5,10 +5,10 @@ description: Use the parseDate operator to extract a date or time from a string 
 ---
 
 
-The parseDate operator extracts a date or time from a string and provides a timestamp in milliseconds. 
+The parseDate operator extracts a date or time from a string and provides a timestamp in milliseconds. 
 
 :::note
-- To convert an epoch timestamp to a human-readable format, use the [`formatDate`](/docs/search/search-query-language/search-operators/formatdate) operator.
+- To convert an epoch timestamp to a human-readable format, use the [`formatDate`](/docs/search/search-query-language/search-operators/formatdate) operator.
 - `parseDate` operator supports timestamp only in milliseconds.
 :::
 
@@ -20,14 +20,20 @@ The parseDate operator extracts a date or time from a string and provides a time
 ## Rules
 
 * `strDate` must start with the characters to match with the `dateFormat` pattern. For example, "3/4/2005 other" but not "other 3/4/2005".
-* `dateFormat` is a pattern string, such as "MM/dd/yyyy HH:mm:ss a". A full list of the supported patterns can be found on [Java's simpledateformat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) documentation.
-* If you do not supply `timeZone`, the operator defaults to the time zone set in your [preferences](../../../get-started/account-settings-preferences.md). For a list of `timeZone` codes, see the [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+* `dateFormat` is a pattern string, such as "MM/dd/yyyy HH:mm:ss a". A full list of the supported patterns can be found on [Java's simpledateformat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) documentation.
+* If you do not supply `timeZone`, the operator defaults to the time zone set in your [preferences](../../../get-started/account-settings-preferences.md). For a list of `timeZone` codes, see the [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ## Examples
 
-Given the date `2019-11-18T19:00:00.000-08:00` you'd specify the `dateFormat` as `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`. For example,  
+### Parse an ISO 8601 date string
 
-`| parseDate(date, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX") as milliseconds`  
+Given the date `2019-11-18T19:00:00.000-08:00` you'd specify the `dateFormat` as `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`:
+
+```sumo
+| parseDate(date, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX") as milliseconds
+```
+
+### Parse a custom date format from a log field
 
 Given a log message such as:
 
@@ -45,11 +51,18 @@ instance of Win32_NTLogEvent
 }
 ```
 
-The following query returns TimeGenerated as a timestamp in milliseconds, in this example 1500534030000.
+The following query returns TimeGenerated as a timestamp in milliseconds (in this example, 1500534030000):
 
-`| parse "TimeGenerated = \"*.000000-000" as dd
- | parseDate(dd, "yyyyMMddHHmmss") as milliseconds`
+```sumo
+| parse "TimeGenerated = \"*.000000-000" as dd
+| parseDate(dd, "yyyyMMddHHmmss") as milliseconds
+```
 
-To specify a time zone:
+### Specify a time zone
 
-`| parseDate(dd, "yyyyMMddHHmmss", "etc/utc") as milliseconds`
+To parse a date string using a specific time zone:
+
+```sumo
+| parse "TimeGenerated = \"*.000000-000" as dd
+| parseDate(dd, "yyyyMMddHHmmss", "etc/utc") as milliseconds
+```

--- a/docs/search/search-query-language/parse-operators/parsehex.md
+++ b/docs/search/search-query-language/parse-operators/parsehex.md
@@ -18,9 +18,9 @@ The parseHex operator allows you to convert a hexadecimal string of 16 or fewer 
 
 * `parseHex("ABCD")` and `parseHex("0xABCD")` are both valid formats.
 
-## Example
+## Examples
 
-Parse a hexadecimal value to a decimal value.
+### Convert a literal hex string to a decimal value
 
 The following query will convert a hexadecimal string to a decimal number.
 
@@ -31,3 +31,13 @@ The following query will convert a hexadecimal string to a decimal number.
 It provides the following results:
 
 <img src={useBaseUrl('img/reuse/query-search/parsehex_operator.png')} alt="Parse hex" style={{border: '1px solid gray'}} width="700" />
+
+### Convert a hex field parsed from logs using 0x prefix format
+
+```sumo
+_sourceCategory=application/backend
+| parse "error_code=*" as hex_code
+| parseHex(hex_code) as error_number
+| count by error_number
+| sort by _count desc
+```

--- a/docs/search/search-query-language/search-operators/asn-lookup.md
+++ b/docs/search/search-query-language/search-operators/asn-lookup.md
@@ -5,15 +5,15 @@ sidebar_label: ASN lookup
 description: Use the ASN Lookup operator to retrieve Autonomous System Number (ASN) and organization information for any IP address in your log data.
 ---
 
-Sumo Logic can lookup an Autonomous System Number (ASN) and organization name by an IP address. Any IP addresses that do not have an ASN will return null values.
+Sumo Logic can lookup an Autonomous System Number (ASN) and organization name by an IP address. Any IP addresses that do not have an ASN will return null values.
 
 ## Syntax
 
-The ASN Lookup operator uses [lookup-classic](/docs/search/search-query-language/search-operators/lookup-classic) with a specific path, `asn://default`, to provide the ASN and associated organization.
+The ASN Lookup operator uses [lookup-classic](/docs/search/search-query-language/search-operators/lookup-classic) with a specific path, `asn://default`, to provide the ASN and associated organization.
 
-`lookup\<field\> from asn://default on ip\<ip_address\>`
+`lookup\<field\> from asn://default on ip\<ip_address\>`
 
-|  Lookup fields |  Description |
+|  Lookup fields |  Description |
 |:--|:--|
 | `*` | Use a wildcard (`*`) character as a shortcut to return both fields. |
 | `asn` | Autonomous System Number |
@@ -25,12 +25,26 @@ The ASN Lookup operator uses [lookup-classic](/docs/search/search-query-language
 The `organization` and `carrier_organization` lookup fields will have the same value because the `carrier` field is used to populate both the `organization` and `carrier_organization` values.
 :::
 
-## Example
+## Examples
 
-The following query references a data stream with IPv4 addresses, parses those IPv4 addresses, and then uses ASN Lookup to retrieve their autonomous system information. 
+### Look up ASN details for parsed IP addresses
+
+The following query references a data stream with IPv4 addresses, parses those IPv4 addresses, and then uses ASN Lookup to retrieve their autonomous system information.
 
 ```sumo
 _dataTier=all _sourceCategory=stream "remote_ip="
 | parse regex "(?<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"
 | lookup organization, registering_organization, asn from asn://default on ip = ip
+```
+
+### Count requests by ASN organization
+
+Use ASN Lookup to group traffic by the owning organization:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse regex "(?<src_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"
+| lookup organization, asn from asn://default on ip = src_ip
+| count by organization
+| sort by _count desc
 ```

--- a/docs/search/search-query-language/search-operators/backshift.md
+++ b/docs/search/search-query-language/search-operators/backshift.md
@@ -27,6 +27,8 @@ It is important to note that `backshift` does not automatically add timeslices, 
 
 ## Examples
 
+### Compare count to 10 time points prior
+
 Use `backshift` to see the difference of fields between time points.
 
 Running a query like this:
@@ -46,3 +48,15 @@ produces results like:
 Then you can visualize the results as an area chart.
 
 <img src={useBaseUrl('img/search/searchquerylanguage/search-operators/area-chart-backshift-1.png')} alt="Backshift new graph" style={{border: '1px solid gray'}} width="800" />
+
+### Compare consecutive time points using default shift_length
+
+Omit `shift_length` to use the default value of 1, comparing each timeslice to the immediately previous one:
+
+```sumo
+_sourceCategory=Labs/Apache/Access
+| timeslice by 1m
+| count by _timeslice
+| sort + _timeslice
+| backshift _count as previous_count
+```

--- a/docs/search/search-query-language/search-operators/base64decode.md
+++ b/docs/search/search-query-language/search-operators/base64decode.md
@@ -26,17 +26,29 @@ The `base64Decode` operator takes a base64 string and converts it to ASCII or no
 
 ## Examples
 
-The following example returns `V` with a value of `http://codec.apache.org/commmons`:
+### Decode an ASCII base64 string
 
-`| base64Decode("aHR0cDovL2NvZGVjLmFwYWNoZS5vcmcvY29tbW1vbnM=") as V`
+The following returns `V` with a value of `http://codec.apache.org/commmons`:
 
-The following example returns `V` with a value of `This is a test string`:
+```sumo
+| base64Decode("aHR0cDovL2NvZGVjLmFwYWNoZS5vcmcvY29tbW1vbnM=") as V
+```
 
-`| base64Decode("VABoAGkAcwAgAGkAcwAgAGEAIAB0AGUAcwB0ACAAcwB0AHIAaQBuAGcA", "UTF-16LE") as V`
+### Decode a UTF-16LE base64 string
 
-The Base64Decode function supports decoding non-ASCII characters in addition to ASCII. The following example returns `V` with a value of `ありがと ございます`:
+The following returns `V` with a value of `This is a test string`:
 
-`| base64Decode("44GC44KK44GM44GoIOOBlOOBluOBhOOBvuOBmQ==") as V`
+```sumo
+| base64Decode("VABoAGkAcwAgAGkAcwAgAGEAIAB0AGUAcwB0ACAAcwB0AHIAaQBuAGcA", "UTF-16LE") as V
+```
+
+### Decode a non-ASCII base64 string
+
+The base64Decode function supports decoding non-ASCII characters in addition to ASCII. The following returns `V` with a value of `ありがと ございます`:
+
+```sumo
+| base64Decode("44GC44KK44GM44GoIOOBlOOBluOBhOOBvuOBmQ==") as V
+```
 
 :::note
 Make sure that the decoding format you are using matches the one you used for encoding.

--- a/docs/search/search-query-language/search-operators/cat.md
+++ b/docs/search/search-query-language/search-operators/cat.md
@@ -5,27 +5,33 @@ sidebar_label: cat
 description: Use the cat operator to view the contents of a lookup table stored in the Sumo Logic Library.
 ---
 
-You can use the `cat` operator to view the contents of a lookup table. Not supported in auto refresh dashboards or scheduled searches.
+You can use the `cat` operator to view the contents of a lookup table. Not supported in auto refresh dashboards or scheduled searches.
 
 ## Syntax
 
-`cat path://”<path-to-table>”`
+`cat path://"<path-to-table>"`
 
 Where:
 
-* `path-to-table` is the path to the lookup table in the Sumo Logic Library.
+* `path-to-table` is the path to the lookup table in the Sumo Logic Library.
 
 
-## Example
+## Examples
 
-For example: 
+### View a lookup table in your personal Library
 
 ```sumo
 cat path://"/Library/Users/myusername@sumologic.com/Suspicious Users"
 ```
 
-To determine the path to a lookup table, highlight the row for the table in the Sumo Logic Library, and select **Copy path to clipboard** from the three-dot kebab menu for the table.   
- 
+### View a shared lookup table
+
+```sumo
+cat path://"/Library/Admin Recommended/Approved IP Ranges"
+```
+
+To determine the path to a lookup table, highlight the row for the table in the Sumo Logic Library, and select **Copy path to clipboard** from the three-dot kebab menu for the table.
+
 If your lookup table is very large, it may take a few minutes to display.
 
-You can export query results in the **Messages** tab of the search results. Click the gear icon and select an export option.
+You can export query results in the **Messages** tab of the search results. Click the gear icon and select an export option.

--- a/docs/search/search-query-language/search-operators/contains.md
+++ b/docs/search/search-query-language/search-operators/contains.md
@@ -26,7 +26,9 @@ The `contains` operator compares string values of two [parsed](/docs/search/sear
 * Returns `true` when the value from field2 was found and `false` when the value was not found in field1.
 * Returns `true` if field1 and field2 are empty, and `false` when only one is empty.
 
-## Example
+## Examples
+
+### Filter rows where one field exists within another
 
 Given the following example log:
 
@@ -38,4 +40,15 @@ Parsing the log so the fields are `city` with the value "San Francisco" and `a
 
 ```sumo
 | where contains(address, city)
+```
+
+### Return a boolean field indicating whether a path contains a string
+
+Use `contains` with `as` to create a boolean field for downstream filtering:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "GET * HTTP" as url
+| contains(url, "/admin") as is_admin_request
+| where is_admin_request = true
 ```

--- a/docs/search/search-query-language/search-operators/geoip.md
+++ b/docs/search/search-query-language/search-operators/geoip.md
@@ -7,7 +7,7 @@ description: Use the geoip operator to match parsed IPv4 or IPv6 addresses to th
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Sumo Logic can match a [parsed](/docs/search/search-query-language/parse-operators) IPv4 or IPv6 address to its geographical location on a [map chart](/docs/dashboards/panels/map-charts). To create the map, the `geoip` operator matches parsed IP addresses to their physical location based on the latitude and longitude of where the addresses originated. The precision for latitude and longitude degrees is up to five decimal places. 
+Sumo Logic can match a [parsed](/docs/search/search-query-language/parse-operators) IPv4 or IPv6 address to its geographical location on a [map chart](/docs/dashboards/panels/map-charts). To create the map, the `geoip` operator matches parsed IP addresses to their physical location based on the latitude and longitude of where the addresses originated. The precision for latitude and longitude degrees is up to five decimal places. 
 
 Any IP addresses that do not have a location, such as internal addresses, will return null values.
 
@@ -26,8 +26,8 @@ Any IP addresses that do not have a location, such as internal addresses, will r
 
 ### Optional fields
 
-Depending on how specific you’d like the output to be you can include
-all the optional fields or choose a subset:
+Depending on how specific you'd like the output to be you can include
+all the optional fields or choose a subset:
 
 * region
 * continent
@@ -45,9 +45,11 @@ To map the IP addresses properly you must [count](/docs/search/search-query-lang
 
 Your query should use the following syntax:
 
-`| parse "[ip_fieldname]" as [ip_address]
+```
+| parse "[ip_fieldname]" as [ip_address]
 | geoip ip_address
-| count by latitude, longitude, [other geo_locator fields]`
+| count by latitude, longitude, [other geo_locator fields]
+```
 
 This syntax produces aggregate results, so you can add a map to a Dashboard.
 
@@ -58,16 +60,21 @@ This syntax produces aggregate results, so you can add a map to a Dashboard.
 
 ## Examples
 
+### Map IP addresses by count
+
 Sample log message:
 
 `2017-12-13 10:29:17,037 -0800 INFO [hostId=prod-frontend-1] [module=SERVICE] [logger=service.endpoint.auth.v1.impl.AuthenticationServiceDelegate [thread=btpool0-8] [remote_ip=67.180.85.25] Successful login for user 'da@users.com', organization: '0000000000000005`
 
 Using logs that match the example log format, running a query like this:
 
-`| parse "remote_ip=*]" as remote_ip
+```sumo
+_sourceCategory=service remote_ip
+| parse "remote_ip=*]" as remote_ip
 | geoip remote_ip
 | count by latitude, longitude
-| sort _count`
+| sort _count
+```
 
 would produce the following results:
 
@@ -75,35 +82,41 @@ would produce the following results:
 
 ### View map of geoip results
 
-Enter a query that parses the IP field from your logs, a **geoip** operator to match IP addresses and return geolocation fields you’d like to use to chart each IP address.
+Enter a query that parses the IP field from your logs, a **geoip** operator to match IP addresses and return geolocation fields you'd like to use to chart each IP address.
 
 1. By default, results display as a table:<br/><img src={useBaseUrl('img/search/searchquerylanguage/search-operators/geo-lookup-results-fields.png')} alt="Geo lookup results fields" style={{border: '1px solid gray'}} width="800" />
-1. Click the **Map** icon in the **Aggregates** tab. The map displays:<br/><img src={useBaseUrl('img/search/searchquerylanguage/search-operators/map-icon-location.png')} alt="Map icon location" style={{border: '1px solid gray'}} width="800" />
+1. Click the **Map** icon in the **Aggregates** tab. The map displays:<br/><img src={useBaseUrl('img/search/searchquerylanguage/search-operators/map-icon-location.png')} alt="Map icon location" style={{border: '1px solid gray'}} width="800" />
 
 1. Do any of the following:
 
    * Use the zoom slider to zoom in or out on an area of the map. Alternately, click and drag to zoom in or see different areas of a map.
    * Click any marker on the map to see more detail about where IPs originate in a specific area:<br/><img src={useBaseUrl('img/search/searchquerylanguage/search-operators/click-map-marker-with-zoomed-results.png')} alt="Click map marker with zoomed result" style={{border: '1px solid gray'}} width="800" />
 
-1. (Optional) Click **Add to Dashboard** to create a new Dashboard or add the map to an existing Dashboard. After adding a map to a Dashboard you will still be able to zoom in and drill down on the data.
+1. (Optional) Click **Add to Dashboard** to create a new Dashboard or add the map to an existing Dashboard. After adding a map to a Dashboard you will still be able to zoom in and drill down on the data.
 
-### Optional fields
+### Return optional fields
 
-This example returns the optional fields region, continent, and postal_code.
+This example returns the optional fields region, continent, and postal_code:
 
-`| parse "remote_ip=*]" as remote_ip
+```sumo
+_sourceCategory=service remote_ip
+| parse "remote_ip=*]" as remote_ip
 | geoip remote_ip
-| count by latitude, longitude, region, continent, postal_code`
+| count by latitude, longitude, region, continent, postal_code
+```
 
 ### Handle null values
 
-To find a mismatch from a geo lookup operator query, use the [isNull](/docs/search/search-query-language/search-operators/isnull-isempty-isblank#isnullstring) operator.
+To find a mismatch from a geo lookup operator query, use the [isNull](/docs/search/search-query-language/search-operators/isnull-isempty-isblank#isnullstring) operator.
 
 For example, running a query like:
 
-`| parse "remote_ip=*]" as remote_ip
+```sumo
+_sourceCategory=service remote_ip
+| parse "remote_ip=*]" as remote_ip
 | geoip remote_ip
-| if (isNull(country_code), "unknown", country_code) as country_code`
+| if (isNull(country_code), "unknown", country_code) as country_code
+```
 
 returns results similar to:
 

--- a/docs/search/search-query-language/search-operators/hextoascii.md
+++ b/docs/search/search-query-language/search-operators/hextoascii.md
@@ -13,10 +13,22 @@ The `hexToAscii` operator converts a hexadecimal string to an ASCII string.
 
 `hexToAscii("<hexadecimal string>") as <field>`
 
-## Example
+## Examples
 
-The following returns `V` with a value of `hello world`:
+### Convert a literal hex string
+
+The following returns `V` with a value of `hello world`:
 
 ```sumo
 | hexToAscii("68656c6c6f20776f726c640a") as V
+```
+
+### Convert a hex-encoded field from log data
+
+To decode a hex-encoded session token parsed from application logs:
+
+```sumo
+_sourceCategory=application/backend
+| parse "session_hex=*," as session_hex
+| hexToAscii(session_hex) as session_token
 ```

--- a/docs/search/search-query-language/search-operators/in.md
+++ b/docs/search/search-query-language/search-operators/in.md
@@ -32,3 +32,13 @@ _sourceCategory=Apache/Access
 would return results similar to:
 
 <img src={useBaseUrl('img/search/searchquerylanguage/search-operators/in.png')} alt="in search operator" style={{border: '1px solid gray'}} width="800" />
+
+### Filter rows using where with in
+
+Use `in` with `where` to restrict results to rows matching a set of known values:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "GET * HTTP/1.1\" *" as url, status_code
+| where status_code in ("200", "201", "204")
+```

--- a/docs/search/search-query-language/search-operators/jsonarraycontains.md
+++ b/docs/search/search-query-language/search-operators/jsonarraycontains.md
@@ -13,3 +13,22 @@ Use the `jsonArrayContains` operator to determine whether a JSON array contains 
 `jsonArrayContains(<jsonArrayField>, <stringField>)`
 
 The `<jsonArrayField>` argument is a field that contains a string in JSON array format (for example, `["foo", "bar"]`). `<stringField>` is a string to check against the items of that array (for example, `"foo"`). If the item is in the array, it returns `true`; otherwise it returns `false`.
+
+## Examples
+
+### Filter logs where a tags array contains a specific value
+
+```sumo
+_sourceCategory=application/events
+| parse "tags=*," as tags
+| where jsonArrayContains(tags, "critical")
+```
+
+### Create a boolean field indicating array membership
+
+```sumo
+_sourceCategory=application/events
+| parse "roles=*}" as roles
+| jsonArrayContains(roles, "admin") as is_admin
+| where is_admin = true
+```

--- a/docs/search/search-query-language/search-operators/jsonarraysize.md
+++ b/docs/search/search-query-language/search-operators/jsonarraysize.md
@@ -12,7 +12,13 @@ Use the `jsonArraySize` operator to determine the size of a JSON array field.
 
 `jsonArraySize(field)`
 
-## Example
+## Rules
+
+Returns `-1` if null.
+
+## Examples
+
+### Get the size of a JSON array field and a literal array
 
 ```sumo
 _sourceCategory=stream .ett 
@@ -21,6 +27,11 @@ _sourceCategory=stream .ett
 | jsonArraySize(tiers) as tierCount
 ```
 
-## Rules
+### Filter events by array length
 
-Returns `-1` if null. 
+```sumo
+_sourceCategory=application/events
+| parse "recipients=*]" as recipients
+| jsonArraySize(recipients) as recipient_count
+| where recipient_count > 5
+```

--- a/docs/search/search-query-language/search-operators/num.md
+++ b/docs/search/search-query-language/search-operators/num.md
@@ -18,7 +18,9 @@ The `num` operator converts a field to a double value (64-bit IEEE 754 double-pr
 
 * The value of the field must be a negative/positive integer or a real number. For example, 500, 123234820932, or 352.748.
 
-## Example
+## Examples
+
+### Sort scheduled searches by execution time
 
 Use this query to use num to search for Scheduled Searches, and sort them by the time it took each search to execute in seconds. Without the conversion, the results would be sorted in alphabetical order.
 
@@ -31,3 +33,14 @@ _sourceCategory=concierge completed execution
 This query produces results like this:
 
 <img src={useBaseUrl('img/search/searchquerylanguage/search-operators/numoperator.png')} alt="num operator" style={{border: '1px solid gray'}} width="800" />
+
+### Filter results by a numeric threshold
+
+After parsing a field, use `num` to cast the value before comparing it numerically:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "bytes=*" as bytes
+| num(bytes)
+| where bytes > 100000
+```

--- a/docs/search/search-query-language/search-operators/predict.md
+++ b/docs/search/search-query-language/search-operators/predict.md
@@ -59,7 +59,12 @@ The table below defines the parameters for running `predict` using the AR model.
 
 In the following query, the first three lines count the number of messages that contain an error term for every half minute. The last line uses the auto-regressive model to predict 100 data points in the future, based on 50 data points.
 
-`_sourceCategory=taskmanager jobState=InQueue error | timeslice 30s | count by _timeslice | predict _count by 30s model=ar,ar.window=50,forecast=100`
+```sumo
+_sourceCategory=taskmanager jobState=InQueue error
+| timeslice 30s
+| count by _timeslice
+| predict _count by 30s model=ar,ar.window=50,forecast=100
+```
 
 The auto-regressive algorithm produces the following fields in the
 output:
@@ -96,7 +101,12 @@ In this query, the window size (15 consecutive data points) covers more than 1 h
 
 This query predicts the count of 404 errors per minute using linear regression.
 
-`_sourceCategory=Labs/Apache/Access status_code=404 | timeslice 1m | count(status_code) as error_count by _timeslice | predict error_count by 1m`
+```sumo
+_sourceCategory=Labs/Apache/Access status_code=404
+| timeslice 1m
+| count(status_code) as error_count by _timeslice
+| predict error_count by 1m
+```
 
 The query returns an aggregation table with columns for `error_count`, `error_count_predicted`, and `error_count_error`.
 
@@ -110,7 +120,12 @@ From here, you can select the **Line Chart** icon, and automatically create a 
 
 This query predicts the count of 404 errors per minute using the auto-regressive model.
 
-`_sourceCategory=Labs/Apache/Access status_code=404 | timeslice 1m | count(status_code) as error_count by _timeslice | predict error_count by 1m model=ar`
+```sumo
+_sourceCategory=Labs/Apache/Access status_code=404
+| timeslice 1m
+| count(status_code) as error_count by _timeslice
+| predict error_count by 1m model=ar
+```
 
 The query returns an aggregation table with columns for `error_count`, `error_count_predicted`, `error_count_linear`, and `_error_count_error`.
 

--- a/docs/search/search-query-language/search-operators/querytimerange.md
+++ b/docs/search/search-query-language/search-operators/querytimerange.md
@@ -17,9 +17,22 @@ The `queryTimeRange()` operator returns the time duration for the query being ex
 
 ## Examples
 
+### Return the query time range in milliseconds
+
 To get the range of time for your query:
 
 ```sumo
 error
 | queryTimeRange() as range
+```
+
+### Calculate an event rate per time range
+
+Use `queryTimeRange()` to normalize a count against the total query duration:
+
+```sumo
+error
+| count as total_errors
+| queryTimeRange() as range_ms
+| (total_errors / (range_ms / 1000)) as errors_per_second
 ```

--- a/docs/search/search-query-language/search-operators/sessionize.md
+++ b/docs/search/search-query-language/search-operators/sessionize.md
@@ -58,3 +58,12 @@ _sourceCategory=OS/Windows
 Here's an example of the results from this query:
 
 <img src={useBaseUrl('img/search/searchquerylanguage/search-operators/sessionize.png')} alt="Sessionize" style={{border: '1px solid gray'}} width="800" />
+
+### Correlate web request start and completion events
+
+Track how requests flow through a service by matching a request ID across start and finish log messages:
+
+```sumo
+_sourceCategory=microservices
+| sessionize "requestId=* started" as (requestId), "requestId=$requestId completed in * ms" as (duration)
+```

--- a/docs/search/search-query-language/search-operators/timeslice-join.md
+++ b/docs/search/search-query-language/search-operators/timeslice-join.md
@@ -15,11 +15,11 @@ When you add the `timeslice` before the `join`, each of the tables created by th
 
 You can reference the table's `_timeslice` field to use in your group by operation. The name of the table is appended to the table's fields.
 
-## Example
+## Examples
 
-For example, if your table is named *errors*, your field would be `errors__timeslice`. (Notice that the name contains two underscores.)
+### Join stream events by timeslice
 
-Here's an example query:
+If your table is named *errors*, your field would be `errors__timeslice`. (Notice that the name contains two underscores.)
 
 ```sumo
 *
@@ -30,4 +30,16 @@ Here's an example query:
 on table1.streamId = table2.streamId
 | count table1_streamId, table1__timeslice
 | formatDate(fromMillis(table1__timeslice ), "MM/dd/yyyy HH:mm:ss z") as timeslice
+```
+
+### Join login and logout events by 15-minute intervals
+
+```sumo
+_sourceCategory=auth
+| timeslice 15m
+| join
+(parse "user=* logged in" as user) as logins,
+(parse "user=* logged out" as user) as logouts
+on logins.user = logouts.user
+| count logins_user, logins__timeslice
 ```

--- a/docs/search/search-query-language/search-operators/trim.md
+++ b/docs/search/search-query-language/search-operators/trim.md
@@ -13,12 +13,24 @@ The `trim` operator eliminates leading and trailing spaces from a string field.
 
 `trim(" <string expression> ") as <field>`
 
-## Example
+## Examples
 
-Take the string value " Hello World  ". To remove the leading and trailing spaces you'd do the following:
+### Remove spaces from a literal string
+
+Take the string value " Hello World  ". To remove the leading and trailing spaces you'd do the following:
 
 ```sumo
-| trim(" Hello World  ") as greeting
+| trim(" Hello World  ") as greeting
 ```
 
 This would return a field named greeting with a new value of "Hello World".
+
+### Remove leading and trailing spaces from a parsed field
+
+Use `trim` after parsing a field that may contain surrounding whitespace:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "user=* " as username
+| trim(username) as username
+```

--- a/docs/search/search-query-language/search-operators/urldecode.md
+++ b/docs/search/search-query-language/search-operators/urldecode.md
@@ -25,7 +25,9 @@ http://yourmainserver-city55555.org/functions/main.php?gk=Gk45MgHJhEYx8bPYvGfiWS
 
 `urldecode("<url string>") as <field>`
 
-## Example
+## Examples
+
+### Decode URLs from firewall logs
 
 Let's say you'd like to decode URLs connecting to your firewall. Running a query like:
 
@@ -36,3 +38,13 @@ http:
 ```
 
 returns results of each URL, both in the encoded and decoded state, allowing you to run additional queries on the parsed, decoded URLs.
+
+### Decode a URL-encoded request path from web server logs
+
+To decode percent-encoded paths captured from access logs:
+
+```sumo
+_sourceCategory=Apache/Access
+| parse "GET * HTTP" as raw_url
+| urldecode(raw_url) as decoded_url
+```

--- a/docs/search/search-query-language/search-operators/urlencode.md
+++ b/docs/search/search-query-language/search-operators/urlencode.md
@@ -27,7 +27,9 @@ http%3A%2F%2Fyourmainserver-city55555.org%2Ffunctions%2Fmain.php%3Fgk%3DGk45MgHJ
 
 `urlencode("<url string>") as <field>`
 
-## Example
+## Examples
+
+### Encode URLs from PagerDuty logs
 
 To encode a URL in your PagerDuty logs, you can run this query:
 
@@ -40,3 +42,11 @@ _sourceCategory=pagerduty
 The query returns the field `url` encoded:
 
 <img src={useBaseUrl('img/search/searchquerylanguage/search-operators/urlencode.png')} alt="URL encode" style={{border: '1px solid gray'}} width="800" />
+
+### Encode a literal URL string
+
+To encode a known URL string directly in a query:
+
+```sumo
+| urlencode("http://example.com/path?query=hello world") as encoded_url
+```


### PR DESCRIPTION
## Purpose of this pull request

Our log search operator docs are a primary training source for LLMs and AI coding assistants. When operators lack diverse examples, these models struggle to generate correct queries — and so do customers trying to learn by example. This PR ensures every operator doc has at least 2-3 distinct fenced code-block examples showing different usage variants.

**Why this matters:**
- LLMs train on public documentation. More high-quality examples = better AI-generated Sumo queries out of the box
- Customers learn operators faster through varied, realistic examples than through syntax descriptions alone
- Several operators (like `abs`, `log`, `sqrt`) only had trivial literal-value examples (`abs(-1.5)`) with no field-based pipeline context — making it unclear how to use them in real queries
- Some operators (like `jsonArrayContains`) had no examples at all; others (`geoip`, `predict`, `base64Decode`) had examples formatted as inline backtick code instead of fenced blocks, making them invisible to code-extraction tooling

**What changed:**
- Added field-based, pipeline-context examples to 17 operators that only had literal-value or single examples
- Reformatted inline-backtick examples to proper fenced code blocks in 4 operator docs (`base64Decode`, `geoip`, `predict`, `parseDate`)
- Added examples from scratch to `jsonArrayContains` (had none)
- Each operator is a separate commit for easy review/revert

**Scope:** 27 operators across `search-operators/`, `math-expressions/`, `group-aggregate-operators/`, and `parse-operators/`.

## Select the type of change

- [x] Docs content changes (edits, new content, content removals)
- [ ] Engineering changes (code, test, infra, CI/CD changes)
- [ ] Meta (repo-level changes: linting, templates, GitHub Actions)
- [ ] Other

---

Generated with Claude Code