### PR TITLE
DOCS-1759 - MCP Server doc - Flex pricing cost risk

### DIFF
--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -344,6 +344,10 @@ MCP endpoints are cost-amplifying by design. A single conversational request can
 
 MCP is designed for conversational, agent-level interaction where cost per request is understood and monitored. For raw data access or high-volume operations, standard APIs remain more efficient and cost-effective.
 
+:::note
+If you're on [Flex pricing](/docs/manage/partitions/flex), cost-amplifying patterns in log search tool calls — broad queries, multi-step investigations, retries — translate directly into scan costs. Monitor usage closely when connecting MCP clients to a Flex account.
+:::
+
 For detailed guidance on securing MCP against cost-based attacks, see our blog post: [Token Torching: How I'd burn your AI budget (so you can fix it)](https://www.sumologic.com/blog/token-torching-ai-attack).
 
 ## Security and data governance


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds a note to the MCP Server doc's Cost dynamics section flagging that Flex (scan-based) pricing customers are directly exposed to cost-amplifying log search tool call patterns (broad queries, multi-step investigations, retries), unlike ingest-based plans.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Update Content - Revisions, updating sections
- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1759