### PR TITLE
DOCS-1712 - Bump actions/github-script from v7 to v8 for Node.js 24

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check merge window
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Two-tier merge window policy:


### PR DESCRIPTION
## Purpose of this pull request

This pull request bumps `actions/github-script` from v7 to v8 to resolve Node.js 20 deprecation warnings on GitHub Actions runners, which now default to Node.js 24.

`github-script` is used in one place (the merge window check in `pr.yml`). The script uses only standard JS features compatible with Node.js 24.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1712