### PR TITLE
DOCS-1711 - Fix merge window to soft-warn for docs-only PRs in merge queue

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check merge window
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Two-tier merge window policy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -241,39 +241,6 @@ jobs:
               return;
             }
 
-            if (context.eventName === 'merge_group') {
-              // merge_group payloads don't include PR labels — extract PR number from head ref
-              // (e.g. refs/heads/gh-readonly-queue/main/pr-1234-abc...) and fetch via API.
-              const headRef = context.payload.merge_group?.head_ref ?? '';
-              const prMatch = headRef.match(/\/pr-(\d+)-/);
-              let hasOverride = false;
-              if (prMatch) {
-                const prNumber = parseInt(prMatch[1], 10);
-                const { data: pr } = await github.rest.pulls.get({
-                  owner:       context.repo.owner,
-                  repo:        context.repo.repo,
-                  pull_number: prNumber,
-                });
-                hasOverride = pr.labels.some(l => l.name === OVERRIDE_LABEL);
-              }
-              if (hasOverride) {
-                core.warning(`active-incident override active — merge queue bypassed: ${siteBlockedReason}`);
-                return;
-              }
-              core.setFailed(
-                `Merge blocked: ${siteBlockedReason}. ` +
-                'Merge queue validation requires the merge window: Mon–Fri, 7:00 am–2:00 pm PT, non-holidays.'
-              );
-              return;
-            }
-
-            // Check override label before fetching files.
-            const labels = context.payload.pull_request?.labels ?? [];
-            if (labels.some(l => l.name === OVERRIDE_LABEL)) {
-              core.warning(`active-incident override active. Bypassed: ${siteBlockedReason}`);
-              return;
-            }
-
             // Classify the PR's changed files to determine enforcement level.
             // Docs, release notes, images, CID redirects, and repo meta files → soft warning only.
             // Everything else (backend site changes) → hard block.
@@ -287,16 +254,71 @@ jobs:
               /^CONTRIBUTING\.md$/,
             ];
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner:       context.repo.owner,
-              repo:        context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page:    100,
-            });
+            async function classifyPR(prNumber) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner:       context.repo.owner,
+                repo:        context.repo.repo,
+                pull_number: prNumber,
+                per_page:    100,
+              });
+              return files.some(f => !ARTICLE_PATTERNS.some(p => p.test(f.filename)));
+            }
 
-            const hasSiteChange = files.some(
-              f => !ARTICLE_PATTERNS.some(p => p.test(f.filename))
-            );
+            function warnOrInfoDocsPR(reason) {
+              const inIndiaHours = WEEKDAYS.has(ist.weekday) && ist.hour >= 8 && !IST_HOLIDAYS.has(ist.date);
+              if (!inIndiaHours) {
+                core.warning(
+                  `Outside recommended merge hours (${reason}, and before 8:00 am IST). ` +
+                  'Docs and release note PRs should generally merge during India or US business hours. ' +
+                  'Proceeding — no action needed unless this is outside a prior arrangement.'
+                );
+              } else {
+                core.info(`Docs/release note PR — India team is active (${ist.weekday} ${ist.hour}:xx IST). Merge allowed.`);
+              }
+            }
+
+            if (context.eventName === 'merge_group') {
+              // merge_group payloads don't include PR labels or files — extract PR number from head ref
+              // (e.g. refs/heads/gh-readonly-queue/main/pr-1234-abc...) and fetch via API.
+              const headRef = context.payload.merge_group?.head_ref ?? '';
+              const prMatch = headRef.match(/\/pr-(\d+)-/);
+              let hasOverride = false;
+              let prNumber = null;
+              if (prMatch) {
+                prNumber = parseInt(prMatch[1], 10);
+                const { data: pr } = await github.rest.pulls.get({
+                  owner:       context.repo.owner,
+                  repo:        context.repo.repo,
+                  pull_number: prNumber,
+                });
+                hasOverride = pr.labels.some(l => l.name === OVERRIDE_LABEL);
+              }
+              if (hasOverride) {
+                core.warning(`active-incident override active — merge queue bypassed: ${siteBlockedReason}`);
+                return;
+              }
+              // Apply the same two-tier policy in the merge queue: hard-block site changes,
+              // soft-warn for docs/release note PRs.
+              const hasSiteChange = prNumber ? await classifyPR(prNumber) : true;
+              if (hasSiteChange) {
+                core.setFailed(
+                  `Merge blocked: ${siteBlockedReason}. ` +
+                  'Merge queue validation requires the merge window: Mon–Fri, 7:00 am–2:00 pm PT, non-holidays.'
+                );
+                return;
+              }
+              warnOrInfoDocsPR(siteBlockedReason);
+              return;
+            }
+
+            // Check override label before fetching files.
+            const labels = context.payload.pull_request?.labels ?? [];
+            if (labels.some(l => l.name === OVERRIDE_LABEL)) {
+              core.warning(`active-incident override active. Bypassed: ${siteBlockedReason}`);
+              return;
+            }
+
+            const hasSiteChange = await classifyPR(context.payload.pull_request.number);
 
             if (hasSiteChange) {
               core.setFailed(
@@ -307,14 +329,4 @@ jobs:
               return;
             }
 
-            // Docs/release note PR — warn if outside India business hours too.
-            const inIndiaHours = WEEKDAYS.has(ist.weekday) && ist.hour >= 8 && !IST_HOLIDAYS.has(ist.date);
-            if (!inIndiaHours) {
-              core.warning(
-                `Outside recommended merge hours (${siteBlockedReason}, and before 8:00 am IST). ` +
-                'Docs and release note PRs should generally merge during India or US business hours. ' +
-                'Proceeding — no action needed unless this is outside a prior arrangement.'
-              );
-            } else {
-              core.info(`Docs/release note PR — India team is active (${ist.weekday} ${ist.hour}:xx IST). Merge allowed.`);
-            }
+            warnOrInfoDocsPR(siteBlockedReason);


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes two issues with the merge window check in `.github/workflows/pr.yml`:

1. **Docs-only PRs hard-blocked in merge queue** — The `merge_group` event path was missing the file classification logic present in the `pull_request` path, causing docs-only PRs to be hard-blocked outside the window instead of passing with a soft warning. Fix hoists `ARTICLE_PATTERNS` and classification into shared helpers used by both paths.

2. **Node.js 20 deprecation warning** — Bumps `actions/github-script` from v7 (Node.js 20) to v8 (Node.js 24) to resolve deprecation warnings on runners that now default to Node.js 24.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1711
https://sumologic.atlassian.net/browse/DOCS-1712