### PR TITLE
DOCS-1692 - Revert revert of MCP Server + OAuth docs, update CIMD terminology

### DIFF
--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -37,7 +37,7 @@ The Sumo Logic MCP server lets MCP clients (external AI models) connect to Sumo 
    | US East (N. Virginia) | `https://mcp.sumologic.com/mcp` |
    | US East (N. Virginia) - FedRAMP | `https://mcp.fed.sumologic.com/mcp` |
    | US West (Oregon) | `https://mcp.us2.sumologic.com/mcp` |
-* **An MCP-compatible client that supports OAuth 2.0**. The default setup uses dynamic client registration. We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or Anthropic Console account).
+* **An MCP-compatible client that supports OAuth 2.0**. The default setup uses client ID metadata documents (CIMD). We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or Anthropic Console account).
 
 :::note
 If you have questions about client compatibility, [contact Sumo Logic Support](https://support.sumologic.com/support/s).
@@ -47,7 +47,7 @@ If you have questions about client compatibility, [contact Sumo Logic Support](h
 
 ### Authentication
 
-Claude Code CLI uses OAuth 2.0 with dynamic client registration. You do not need to create OAuth credentials before setup. Browser-based login handles authentication and token refresh automatically.
+Claude Code CLI uses OAuth 2.0 with CIMD. You do not need to create OAuth credentials before setup. Browser-based login handles authentication and token refresh automatically.
 
 ### Setup
 
@@ -85,7 +85,7 @@ If you previously granted consent for an org, you will not be prompted again. To
 
 ### Manual OAuth setup
 
-Dynamic client registration is the recommended setup for most MCP server users. If your MCP client does not support dynamic client registration, you can connect with manually created OAuth credentials by providing a client ID and secret. See [OAuth Client Setup](/docs/manage/security/oauth#authorization-code-flow) for instructions on creating an OAuth client, then register the MCP server with:
+CIMD is the recommended setup for most MCP server users. If your MCP client does not support CIMD, you can connect with manually created OAuth credentials by providing a client ID and secret. See [OAuth Client Setup](/docs/manage/security/oauth#authorization-code-flow) for instructions on creating an OAuth client, then register the MCP server with:
 
 ```bash
 claude mcp add --scope user --transport http \
@@ -94,7 +94,7 @@ claude mcp add --scope user --transport http \
 ```
 
 :::note
-Recent VS Code releases do not work with explicit client credentials. Use the default dynamic registration setup above for VS Code.
+Recent VS Code releases do not work with explicit client credentials. Use the default CIMD setup above for VS Code.
 :::
 
 ## Available MCP tools
@@ -115,19 +115,19 @@ Tool identifiers are subject to change during the preview period.
 
 ### Utility tools
 
-| Tool | Description |
-| :--- | :---------- |
-| `x_amz_bedrock_agentcore_search` | Search/filter the available tools by context. |
+| Tool | Description | Required scope |
+| :--- | :---------- | :-------------- |
+| `x_amz_bedrock_agentcore_search` | Search/filter the available tools by context. | TBD |
 
 ### Alerts management
 
-| Tool | Description |
-| :--- | :---------- |
-| `alertsReadById`   | Get an alert or folder by ID. |
-| `alertsSearch`     | Search alerts by status, severity, monitor name, mute status, and more. |
-| `getHistory`       | Get alert history for a monitor over a time range. |
-| `getRelatedAlerts` | Get alerts related to a given alert by time proximity or shared entity. |
-| `resolve`          | Resolve an alert. |
+| Tool | Description | Required scope |
+| :--- | :---------- | :-------------- |
+| `alertsReadById`   | Get an alert or folder by ID. | View Alerts (`viewAlerts`) |
+| `alertsSearch`     | Search alerts by status, severity, monitor name, mute status, and more. | View Alerts (`viewAlerts`) |
+| `getHistory`       | Get alert history for a monitor over a time range. | TBD |
+| `getRelatedAlerts` | Get alerts related to a given alert by time proximity or shared entity. | TBD |
+| `resolve`          | Resolve an alert. | TBD |
 
 #### Sample prompts
 
@@ -138,13 +138,13 @@ Tool identifiers are subject to change during the preview period.
 
 ### Dashboard management
 
-| Tool | Description |
-| :--- | :---------- |
-| `createDashboard` | Create a new dashboard. |
-| `deleteDashboard` | Delete a dashboard by ID. |
-| `getDashboard`    | Get a dashboard by ID. |
-| `listDashboards`  | List all dashboards. |
-| `updateDashboard` | Update a dashboard by ID. |
+| Tool | Description | Required scope |
+| :--- | :---------- | :-------------- |
+| `createDashboard` | Create a new dashboard. | Manage Library (`manageLibrary`) |
+| `deleteDashboard` | Delete a dashboard by ID. | TBD |
+| `getDashboard`    | Get a dashboard by ID. | View Library (`viewLibrary`) |
+| `listDashboards`  | List all dashboards. | View Library (`viewLibrary`) |
+| `updateDashboard` | Update a dashboard by ID. | Manage Library (`manageLibrary`) |
 
 #### Sample prompts
 
@@ -155,27 +155,27 @@ Tool identifiers are subject to change during the preview period.
 
 #### Insights
 
-| Tool | Description |
-| :--- | :---------- |
-| `GetAllInsights`            | Get all insights (paginated via token). |
-| `GetInsight`                | Get a single insight by ID, including signals, artifacts, and entity details. |
-| `GetInsightComments`        | Get comments on an insight. |
-| `GetInsightHistory`         | Get history of an insight. |
-| `GetInsightRelatedEntities` | Get involved entities for an insight. |
-| `GetInsightTriage`          | Get triage info for an insight. |
-| `GetInsights`               | Get insights with filtering by severity, status, assignee, entity, confidence, tags, and more. |
-| `UpdateInsightAssignee`     | Update the assignee of an insight. |
-| `UpdateInsightStatus`       | Update the status of an insight. |
+| Tool | Description | Required scope |
+| :--- | :---------- | :-------------- |
+| `GetAllInsights`            | Get all insights (paginated via token). | View Cloud SIEM Enterprise (`viewCse`) |
+| `GetInsight`                | Get a single insight by ID, including signals, artifacts, and entity details. | View Cloud SIEM Enterprise (`viewCse`) |
+| `GetInsightComments`        | Get comments on an insight. | TBD |
+| `GetInsightHistory`         | Get history of an insight. | TBD |
+| `GetInsightRelatedEntities` | Get involved entities for an insight. | TBD |
+| `GetInsightTriage`          | Get triage info for an insight. | TBD |
+| `GetInsights`               | Get insights with filtering by severity, status, assignee, entity, confidence, tags, and more. | View Cloud SIEM Enterprise (`viewCse`) |
+| `UpdateInsightAssignee`     | Update the assignee of an insight. | View Cloud SIEM Enterprise, Manage Insight Assignee (`viewCse`, `cseManageInsightAssignee`) |
+| `UpdateInsightStatus`       | Update the status of an insight. | View Cloud SIEM Enterprise, Manage Insight Status (`viewCse`, `cseManageInsightStatus`) |
 
 #### Detection Rules
 
-| Tool | Description |
-| :--- | :---------- |
-| `CreateTemplatedMatchRule` | Create a new match rule. |
-| `CreateThresholdRule`      | Create a new threshold rule. |
-| `GetRule`                  | Get a single rule by ID with optional tuning expressions. |
-| `GetRules`                 | Get rules with filtering by category, enabled status, rule source, score, severity, stream, tags, and more. |
-| `UpdateRuleEnabled`        | Enable or disable a detection rule. |
+| Tool | Description | Required scope |
+| :--- | :---------- | :-------------- |
+| `CreateTemplatedMatchRule` | Create a new match rule. | View Cloud SIEM Enterprise, Manage Rules (`viewCse`, `cseManageRules`) |
+| `CreateThresholdRule`      | Create a new threshold rule. | View Cloud SIEM Enterprise, Manage Rules (`viewCse`, `cseManageRules`) |
+| `GetRule`                  | Get a single rule by ID with optional tuning expressions. | View Cloud SIEM Enterprise, View Rules (`viewCse`, `cseViewRules`) |
+| `GetRules`                 | Get rules with filtering by category, enabled status, rule source, score, severity, stream, tags, and more. | View Cloud SIEM Enterprise, View Rules (`viewCse`, `cseViewRules`) |
+| `UpdateRuleEnabled`        | Enable or disable a detection rule. | TBD |
 
 #### Sample prompts
 
@@ -193,13 +193,13 @@ Tool identifiers are subject to change during the preview period.
 
 ### Log search
 
-| Tool | Description |
-| :--- | :---------- |
-| `createSearchJob`               | Create a search job with a custom query and time range. |
-| `deleteSearchJob`               | Delete a search job. |
-| `getSearchJobPaginatedMessages` | Get paginated raw messages from a search job. |
-| `getSearchJobPaginatedRecords`  | Get paginated aggregated records from a search job. |
-| `getSearchJobStatus`            | Get the status of a search job. |
+| Tool | Description | Required scope |
+| :--- | :---------- | :-------------- |
+| `createSearchJob`               | Create a search job with a custom query and time range. | Run Log Search (`runLogSearch`) |
+| `deleteSearchJob`               | Delete a search job. | Run Log Search (`runLogSearch`) |
+| `getSearchJobPaginatedMessages` | Get paginated raw messages from a search job. | Run Log Search (`runLogSearch`) |
+| `getSearchJobPaginatedRecords`  | Get paginated aggregated records from a search job. | Run Log Search (`runLogSearch`) |
+| `getSearchJobStatus`            | Get the status of a search job. | Run Log Search (`runLogSearch`) |
 
 #### Sample prompts
 
@@ -208,9 +208,9 @@ Tool identifiers are subject to change during the preview period.
 
 ### User management
 
-| Tool | Description |
-| :--- | :---------- |
-| `listUsers` | List all users in the organization. |
+| Tool | Description | Required scope |
+| :--- | :---------- | :-------------- |
+| `listUsers` | List all users in the organization. | TBD |
 
 #### Sample prompts
 

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -24,8 +24,6 @@ The Sumo Logic MCP server lets MCP clients (external AI models) connect to Sumo 
 
 ## Prerequisites
 
-* **Sumo Logic Administrator role**. You'll need this to create OAuth clients. If you're unsure whether you have this role, check your [Preferences](/docs/get-started/onboarding-checklists/).
-* **Sumo Logic OAuth credentials**. The MCP client uses [OAuth credentials](/docs/manage/security/oauth) to authenticate with Sumo Logic. For Claude Code CLI, you'll create them during the setup steps below.
 * **MCP server URL for your deployment**. OAuth tokens are deployment-bound, so you must use the correct URL for your Sumo Logic deployment:
    | Deployment | MCP Server URL |
    | :--- | :--- |
@@ -39,12 +37,7 @@ The Sumo Logic MCP server lets MCP clients (external AI models) connect to Sumo 
    | US East (N. Virginia) | `https://mcp.sumologic.com/mcp` |
    | US East (N. Virginia) - FedRAMP | `https://mcp.fed.sumologic.com/mcp` |
    | US West (Oregon) | `https://mcp.us2.sumologic.com/mcp` |
-* **An MCP-compatible client that supports OAuth 2.0 Authorization Code flow**. Any MCP client that supports OAuth 2.0 Authorization Code flow with a client ID and secret will work.
-   * We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or Anthropic Console account).
-
-## Known limitations
-
-* **VS Code**. Recent VS Code releases do not work with the authorization code flow when an explicit client ID and secret are provided.
+* **An MCP-compatible client that supports OAuth 2.0**. The default setup uses dynamic client registration. We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or Anthropic Console account).
 
 :::note
 If you have questions about client compatibility, [contact Sumo Logic Support](https://support.sumologic.com/support/s).
@@ -54,35 +47,19 @@ If you have questions about client compatibility, [contact Sumo Logic Support](h
 
 ### Authentication
 
-Claude Code CLI uses OAuth 2.0 Authorization Code flow for authentication. Browser-based login handles token refresh automatically.
+Claude Code CLI uses OAuth 2.0 with dynamic client registration. You do not need to create OAuth credentials before setup. Browser-based login handles authentication and token refresh automatically.
 
 ### Setup
 
-1. In Sumo Logic, create an OAuth client for Claude Code:
-   1. Go to **Administration** > **Security** > **OAuth Clients**.
-   1. Click **+ Add Client**.
-   1. For **Type**, select **Authorization Code**.
-   1. Enter a **Name** and optional **Description**.
-   1. For **Redirect URI**, enter:
-      ```
-      http://localhost:8888/callback
-      ```
-   1. Click **Save**.
-   1. Copy the **Client ID** and **Client Secret**. You'll use these in the next step.
-   For more details about OAuth clients, see [OAuth Client Setup](/docs/manage/security/oauth#authorization-code-flow).
-1. In a Terminal window, not in Claude Code, register the MCP server. Replace `<client-id>` with your value from Sumo Logic, and replace `<MCP-server-URL>` with your deployment's MCP server URL from the [Prerequisites table](#prerequisites) above. When you run the command, Claude Code prompts you to enter the client secret securely. Choose a scope:
+1. In a Terminal window, register the MCP server. Replace `<MCP-server-URL>` with your deployment's URL from the [Prerequisites table](#prerequisites). Choose a scope:
    * **User scope** (available in all directories, recommended).
      ```bash
-     claude mcp add --transport http \
-       --scope user \
-       --client-id "<client-id>" --client-secret --callback-port 8888 \
+     claude mcp add --scope user --transport http \
        sumo-logic "<MCP-server-URL>"
      ```
    * **Project scope** (available only in the current directory, writes to `.mcp.json`).
      ```bash
-     claude mcp add --transport http \
-       --scope project \
-       --client-id "<client-id>" --client-secret --callback-port 8888 \
+     claude mcp add --scope project --transport http \
        sumo-logic "<MCP-server-URL>"
      ```
 1. Launch Claude Code. With **user scope**, run `claude` from any directory. With **project scope**, run it from the directory where you registered the server.
@@ -91,9 +68,34 @@ Claude Code CLI uses OAuth 2.0 Authorization Code flow for authentication. Brows
    ```
 1. In Claude Code, run `/mcp`.
 1. Select **sumo-logic** and then **Authenticate**.
-1. Claude Code will open a browser window to authenticate with Sumo Logic. Log in to complete the OAuth flow.
+1. Claude Code opens a browser window. Log in with your Sumo Logic credentials. If your org uses an identity provider, click **Sign in with your identity provider**, navigate to your org, and complete sign-in.
 1. Verify the connection with `/mcp` to confirm the server is connected.<br/><img src={useBaseUrl('img/api/mcp/claude-mcp-connected.png')} alt="Claude Code CLI showing Sumo Logic MCP server connected" width="600"/>
 1. Prompt Claude Code to `List my available MCP tools` to see what you can do. You can also refer to [Available MCP Tools](#available-mcp-tools).
+
+### Switching organizations
+
+To connect to a different Sumo Logic org:
+1. In Claude Code, run `/mcp`.
+1. Select **sumo-logic** > **Clear authentication**.
+1. Select **Authenticate** and log in to the new org.
+
+:::note
+If you previously granted consent for an org, you will not be prompted again. To revoke consent, go to your Sumo Logic user settings and remove the app under **Personal Authorized Apps** (next to Personal Access Tokens).
+:::
+
+### Manual OAuth setup
+
+Dynamic client registration is the recommended setup for most MCP server users. If your MCP client does not support dynamic client registration, you can connect with manually created OAuth credentials by providing a client ID and secret. See [OAuth Client Setup](/docs/manage/security/oauth#authorization-code-flow) for instructions on creating an OAuth client, then register the MCP server with:
+
+```bash
+claude mcp add --scope user --transport http \
+  --client-id "<client-id>" --client-secret --callback-port 8888 \
+  sumo-logic "<MCP-server-URL>"
+```
+
+:::note
+Recent VS Code releases do not work with explicit client credentials. Use the default dynamic registration setup above for VS Code.
+:::
 
 ## Available MCP tools
 

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -115,19 +115,19 @@ Tool identifiers are subject to change during the preview period.
 
 ### Utility tools
 
-| Tool | Description | Required scope |
-| :--- | :---------- | :-------------- |
-| `x_amz_bedrock_agentcore_search` | Search/filter the available tools by context. | TBD |
+| Tool | Description |
+| :--- | :---------- |
+| `x_amz_bedrock_agentcore_search` | Search/filter the available tools by context. |
 
 ### Alerts management
 
-| Tool | Description | Required scope |
-| :--- | :---------- | :-------------- |
-| `alertsReadById`   | Get an alert or folder by ID. | View Alerts (`viewAlerts`) |
-| `alertsSearch`     | Search alerts by status, severity, monitor name, mute status, and more. | View Alerts (`viewAlerts`) |
-| `getHistory`       | Get alert history for a monitor over a time range. | TBD |
-| `getRelatedAlerts` | Get alerts related to a given alert by time proximity or shared entity. | TBD |
-| `resolve`          | Resolve an alert. | TBD |
+| Tool | Description |
+| :--- | :---------- |
+| `alertsReadById`   | Get an alert or folder by ID. |
+| `alertsSearch`     | Search alerts by status, severity, monitor name, mute status, and more. |
+| `getHistory`       | Get alert history for a monitor over a time range. |
+| `getRelatedAlerts` | Get alerts related to a given alert by time proximity or shared entity. |
+| `resolve`          | Resolve an alert. |
 
 #### Sample prompts
 
@@ -138,13 +138,13 @@ Tool identifiers are subject to change during the preview period.
 
 ### Dashboard management
 
-| Tool | Description | Required scope |
-| :--- | :---------- | :-------------- |
-| `createDashboard` | Create a new dashboard. | Manage Library (`manageLibrary`) |
-| `deleteDashboard` | Delete a dashboard by ID. | TBD |
-| `getDashboard`    | Get a dashboard by ID. | View Library (`viewLibrary`) |
-| `listDashboards`  | List all dashboards. | View Library (`viewLibrary`) |
-| `updateDashboard` | Update a dashboard by ID. | Manage Library (`manageLibrary`) |
+| Tool | Description |
+| :--- | :---------- |
+| `createDashboard` | Create a new dashboard. |
+| `deleteDashboard` | Delete a dashboard by ID. |
+| `getDashboard`    | Get a dashboard by ID. |
+| `listDashboards`  | List all dashboards. |
+| `updateDashboard` | Update a dashboard by ID. |
 
 #### Sample prompts
 
@@ -155,27 +155,27 @@ Tool identifiers are subject to change during the preview period.
 
 #### Insights
 
-| Tool | Description | Required scope |
-| :--- | :---------- | :-------------- |
-| `GetAllInsights`            | Get all insights (paginated via token). | View Cloud SIEM Enterprise (`viewCse`) |
-| `GetInsight`                | Get a single insight by ID, including signals, artifacts, and entity details. | View Cloud SIEM Enterprise (`viewCse`) |
-| `GetInsightComments`        | Get comments on an insight. | TBD |
-| `GetInsightHistory`         | Get history of an insight. | TBD |
-| `GetInsightRelatedEntities` | Get involved entities for an insight. | TBD |
-| `GetInsightTriage`          | Get triage info for an insight. | TBD |
-| `GetInsights`               | Get insights with filtering by severity, status, assignee, entity, confidence, tags, and more. | View Cloud SIEM Enterprise (`viewCse`) |
-| `UpdateInsightAssignee`     | Update the assignee of an insight. | View Cloud SIEM Enterprise, Manage Insight Assignee (`viewCse`, `cseManageInsightAssignee`) |
-| `UpdateInsightStatus`       | Update the status of an insight. | View Cloud SIEM Enterprise, Manage Insight Status (`viewCse`, `cseManageInsightStatus`) |
+| Tool | Description |
+| :--- | :---------- |
+| `GetAllInsights`            | Get all insights (paginated via token). |
+| `GetInsight`                | Get a single insight by ID, including signals, artifacts, and entity details. |
+| `GetInsightComments`        | Get comments on an insight. |
+| `GetInsightHistory`         | Get history of an insight. |
+| `GetInsightRelatedEntities` | Get involved entities for an insight. |
+| `GetInsightTriage`          | Get triage info for an insight. |
+| `GetInsights`               | Get insights with filtering by severity, status, assignee, entity, confidence, tags, and more. |
+| `UpdateInsightAssignee`     | Update the assignee of an insight. |
+| `UpdateInsightStatus`       | Update the status of an insight. |
 
 #### Detection Rules
 
-| Tool | Description | Required scope |
-| :--- | :---------- | :-------------- |
-| `CreateTemplatedMatchRule` | Create a new match rule. | View Cloud SIEM Enterprise, Manage Rules (`viewCse`, `cseManageRules`) |
-| `CreateThresholdRule`      | Create a new threshold rule. | View Cloud SIEM Enterprise, Manage Rules (`viewCse`, `cseManageRules`) |
-| `GetRule`                  | Get a single rule by ID with optional tuning expressions. | View Cloud SIEM Enterprise, View Rules (`viewCse`, `cseViewRules`) |
-| `GetRules`                 | Get rules with filtering by category, enabled status, rule source, score, severity, stream, tags, and more. | View Cloud SIEM Enterprise, View Rules (`viewCse`, `cseViewRules`) |
-| `UpdateRuleEnabled`        | Enable or disable a detection rule. | TBD |
+| Tool | Description |
+| :--- | :---------- |
+| `CreateTemplatedMatchRule` | Create a new match rule. |
+| `CreateThresholdRule`      | Create a new threshold rule. |
+| `GetRule`                  | Get a single rule by ID with optional tuning expressions. |
+| `GetRules`                 | Get rules with filtering by category, enabled status, rule source, score, severity, stream, tags, and more. |
+| `UpdateRuleEnabled`        | Enable or disable a detection rule. |
 
 #### Sample prompts
 
@@ -193,13 +193,13 @@ Tool identifiers are subject to change during the preview period.
 
 ### Log search
 
-| Tool | Description | Required scope |
-| :--- | :---------- | :-------------- |
-| `createSearchJob`               | Create a search job with a custom query and time range. | Run Log Search (`runLogSearch`) |
-| `deleteSearchJob`               | Delete a search job. | Run Log Search (`runLogSearch`) |
-| `getSearchJobPaginatedMessages` | Get paginated raw messages from a search job. | Run Log Search (`runLogSearch`) |
-| `getSearchJobPaginatedRecords`  | Get paginated aggregated records from a search job. | Run Log Search (`runLogSearch`) |
-| `getSearchJobStatus`            | Get the status of a search job. | Run Log Search (`runLogSearch`) |
+| Tool | Description |
+| :--- | :---------- |
+| `createSearchJob`               | Create a search job with a custom query and time range. |
+| `deleteSearchJob`               | Delete a search job. |
+| `getSearchJobPaginatedMessages` | Get paginated raw messages from a search job. |
+| `getSearchJobPaginatedRecords`  | Get paginated aggregated records from a search job. |
+| `getSearchJobStatus`            | Get the status of a search job. |
 
 #### Sample prompts
 
@@ -208,9 +208,9 @@ Tool identifiers are subject to change during the preview period.
 
 ### User management
 
-| Tool | Description | Required scope |
-| :--- | :---------- | :-------------- |
-| `listUsers` | List all users in the organization. | TBD |
+| Tool | Description |
+| :--- | :---------- |
+| `listUsers` | List all users in the organization. |
 
 #### Sample prompts
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request re-applies the DOCS-1692 MCP Server + OAuth docs update (originally #6838, temporarily reverted in #6859 while CIMD support rolled out to prod) now that CIMD is enabled for MCP-preview customers on all production deployments. It also applies terminology feedback from Garrett/Keith, replacing "dynamic client registration" with "client ID metadata documents (CIMD)" in the four places that phrase appears.

The "Required scope" column for the MCP tool tables was split out into a separate PR (#6878, DOCS-1739) since that scope data isn't fully confirmed by engineering yet.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1692