### PR TITLE
Basic_Tools:upgraded python3_generic

### DIFF
--- a/docs/platform-services/automation-service/app-central/integrations/basic-tools.md
+++ b/docs/platform-services/automation-service/app-central/integrations/basic-tools.md
@@ -6,8 +6,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 <img src={useBaseUrl('/img/platform-services/automation-service/app-central/logos/basic-tools.png')} alt="Basic tools icon" width="100"/>
 
-***Version: 1.11  
-Updated: Apr 17, 2024***
+***Version: 1.12  
+Updated: Jul 20, 2026***
 
 Basic Tools implement some utils method to use inside Playbook
 
@@ -28,3 +28,4 @@ No configuration is needed. Basic Tools executes without additional authenticati
 * April 17, 2024 (v1.11)
     + Added new Field *Cc Recipients* to Send Email Action 
     + Removed the *Plain Text Content* Field from Send Email Action
+* July 20, 2026 (v1.12) - Upgraded the `python3_generic` Docker image (Python 3.8) to `python3_12_generic` (Python 3.12) to address Python 3.8 end-of-life and improve security and performance.


### PR DESCRIPTION
 Upgraded the python3_generic Docker image (Python 3.8) to python3_12_generic (Python 3.12) to address Python 3.8 end-of-life and improve security and performance.


## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

<!-- enter your Jira, Asana, or GitHub ticket number -->
