### PR TITLE
DOCS-1721 - Default code reviews to fast single-pass mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,9 @@ Primary commands for documentation work. Proactively suggest when context fits �
 - `/audit-doc` = structure/style/links | `/seo-audit` = discoverability signals (run both before PRs)
 
 ## Code Review
-**Default to fast mode**: For routine PR reviews, do a single-pass read of the diff (e.g. via `gh pr diff`) and report findings directly — don't invoke the full multi-agent `/review` pipeline (parallel finder agents + verification pass) unless the user explicitly asks for a deep/thorough review, or the PR is unusually large or high-risk.
+**Default to fast mode**: For PR reviews, read the diff once (e.g. via `gh pr diff`) and report findings directly in that same turn. Do not invoke the multi-agent `/review` pipeline, spawn background research/finder agents, or run a verification pass, unless the user has explicitly asked for a deep/thorough review.
+
+**File count and diff size are NOT valid reasons to escalate on your own.** A PR that repeats the same simple templated edit across many files (e.g. a doc migration touching 18 pages) is still routine, no matter how many lines it touches — judge by the complexity of the *change*, not the size of the diff. If a PR seems to genuinely warrant deeper review (security-sensitive files, logic/behavior changes, something you're not confident you can verify in one pass), say so and ask the user before escalating — never decide to run the deep pipeline unilaterally.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,9 @@ Primary commands for documentation work. Proactively suggest when context fits �
 - `/jira` = manage tickets | `/doc-from-jira` = scaffold doc from ticket
 - `/audit-doc` = structure/style/links | `/seo-audit` = discoverability signals (run both before PRs)
 
+## Code Review
+**Default to fast mode**: For routine PR reviews, do a single-pass read of the diff (e.g. via `gh pr diff`) and report findings directly — don't invoke the full multi-agent `/review` pipeline (parallel finder agents + verification pass) unless the user explicitly asks for a deep/thorough review, or the PR is unusually large or high-risk.
+
 ## Commands
 
 - **Start dev server**: `yarn start` — use this to preview changes locally


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds a Code Review section to CLAUDE.md so Claude Code defaults to a fast, single-pass diff review for routine PRs instead of the deep multi-agent `/review` pipeline (parallel finder agents + verification pass). The deep review stays available on request, or automatically for large/high-risk PRs.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1721