### PR TITLE
DOCS-1764 - Update OAuth and CIMD documentation

### DIFF
--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -30,11 +30,12 @@ The Sumo Logic MCP server lets MCP clients (external AI models) connect to Sumo 
    | Asia Pacific (Tokyo) | `https://mcp.jp.sumologic.com/mcp` |
    | Canada (Central) | `https://mcp.ca.sumologic.com/mcp` |
    | Europe (Frankfurt) | `https://mcp.de.sumologic.com/mcp` |
-   | Europe (Ireland) | `https://mcp.eu.sumologic.com/mcp` |
-   | Europe (Zurich) | `https://mcp.ch.sumologic.com/mcp` |
    | US East (N. Virginia) | `https://mcp.sumologic.com/mcp` |
    | US East (N. Virginia) - FedRAMP | `https://mcp.fed.sumologic.com/mcp` |
    | US West (Oregon) | `https://mcp.us2.sumologic.com/mcp` |
+   :::note
+   The MCP server is not currently supported in the Europe (Ireland) and Europe (Zurich) deployments.
+   :::
 * **An MCP-compatible client that supports remote HTTP/SSE transport and OAuth 2.0**. The default setup uses Client ID Metadata Documents (CIMD). We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or an Anthropic Console account).
    :::note
    [CIMD](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) is the recommended authentication mechanism for MCP clients. An administrator needs to enable it for your organization first; see [Enable CIMD](/docs/manage/security/oauth#enable-cimd). You can learn more about how CIMD works at [client.dev](https://client.dev/). If you have any questions about client compatibility, contact [Sumo Logic Support](https://support.sumologic.com/support/s).

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -37,7 +37,7 @@ The Sumo Logic MCP server lets MCP clients (external AI models) connect to Sumo 
    | US West (Oregon) | `https://mcp.us2.sumologic.com/mcp` |
 * **An MCP-compatible client that supports remote HTTP/SSE transport and OAuth 2.0**. The default setup uses Client ID Metadata Documents (CIMD). We've documented setup below for [Claude Code CLI](https://code.claude.com/docs/en/quickstart) (requires a paid Claude subscription or an Anthropic Console account).
    :::note
-   [CIMD](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) is the recommended authentication mechanism for MCP clients. You can learn more about how CIMD works at [client.dev](https://client.dev/). If you have any questions about client compatibility, contact [Sumo Logic Support](https://support.sumologic.com/support/s).
+   [CIMD](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) is the recommended authentication mechanism for MCP clients. An administrator needs to enable it for your organization first; see [Enable CIMD](/docs/manage/security/oauth#enable-cimd). You can learn more about how CIMD works at [client.dev](https://client.dev/). If you have any questions about client compatibility, contact [Sumo Logic Support](https://support.sumologic.com/support/s).
    :::
 
 ## Configure in Claude Code CLI
@@ -82,7 +82,12 @@ If you previously granted consent for an org, you will not be prompted again. To
 
 ### Manual OAuth setup
 
-CIMD is the recommended setup for most MCP server users. If your MCP client does not support CIMD, you can connect with manually created OAuth credentials instead. This requires the **Sumo Logic Administrator role** to create an OAuth client, and you'll set up [OAuth credentials](/docs/manage/security/oauth) (a client ID and client secret) to authenticate.
+CIMD is the default, recommended setup for most MCP server users. If your MCP client does not support CIMD, connect with a manually created, pre-registered OAuth client instead. Sumo Logic supports two OAuth 2.0 flows for this:
+
+* **Authorization Code with a pre-registered client**. Best for interactive clients that handle browser-based login. Follow the steps below to create the client, or see [Authorization Code flow](/docs/manage/security/oauth#authorization-code-flow) for details.
+* **Client Credentials**. Best for service-to-service or automated clients with no interactive user. See [Client Credentials flow](/docs/manage/security/oauth#client-credentials-flow) to set it up with a service account.
+
+Both require the **Sumo Logic Administrator role** to create the OAuth client and its [OAuth credentials](/docs/manage/security/oauth) (a client ID and client secret).
 
 #### Create an OAuth client
 
@@ -300,6 +305,7 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    * Always operate in the user's timezone and ISO 8601 format
    * Use the current date (available from context) for relative time references
    * For "last hour" / "last 24 hours" style requests, calculate the appropriate ISO 8601 `from` and `to` values
+   * Default timezone: `UTC` unless the user specifies otherwise
 
    ---
 
@@ -357,6 +363,12 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
 
    **Call all three in parallel** to minimize latency. Identify target `_sourceCategory` values before proceeding.
 
+   **How to pick the right `_sourceCategory` from `listPartitions`:**
+   - Each partition has a `routingExpression` like `_sourceCategory=glass/*` or `_sourceCategory=stream`.
+   - Match the user's question to the service name in the routing expression.
+   - Use that `_sourceCategory` directly — do NOT try multiple categories sequentially.
+   - If uncertain between 2-3 candidates, run ONE sample with `| count by _sourceCategory | sort by _count desc` instead of N separate searches.
+
    ### Step 2 — SCOPED SAMPLE
 
    Run a narrow sample search to confirm the correct data source:
@@ -374,6 +386,7 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    - Use the full time range needed
    - Apply specific field filters based on patterns observed in Step 2
    - Use appropriate aggregations (`count by`, `sum`, `avg`, `timeslice`, etc.)
+   - **Put discriminating keywords BEFORE the first `|` operator** — keywords on the scope line filter via bloom filter (10-100x faster than `| where` after parse)
 
    ### Hard rules
 
@@ -381,7 +394,9 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    - **NEVER** skip Step 1 — unscoped queries WILL timeout
    - **NEVER** merge Steps 2 and 3 into a single call for complex investigations
    - For aggregate queries spanning **more than 2 days**, split into parallel 1-day windows
-   - Prefer smaller limits to avoid overwhelming context
+   - **RAW queries (no aggregation): ALWAYS add `| limit N` on the FIRST line (before any `|` operators).** This stops scanning early — a line-1 limit scans MB, an end-of-query limit scans TB then truncates.
+   - **Aggregate queries: ALWAYS end with `| sort _count desc | limit N`** (or `topk`). Unbounded aggregates overflow context.
+   - **Parse/json fields that may be absent: ALWAYS use `nodrop`.** Without it, rows with missing fields are silently dropped — you lose data without any error.
    - Max runtime: 2 minutes per query; Max result size: 256MB
 
    ---
@@ -391,10 +406,17 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    Build queries following this pattern: **source → filter → aggregate → format**
 
    ```
-   _sourceCategory=prod/api/*
+   # Aggregate query (bounded output):
+   _sourceCategory=prod/api/* error
    | where status_code >= 400
    | count by service_name
-   | sort by _count desc
+   | sort _count desc | limit 20
+
+   # Raw query (early-termination limit):
+   _sourceCategory=prod/api/* "TimeoutException" | limit 10
+   | json "service" as service_name nodrop
+   | json "endpoint" as endpoint nodrop
+   | fields _messagetime, service_name, endpoint, _raw
    ```
 
    ### Key Sumo Logic operators

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -306,7 +306,6 @@ As the Sumo Logic MCP server evolves, for example, as tools are added, removed, 
    * Always operate in the user's timezone and ISO 8601 format
    * Use the current date (available from context) for relative time references
    * For "last hour" / "last 24 hours" style requests, calculate the appropriate ISO 8601 `from` and `to` values
-   * Default timezone: `UTC` unless the user specifies otherwise
 
    ---
 

--- a/docs/manage/security/oauth.md
+++ b/docs/manage/security/oauth.md
@@ -51,12 +51,10 @@ CIMD uses the [Authorization Code flow](#authorization-code-flow) behind the sce
 An administrator needs to enable CIMD for your organization before clients can use it.
 
 1. [**New UI**](/docs/get-started/sumo-logic-ui). In the main Sumo Logic menu select **Administration**, and then under **Account Security Settings** select **Policies**. You can also click the **Go To...** menu at the top of the screen and select **Policies**.<br/>[**Classic UI**](/docs/get-started/sumo-logic-ui-classic). In the main Sumo Logic menu, select **Administration > Security > Policies**.
-1. Turn on **CIMD Enabled**.
+1. Select the **Enable CIMD Clients** check box.
 1. Click **Save**.
 
 Clients that do not support CIMD can connect with a pre-registered OAuth client instead, using either the [Authorization Code flow](#authorization-code-flow) or the [Client Credentials flow](#client-credentials-flow). See [Manual OAuth setup](/docs/api/mcp-server#manual-oauth-setup) for the MCP server.
-
-{/* VERIFY before publishing: confirm the exact toggle label ("CIMD Enabled") and its location on the Policies page with the OAuth/MCP engineering team. */}
 
 ## Authorization Code flow
 

--- a/docs/manage/security/oauth.md
+++ b/docs/manage/security/oauth.md
@@ -28,6 +28,8 @@ Sumo Logic supports two OAuth 2.0 authentication flows:
 | [Authorization Code](#authorization-code-flow) | User-facing applications with browser-based login | Simple (UI-based) | Automatic |
 | [Client Credentials](#client-credentials-flow) | Service-to-service authentication, automated workflows | Moderate (API-based) | Manual or automatic |
 
+For MCP clients, Sumo Logic also supports [Client ID Metadata Documents (CIMD)](#client-id-metadata-documents-cimd), which let a client authenticate without an administrator pre-registering an OAuth client.
+
 ## Prerequisites
 
 * **Sumo Logic Administrator role**. You'll need this to create OAuth clients and service accounts. If you're unsure whether you have this role, check your [Preferences](/docs/get-started/onboarding-checklists/).
@@ -38,6 +40,24 @@ Effective permissions are always the intersection of the OAuth client's configur
 
 * **Authorization Code flow**. Effective permissions are the intersection of the authenticated user's roles and the OAuth client's configured scopes. When specific scopes are requested during authorization, effective permissions are further limited to those requested scopes.
 * **Client Credentials flow**. Effective permissions are the intersection of the service account's roles, the OAuth client's configured scopes, and any scopes explicitly requested when obtaining a token.
+
+## Client ID Metadata Documents (CIMD)
+
+[Client ID Metadata Documents (CIMD)](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) let a client identify itself to Sumo Logic using a hosted metadata URL as its client ID, without an administrator pre-registering an OAuth client. CIMD is the default, recommended authentication mechanism for [MCP server](/docs/api/mcp-server) clients such as the Claude Code CLI, which handle browser-based login and token refresh automatically.
+
+CIMD uses the [Authorization Code flow](#authorization-code-flow) behind the scenes, so the same [permission rules](#how-permissions-work) apply.
+
+### Enable CIMD
+
+An administrator needs to enable CIMD for your organization before clients can use it.
+
+1. [**New UI**](/docs/get-started/sumo-logic-ui). In the main Sumo Logic menu select **Administration**, and then under **Account Security Settings** select **Policies**. You can also click the **Go To...** menu at the top of the screen and select **Policies**.<br/>[**Classic UI**](/docs/get-started/sumo-logic-ui-classic). In the main Sumo Logic menu, select **Administration > Security > Policies**.
+1. Turn on **CIMD Enabled**.
+1. Click **Save**.
+
+Clients that do not support CIMD can connect with a pre-registered OAuth client instead, using either the [Authorization Code flow](#authorization-code-flow) or the [Client Credentials flow](#client-credentials-flow). See [Manual OAuth setup](/docs/api/mcp-server#manual-oauth-setup) for the MCP server.
+
+{/* VERIFY before publishing: confirm the exact toggle label ("CIMD Enabled") and its location on the Policies page with the OAuth/MCP engineering team. */}
 
 ## Authorization Code flow
 
@@ -256,6 +276,28 @@ curl <api-endpoint>/api/v1/search/jobs \
 
 Access tokens generated with Client Credentials flow expire after 12 hours. When a token expires, generate a new one by repeating the [token request](#step-3-generate-an-access-token). Unlike Authorization Code flow, Client Credentials flow does not provide refresh tokens.
 
+## Metadata endpoints
+
+Sumo Logic publishes OAuth 2.0 and OpenID Connect discovery documents so clients can automatically discover endpoints and supported capabilities. Replace `[deployment-endpoint]` with your deployment's service endpoint (for example, `service.sumologic.com` for US1). See [How do I find the authorization or token endpoint for my deployment?](#how-do-i-find-the-authorization-or-token-endpoint-for-my-deployment) for the endpoint that matches your deployment.
+
+| Metadata document | URL |
+| :--- | :--- |
+| Authorization server metadata ([RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414)) | `https://[deployment-endpoint]/.well-known/oauth-authorization-server` |
+| OpenID Connect configuration | `https://[deployment-endpoint]/.well-known/openid-configuration` |
+| Protected resource metadata ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)) | `https://[mcp-server-endpoint]/.well-known/oauth-protected-resource` |
+
+* **Authorization server metadata** returns the `authorization_endpoint`, `token_endpoint`, and other supported OAuth 2.0 parameters, such as scopes, grant types, and response types.
+* **OpenID Connect configuration** returns the OpenID Provider configuration, including the `issuer`, endpoint URLs, and supported claims.
+* **Protected resource metadata** is served by the [Sumo Logic MCP server](/docs/api/mcp-server) to advertise which authorization server issues tokens for it. Replace `[mcp-server-endpoint]` with your [deployment's MCP server URL](/docs/api/mcp-server#prerequisites).
+
+For example, to retrieve the authorization server metadata:
+
+```bash
+curl https://[deployment-endpoint]/.well-known/oauth-authorization-server
+```
+
+{/* VERIFY before publishing: confirm the OpenID configuration path (/.well-known/openid-configuration) and the protected resource metadata host/path (served by the MCP server) with the OAuth/MCP engineering team. */}
+
 ## Security best practices
 
 * **Protect client secrets**. For Client Credentials flow, store client secrets securely using environment variables, secrets management systems, or encrypted configuration files — never commit them to version control. In Authorization Code flow, the `clientSecret` is not directly exposed in the token exchange and carries less risk, but should still be stored securely.
@@ -331,7 +373,7 @@ To find the `authorization_endpoint` for your deployment (used in [Authorization
 curl https://[deployment-endpoint]/.well-known/oauth-authorization-server
 ```
 
-The response includes `authorization_endpoint`, `token_endpoint`, and other supported OAuth parameters.
+The response includes `authorization_endpoint`, `token_endpoint`, and other supported OAuth parameters. For the OpenID Connect and protected resource discovery documents, see [Metadata endpoints](#metadata-endpoints).
 
 ### Can I use OAuth with the Sumo Logic APIs?
 

--- a/docs/manage/security/oauth.md
+++ b/docs/manage/security/oauth.md
@@ -28,7 +28,6 @@ Sumo Logic supports two OAuth 2.0 authentication flows:
 | [Authorization Code](#authorization-code-flow) | User-facing applications with browser-based login | Simple (UI-based) | Automatic |
 | [Client Credentials](#client-credentials-flow) | Service-to-service authentication, automated workflows | Moderate (API-based) | Manual or automatic |
 
-For MCP clients, Sumo Logic also supports [Client ID Metadata Documents (CIMD)](#client-id-metadata-documents-cimd), which let a client authenticate without an administrator pre-registering an OAuth client.
 
 ## Prerequisites
 

--- a/docs/manage/security/oauth.md
+++ b/docs/manage/security/oauth.md
@@ -295,7 +295,6 @@ For example, to retrieve the authorization server metadata:
 curl https://[deployment-endpoint]/.well-known/oauth-authorization-server
 ```
 
-{/* VERIFY before publishing: confirm the OpenID configuration path (/.well-known/openid-configuration) and the protected resource metadata host/path (served by the MCP server) with the OAuth/MCP engineering team. */}
 
 ## Security best practices
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the OAuth and MCP server documentation to cover CIMD, OAuth discovery metadata, and manual OAuth alternatives:

- Adds a **Client ID Metadata Documents (CIMD)** section to the OAuth doc, including how to enable it via the **CIMD Enabled** toggle on the Policies page.
- Adds a **Metadata endpoints** section documenting the authorization server metadata, OpenID Connect configuration, and protected resource metadata URLs.
- Clarifies on the MCP server page that CIMD is the default, with **Authorization Code** (pre-registered clients) and **Client Credentials** as alternatives for clients that do not support CIMD.
- Incorporates query best-practice improvements (sourceCategory selection, bloom-filter keyword placement, raw/aggregate `limit` rules, `nodrop`) into the embedded `sumo-investigator` skill.

> [!NOTE]
> These are preview-stage docs. Three details are marked with `{/* VERIFY ... */}` comments and need engineering confirmation before publishing: the exact **CIMD Enabled** toggle label/location, the OpenID configuration path, and the protected resource metadata host/path.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
