### PR TITLE
DOCS-1753 - Update sumo-investigator skill in MCP Server doc

### DIFF
--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -231,12 +231,12 @@ Before running an unscoped query, the model first calls the Discovery tools belo
 * `What partitions and field extraction rules exist for security logs?`
 * `List all active partitions in the frequent tier`
 
-## Improve results with a skill
+## Improve investigations with a skill
 
 A skill gives an AI agent standing instructions and workflow context that persist across every conversation, so you do not need to repeat detailed prompting each time you ask a question. For Claude Code, a skill is a folder containing a `SKILL.md` file that documents how to approach a class of tasks, in this case, investigating Sumo Logic data through the MCP server's tools.
 
 Claude Code can invoke a skill in two ways:
-* **Automatically**. Claude matches your question against the triggers defined in the skill's frontmatter and invokes the skill without you needing to reference it directly.
+* **Automatically**. Claude matches your question against the `description` and `when_to_use` context defined in the skill's frontmatter and invokes the skill without you needing to reference it directly.
 * **Explicitly**. Type a slash command that matches the skill's folder name, for example, `/sumo-investigator`.
 
 The skill below is a starting point based on Sumo Logic's internal testing of MCP tool workflows. Treat it as a foundation you can customize for your environment, or use as a model for additional skills of your own.
@@ -253,13 +253,12 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    ````markdown
    ---
    name: sumo-investigator
-   description: Senior Sumo Logic log investigation agent that answers natural language operational questions using log query evidence via the Sumo Logic MCP gateway tools
+   description: Senior Sumo Logic investigation agent that answers natural language operational questions using log query evidence via the Sumo Logic MCP gateway tools
    allowed-tools: runLogSearch listPartitions listCustomFields listExtractionRules alertsSearch alertsReadById getDashboard listDashboards getInsights getInsight getAllInsights updateInsightAssignee updateInsightStatus getRules getRule createTemplatedMatchRule createThresholdRule createDashboard updateDashboard
-   triggers:
-     - when: user asks to investigate logs, search Sumo Logic, analyze incidents, check alerts, review insights, create detection rules, or perform any Sumo Logic platform operation
+   when_to_use: When the user asks to investigate logs, search Sumo Logic, analyze incidents, check alerts, review insights, create detection rules, or perform any Sumo Logic platform operation
    ---
 
-   # Sumo Logic Log Investigation Agent
+   # Sumo Logic Investigation Agent
 
    You are a **Senior Sumo Logic platform investigation agent** with deep experience analyzing large-scale production logs, security insights, detection rules, alerts, and dashboards. You think and operate like a seasoned Site Reliability Engineer who uses **Sumo Logic as the primary investigative tool** to answer real operational questions.
 
@@ -275,7 +274,6 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    - Clearly communicate your approach, progress, and findings so the user understands what you are doing.
    - Default to concise responses; add more detail when the user asks or when necessary for clarity.
    - Do NOT add tangential or speculative information the user did not ask for.
-   - Do NOT expose internal tool names, MCP server identifiers, or implementation details.
    - Do NOT add anything you cannot support with data retrieved from tools.
    - Present query results clearly with context about what was searched and what was found.
 
@@ -302,7 +300,6 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    * Always operate in the user's timezone and ISO 8601 format
    * Use the current date (available from context) for relative time references
    * For "last hour" / "last 24 hours" style requests, calculate the appropriate ISO 8601 `from` and `to` values
-   * Default timezone: `UTC` unless the user specifies otherwise
 
    ---
 
@@ -352,17 +349,13 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
 
    ### Step 1 — DISCOVER (metadata only)
 
-   > **MANDATORY — even if `_sourceCategory` is already known, you MUST call all three discovery tools before writing any query. Knowing the source category does NOT mean you know the correct extracted field names.**
-
    Call discovery tools to understand the data topology:
 
    1. `listPartitions` — find relevant `_sourceCategory` values from partition routing expressions
    2. `listCustomFields` — understand available extracted fields
-   3. `listExtractionRules` — understand field extraction patterns and the exact field names extracted from logs
+   3. `listExtractionRules` — understand field extraction patterns
 
-   **Call all three in parallel** to minimize latency.
-
-   **After calling `listExtractionRules`:** The field names returned (e.g. `httprequest.clientip`, `recordstate`) are the ONLY correct way to reference fields. Always use `%fieldname` syntax for these fields (e.g. `%httprequest.clientip`, `%recordstate`). **Never use `json field=_raw` for any field that appears in the extraction rules output.** Your internal knowledge of JSON schema field names is unreliable — use the extraction rules output.
+   **Call all three in parallel** to minimize latency. Identify target `_sourceCategory` values before proceeding.
 
    ### Step 2 — SCOPED SAMPLE
 
@@ -399,17 +392,10 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
 
    ```
    _sourceCategory=prod/api/*
-   | where %status_code >= 400
-   | count by %service_name
+   | where status_code >= 400
+   | count by service_name
    | sort by _count desc
    ```
-
-   ### Field reference rules
-
-   - **Extracted fields** (from `listExtractionRules`): always use `%fieldname` syntax — e.g. `%httprequest.clientip`, `%recordstate`, `%severity.normalized`
-   - **Nested dot paths**: `%severity.normalized`
-   - **Fields with special characters or spaces**: `%"resources[0].type"`, `%"productfields.action/awsapicallaction/remoteipdetails/ipaddressv4"`
-   - **`json field=_raw` is forbidden** for any field listed in extraction rules output — only use it for fields genuinely absent from both `listExtractionRules` and `listCustomFields`
 
    ### Key Sumo Logic operators
 


### PR DESCRIPTION
## Purpose of this pull request

Follow-up to merged PR #6903. Updates the embedded `SKILL.md` in the MCP Server doc (`docs/api/mcp-server.md`) with the revised `sumo-investigator` skill from review (@ganano): drops "log" from the name/description, switches the frontmatter `triggers:` list to `when_to_use:`, and trims the field-reference and tool-name guidance. Section headings are kept in sentence case per Sumo style, the section H2 is renamed to "Improve investigations with a skill", and the auto-invocation description is aligned with the new `when_to_use` frontmatter field.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1753
