### PR TITLE
DOCS-1737 - Add June 2026 CSOAR application update release note

### DIFF
--- a/blog-csoar/2026-07-13-application-update.md
+++ b/blog-csoar/2026-07-13-application-update.md
@@ -1,0 +1,28 @@
+---
+title: July 13, 2026 - Application Update
+hide_table_of_contents: true
+image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-center_82_none/SumoLogic_Preview_600x600.jpg?mtime=1617040082
+keywords:
+  - automation service
+  - cloud soar
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+## June release
+
+The following are the updates made in June 2026.
+
+### Integrations
+
+This section includes new integrations and upgrades to existing ones.
+
+- **Google Cloud Armor**. Added new integration for [Google Cloud Armor](/docs/platform-services/automation-service/app-central/integrations/google-cloud-armor/).
+- **Google Cloud Composer**. Added new integration for [Google Cloud Composer](/docs/platform-services/automation-service/app-central/integrations/google-cloud-composer/).
+- **Google Cloud Run**. Added new integration for [Google Cloud Run](/docs/platform-services/automation-service/app-central/integrations/google-cloud-run/).
+- **Google Cloud Service Mesh**. Added new integration for [Google Cloud Service Mesh](/docs/platform-services/automation-service/app-central/integrations/google-cloud-service-mesh/).
+- **Google Compute Engine**. Added new integration for [Google Compute Engine](/docs/platform-services/automation-service/app-central/integrations/google-compute-engine/).
+- **Google Kubernetes Engine**. Added new integration for [Google Kubernetes Engine](/docs/platform-services/automation-service/app-central/integrations/google-kubernetes-engine/).
+- **Slack**. Updated the **Send Message** action in [Slack](/docs/platform-services/automation-service/app-central/integrations/slack/) to support the **link preview** configuration.
+- **1Password**. Modified the `user` field in [1Password](/docs/platform-services/automation-service/app-central/integrations/1password/) header.
+- **Atlassian Jira V2**. Added the new **Search User** action to search for Jira users by displaying the name, email address, or account ID in [Atlassian Jira V2](/docs/platform-services/automation-service/app-central/integrations/atlassian-jira-v2/) integration.


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the June 2026 Cloud SOAR (automation service) application update release note, covering new Google Cloud integrations and updates to Slack, 1Password, and Atlassian Jira V2.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)