### PR TITLE
DOCS-1708 - Add release note for defaulting new users to Kanso UI

### DIFF
--- a/blog-service/2026-06-30-apps.md
+++ b/blog-service/2026-06-30-apps.md
@@ -23,6 +23,10 @@ Added new dashboards, monitor alerts, and an IDP category for the following apps
 - [ChatGPT Compliance](/docs/integrations/saas-cloud/chatgpt-compliance/#viewing-the-chatgpt-compliance-dashboards). Updated dashboard queries to align with the latest log format, and added a `custom_gpt` selection variable to the dashboard for easier filtering.
 - [JumpCloud Directory Insights](/docs/integrations/saas-cloud/jumpcloud-directory-insights/#viewing-the-jumpcloud-directory-insights-dashboards)
 - [OneLogin](/docs/integrations/saml/onelogin/#viewing-onelogin-dashboards)
+- Updated 14 Source Templates with the following improvements:
+    - Batch processor deprecation handling. Removed deprecated batch processor configurations to ensure compatibility with current collector versions.
+    - Field table validation. Added validation for field tables in filelog receiver-based source templates to prevent misconfiguration.
+    - Hashing functionality. Introduced hashing support for fields in filelog receiver-based source templates.
 - Migrated the following Classic Apps to Next-Gen Apps:
     - [Amazon DynamoDB](/docs/integrations/amazon-aws/dynamodb/)
     - [Amazon ECS without Container Insights and Traces](/docs/integrations/amazon-aws/elastic-container-service)

--- a/blog-service/2026-06-30-apps.md
+++ b/blog-service/2026-06-30-apps.md
@@ -24,9 +24,9 @@ Added new dashboards, monitor alerts, and an IDP category for the following apps
 - [JumpCloud Directory Insights](/docs/integrations/saas-cloud/jumpcloud-directory-insights/#viewing-the-jumpcloud-directory-insights-dashboards)
 - [OneLogin](/docs/integrations/saml/onelogin/#viewing-onelogin-dashboards)
 - Updated 14 Source Templates with the following improvements:
-    - Batch processor deprecation handling. Removed deprecated batch processor configurations to ensure compatibility with current collector versions.
-    - Field table validation. Added validation for field tables in filelog receiver-based source templates to prevent misconfiguration.
-    - Hashing functionality. Introduced hashing support for fields in filelog receiver-based source templates.
+    - **Batch processor deprecation handling**. Removed deprecated batch processor configurations to ensure compatibility with current collector versions.
+    - **Field table validation**. Added validation for field tables in filelog receiver-based source templates to prevent misconfiguration.
+    - **Hashing functionality**. Introduced hashing support for fields in filelog receiver-based source templates.
 - Migrated the following Classic Apps to Next-Gen Apps:
     - [Amazon DynamoDB](/docs/integrations/amazon-aws/dynamodb/)
     - [Amazon ECS without Container Insights and Traces](/docs/integrations/amazon-aws/elastic-container-service)

--- a/blog-service/2026-07-02-platform.md
+++ b/blog-service/2026-07-02-platform.md
@@ -1,16 +1,16 @@
 ---
-title: New user onboarding now defaults to the New UI (Kanso)
+title: New user onboarding now defaults to the New UI
 image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-center_82_none/SumoLogic_Preview_600x600.jpg?mtime=1617040082
 keywords:
   - onboarding
   - platform-service
-hide_table_of_contents: true    
+hide_table_of_contents: true
 ---
 
-New Sumo Logic users and organizations are now onboarded directly into the New UI (Kanso) by default, replacing the previous Classic UI (Bento) onboarding experience.
+New Sumo Logic users and organizations are now onboarded directly into the New UI by default, replacing the previous Classic UI onboarding experience.
 
 :::note
-If you prefer the previous experience, you can switch back to the Bento/Classic UI at any time by selecting **Switch to classic UI** from the left navigation menu.
+If you prefer the previous experience, you can switch back to the Classic UI at any time by selecting **Switch to classic UI** from the left navigation menu.
 :::
 
 ### Who is affected

--- a/blog-service/2026-07-02-platform.md
+++ b/blog-service/2026-07-02-platform.md
@@ -1,0 +1,20 @@
+---
+title: New user onboarding now defaults to the New UI (Kanso)
+image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-center_82_none/SumoLogic_Preview_600x600.jpg?mtime=1617040082
+keywords:
+  - onboarding
+  - platform-service
+hide_table_of_contents: true    
+---
+
+New Sumo Logic users and organizations are now onboarded directly into the New UI (Kanso) by default, replacing the previous Classic UI (Bento) onboarding experience.
+
+:::note
+If you prefer the previous experience, you can switch back to the Bento/Classic UI at any time by selecting **Switch to classic UI** from the left navigation menu.
+:::
+
+### Who is affected
+
+- All new users signing up for Sumo Logic.
+- All new organizations created after this change.
+- Existing users are not affected. Your current UI experience remains unchanged.


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds a service release note announcing that all new Sumo Logic users and organizations are now onboarded into the New UI (Kanso) by default, replacing the Classic UI (Bento) experience.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1708

🤖 Generated with [Claude Code](https://claude.com/claude-code)