### PR TITLE
apply `paths-ignore` to `.claude` directory contents

### DIFF
--- a/.github/workflows/workflow_deploy-to-pantheon-prod.yml
+++ b/.github/workflows/workflow_deploy-to-pantheon-prod.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - .claude
+      - .claude/**
       - .github/**
       - .clabot
       - CONTRIBUTING.md

--- a/.github/workflows/workflow_deploy-to-pantheon-staging.yml
+++ b/.github/workflows/workflow_deploy-to-pantheon-staging.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - staging/**
     paths-ignore:
-      - .claude
+      - .claude/**
       - .github/**
       - .clabot
       - CONTRIBUTING.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request applies the `paths-ignore` to the contents of `.claude`, not just the directory itself.

Changes to the repo's Claude config trigger the deployment workflows, which fail because there are no changes to the build output, sending a false error message in Slack.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)