### PR TITLE
DOCS-1374 - Fix mirror URL example in llms.txt

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -23,7 +23,7 @@
 - Sitemap: https://www.sumologic.com/help/sitemap.xml
 - LLM guidance (this file): https://www.sumologic.com/help/llms.txt
 - All page URLs end with a trailing slash
-- Raw Markdown mirror: every documentation page is available as source Markdown at `/help/llm/docs/{path}.md` (e.g. `https://www.sumologic.com/help/llm/docs/search/get-started-with-search.md`)
+- Raw Markdown mirror: every documentation page is available as source Markdown at `/help/llm/docs/{path}` (e.g. `https://www.sumologic.com/help/llm/docs/alerts/difference-from-scheduled-searches.md` for a single page, or `https://www.sumologic.com/help/llm/docs/alerts/monitors/index.md` for a section index page)
 - Mirror index: `https://www.sumologic.com/help/llm/docs/index.txt` — lists every mirrored path, one per line
 
 ## Content usage

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -113,4 +113,4 @@ The following are not product documentation and should not be used as primary so
 - Documentation questions: documentation@sumologic.com
 - Documentation issues: Use the feedback widget on any documentation page
 - Source code: https://github.com/SumoLogic/sumologic-documentation
-- Last updated: 2026-06-05
+- Last updated: 2026-06-15


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes the raw Markdown mirror URL example in `static/llms.txt`. The previous example used an incorrect path that doesn't exist in the mirror. Updated to show two real URL patterns:

- A single-page example: `/llm/docs/alerts/difference-from-scheduled-searches.md`
- A section index page example: `/llm/docs/alerts/monitors/index.md`

## Select the type of change

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1374