### PR TITLE
update workflows for multi-line commit messages

### DIFF
--- a/.github/workflows/job_pantheon.yml
+++ b/.github/workflows/job_pantheon.yml
@@ -94,14 +94,23 @@ jobs:
           echo "PANTHEON_ENV=helpdocs" >> $GITHUB_ENV
           echo "PANTHEON_BRANCH=$NORMLIZED_STAGING_ENV_NAME" >> $GITHUB_ENV
       - name: Commit build and deploy to Pantheon repo
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          DEFAULT_REASON: "${{ github.workflow }} run #${{ github.run_number }}"
+          PANTHEON_SITE_ID: ${{ inputs.PANTHEON_SITE_ID }}
+          SITE_PATH: ${{ inputs.SITE_PATH }}
         run: |
-          DEFAULT_REASON="${{ github.workflow }} run #${{ github.run_number }}"
-          REASON="DOCS@$(echo "${{ github.sha }}" | cut -c 1-7): ${{ github.event.pull_request.title || github.event.head_commit.message || '$DEFAULT_REASON' }}"
+          set -euo pipefail
+          SHA="$(echo "${{ github.sha }}" | cut -c 1-7)"
+          DETAILS="${PR_TITLE:-${HEAD_COMMIT_MSG:-$DEFAULT_REASON}}"
+          REASON="DOCS@${SHA}: $DETAILS"
+          COMMIT_MESSAGE="$(echo "$REASON" | head -n 1 | tr -d '"`$\\')"
           terminus local:clone --yes --branch="${{ env.PANTHEON_BRANCH }}" ${{ inputs.PANTHEON_SITE_ID }}
           rsync --archive --delete --exclude="cid.php" ./build/ "$HOME/pantheon-local-copies/${{ inputs.PANTHEON_SITE_ID }}/${{ inputs.SITE_PATH }}"
           chmod -R 755 $HOME/pantheon-local-copies/${{ inputs.PANTHEON_SITE_ID }}/${{ inputs.SITE_PATH }}
           git -C "$HOME/pantheon-local-copies/${{ inputs.PANTHEON_SITE_ID }}" add .
-          git -C "$HOME/pantheon-local-copies/${{ inputs.PANTHEON_SITE_ID }}" commit -m "$REASON"
+          git -C "$HOME/pantheon-local-copies/${{ inputs.PANTHEON_SITE_ID }}" commit -m "$COMMIT_MESSAGE"
           WATCH_COMMIT=$(git -C "$HOME/pantheon-local-copies/${{ inputs.PANTHEON_SITE_ID }}" rev-parse --verify HEAD)
           git -C "$HOME/pantheon-local-copies/${{ inputs.PANTHEON_SITE_ID }}" push origin
           terminus workflow:wait --max 600 --commit $WATCH_COMMIT -- ${{ inputs.PANTHEON_SITE_ID }}.${{ env.PANTHEON_ENV }}

--- a/.github/workflows/job_trigger-jenkins-pipeline.yml
+++ b/.github/workflows/job_trigger-jenkins-pipeline.yml
@@ -47,10 +47,17 @@ jobs:
           echo "v4=$IPV4" >> $GITHUB_OUTPUT
       - name: Get cause
         id: cause
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          DEFAULT_REASON: "${{ github.workflow }} run #${{ github.run_number }}"
+          PANTHEON_SITE_ID: ${{ inputs.PANTHEON_SITE_ID }}
+          SITE_PATH: ${{ inputs.SITE_PATH }}
         run: |
-          DEFAULT_DETAILS="${{ github.workflow }} run #${{ github.run_number }}"
-          DETAILS="${{ github.event.pull_request.title || github.event.head_commit.message || '$DEFAULT_DETAILS' }}"
-          REASON="DOCS@$(echo "${{ github.sha }}" | cut -c 1-7): $(echo "$DETAILS" | head -n 1)"
+          set -euo pipefail
+          SHA="$(echo "${{ github.sha }}" | cut -c 1-7)"
+          DETAILS="${PR_TITLE:-${HEAD_COMMIT_MSG:-$DEFAULT_REASON}}"
+          REASON="$(echo "DOCS@${SHA}: $DETAILS" | head -n 1 | tr -cd 'A-Za-z0-9 @:._#/-')"
           echo "reason=$REASON" >> $GITHUB_OUTPUT
       - name: Authenticate to AWS via OIDC
         env:
@@ -80,9 +87,11 @@ jobs:
       - name: Add runner to AWS security group ingress
         run: aws ec2 authorize-security-group-ingress --group-name ${{ secrets.WEBOPS_AWS_SG_NAME }} --protocol tcp --port ${{ secrets.WEBOPS_JENKINS_PORT }} --cidr ${{ steps.ip.outputs.v4 }}/32
       - name: Trigger Jenkins pipeline
+        env:
+          REASON: ${{ steps.cause.outputs.reason }}
         run: |
           curl -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg src "${{ steps.cause.outputs.reason }}" '{"TRIGGER_SOURCE": $src}')" \
+            -d "$(jq -n --arg src "$REASON" '{"TRIGGER_SOURCE": $src}')" \
             -X POST \
             ${{ secrets.WEBOPS_JENKINS_HOST }}:${{ secrets.WEBOPS_JENKINS_PORT || '80' }}/generic-webhook-trigger/invoke?token=${{ secrets.WEBOPS_WEBHOOK_TOKEN }}
       - name: Remove runner from AWS security group ingress


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds handling for multi-line commit messages to the deployment workflows. Multiple runs of the deployment workflows have failed when commit messages contain more than one line.

Per policy, I used Claude for reviewing changes prior to opening the PR, and adopted its suggestions:
- Using the `env` block as an intermediary for the potentially unsafe values in the `github` object
- Using `tr` to further sanitize potentially unsafe inputs from commit messages and PR titles

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [X] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

[Asana](https://app.asana.com/1/144190854636/project/1208463663409813/task/1216019581154240)