### PR TITLE
DOCS-1754 - Update Palo Alto Networks 11 hyperlink

### DIFF
--- a/docs/integrations/cloud-security-monitoring-analytics/palo-alto-networks-11.md
+++ b/docs/integrations/cloud-security-monitoring-analytics/palo-alto-networks-11.md
@@ -103,7 +103,7 @@ To create a server profile specifying  the log destination, do the following:
 
 ### Step 3. Configure syslog forwarding
 
-To configure syslog forwarding for traffic and threat logs, follow the steps to [Configure Log Forwarding](https://docs.paloaltonetworks.com/pan-os/9-1/pan-os-admin/monitoring/configure-log-forwarding) as described in the Palo Networks documentation.
+To configure syslog forwarding for traffic and threat logs, follow the steps to [Configure Log Forwarding](https://docs.paloaltonetworks.com/ngfw/administration/monitoring/configure-log-forwarding) as described in the Palo Networks documentation.
 
 As of March 24, 2022, some Palo Alto Network systems have experienced troubles with validating the Sumo Logic certificate due to their OCSP checking logic. If you encounter this problem, try disabling OCSP checking logic in the firewall. If you continue to have issues, contact Palo Alto’s support, and if needed, contact Sumo Logic’s support for the related Palo Alto case number. [Learn more](https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA14u000000wlXXCAY).
 


### PR DESCRIPTION
## Purpose of this pull request

Updates the outdated "Configure Log Forwarding" hyperlink in the Palo Alto Networks 11 doc, replacing the stale `pan-os/9-1` path with the current `ngfw/administration` path.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1754