### PR TITLE
DOCS-1788 - Document AgentCore Gateway setup for MCP server

### DIFF
--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -54,7 +54,7 @@ The client must support remote HTTP/SSE transport and OAuth 2.0. The setup steps
 
 [CIMD](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) is the recommended authentication mechanism for MCP clients. To learn how CIMD works, see [client.dev](https://client.dev/); for how Sumo Logic implements OAuth 2.0 and CIMD, including how an administrator enables it, see [OAuth Client Setup](/docs/manage/security/oauth).
 
-The MCP server also works behind gateway aggregators, such as AWS Bedrock AgentCore Gateway, that connect to multiple MCP servers through a single endpoint. Configure the gateway's OAuth client using the [Client Credentials flow](/docs/manage/security/oauth#client-credentials-flow). If the gateway target fails with an error resembling `Error parsing ClientCredentials response`, check that its credential provider config explicitly sets `grantType: CLIENT_CREDENTIALS` — some gateways require this field even though Sumo Logic's own OAuth setup doesn't need it named explicitly.
+The MCP server also works behind gateway aggregators, such as AWS Bedrock AgentCore Gateway, that connect to multiple MCP servers through a single endpoint. Configure the gateway's OAuth client using the [Client Credentials flow](/docs/manage/security/oauth#client-credentials-flow). If the gateway target fails with an error resembling `Error parsing ClientCredentials response`, check that its credential provider config explicitly sets `grantType: CLIENT_CREDENTIALS`.
 
 For client compatibility questions, contact [Sumo Logic Support](https://support.sumologic.com/support/s).
 

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -178,6 +178,58 @@ Both require the **Sumo Logic Administrator role** to create the OAuth client an
 Recent VS Code releases do not work with explicit client credentials. Use the default CIMD setup above for VS Code.
 :::
 
+#### Connect through an AWS Bedrock AgentCore Gateway
+
+AWS Bedrock AgentCore Gateway lets you aggregate multiple MCP servers behind a single gateway endpoint. To add the Sumo Logic MCP server as a gateway target, use the [Client Credentials flow](/docs/manage/security/oauth#client-credentials-flow) with a service account, rather than the Authorization Code flow used above for interactive clients.
+
+1. [Create a service account and Client Credentials OAuth client](/docs/manage/security/oauth#client-credentials-flow) for the gateway to authenticate with.
+1. Create an OAuth2 credential provider for the gateway, using your Sumo Logic OAuth client ID and secret:
+   ```bash
+   aws bedrock-agentcore-control create-oauth2-credential-provider \
+     --name "sumologic-oauth-provider" \
+     --credential-provider-vendor CustomOauth2 \
+     --oauth2-provider-config-input '{
+       "customOauth2ProviderConfig": {
+         "oauthDiscovery": {
+           "authorizationServerMetadata": {
+             "issuer": "<mcp-server-url>",
+             "tokenEndpoint": "<mcp-server-url>/oauth2/token"
+           }
+         },
+         "clientId": "<client-id>",
+         "clientSecret": "<client-secret>"
+       }
+     }'
+   ```
+   Replace `<mcp-server-url>` with your [Sumo Logic deployment's MCP server URL](#prerequisites) — the base deployment domain works, a customer-specific subdomain is not required. This flow doesn't use an authorization endpoint, so it's left out of the config above. Instead of specifying `tokenEndpoint` directly, you can point `oauthDiscovery` at your deployment's [OpenID Connect metadata endpoint](/docs/manage/security/oauth#metadata-endpoints); see the AWS `create-oauth2-credential-provider` reference for the exact discovery field name.
+1. Create the gateway target, pointing at the Sumo Logic MCP server and specifying the OAuth2 credential provider:
+   ```bash
+   aws bedrock-agentcore-control create-gateway-target \
+     --gateway-identifier "<your-gateway-id>" \
+     --name "SumoLogicMcpTarget" \
+     --target-configuration '{
+       "mcp": {
+         "mcpServer": {
+           "endpoint": "<mcp-server-url>/mcp"
+         }
+       }
+     }' \
+     --credential-provider-configurations '[{
+       "credentialProviderType": "OAUTH",
+       "credentialProvider": {
+         "oauthCredentialProvider": {
+           "providerArn": "<your-oauth2-credential-provider-arn>",
+           "scopes": [],
+           "grantType": "CLIENT_CREDENTIALS"
+         }
+       }
+     }]'
+   ```
+   :::note
+   The `grantType` field is required. Omitting it fails gateway target creation with an error resembling `Error parsing ClientCredentials response`.
+   :::
+1. Once the target status shows **Ready**, connect your MCP client to the gateway's endpoint instead of connecting directly to Sumo Logic.
+
 ## Available MCP tools
 
 Our MCP server provides access to Sumo Logic through these tool categories:

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -54,6 +54,8 @@ The client must support remote HTTP/SSE transport and OAuth 2.0. The setup steps
 
 [CIMD](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) is the recommended authentication mechanism for MCP clients. To learn how CIMD works, see [client.dev](https://client.dev/); for how Sumo Logic implements OAuth 2.0 and CIMD, including how an administrator enables it, see [OAuth Client Setup](/docs/manage/security/oauth).
 
+The MCP server also works behind gateway aggregators, such as AWS Bedrock AgentCore Gateway, that connect to multiple MCP servers through a single endpoint. Configure the gateway's OAuth client using the [Client Credentials flow](/docs/manage/security/oauth#client-credentials-flow). If the gateway target fails with an error resembling `Error parsing ClientCredentials response`, check that its credential provider config explicitly sets `grantType: CLIENT_CREDENTIALS` — some gateways require this field even though Sumo Logic's own OAuth setup doesn't need it named explicitly.
+
 For client compatibility questions, contact [Sumo Logic Support](https://support.sumologic.com/support/s).
 
 ## Enable or disable the MCP server
@@ -177,58 +179,6 @@ Both require the **Sumo Logic Administrator role** to create the OAuth client an
 :::note
 Recent VS Code releases do not work with explicit client credentials. Use the default CIMD setup above for VS Code.
 :::
-
-#### Connect through an AWS Bedrock AgentCore Gateway
-
-AWS Bedrock AgentCore Gateway lets you aggregate multiple MCP servers behind a single gateway endpoint. To add the Sumo Logic MCP server as a gateway target, use the [Client Credentials flow](/docs/manage/security/oauth#client-credentials-flow) with a service account, rather than the Authorization Code flow used above for interactive clients.
-
-1. [Create a service account and Client Credentials OAuth client](/docs/manage/security/oauth#client-credentials-flow) for the gateway to authenticate with.
-1. Create an OAuth2 credential provider for the gateway, using your Sumo Logic OAuth client ID and secret:
-   ```bash
-   aws bedrock-agentcore-control create-oauth2-credential-provider \
-     --name "sumologic-oauth-provider" \
-     --credential-provider-vendor CustomOauth2 \
-     --oauth2-provider-config-input '{
-       "customOauth2ProviderConfig": {
-         "oauthDiscovery": {
-           "authorizationServerMetadata": {
-             "issuer": "<mcp-server-url>",
-             "tokenEndpoint": "<mcp-server-url>/oauth2/token"
-           }
-         },
-         "clientId": "<client-id>",
-         "clientSecret": "<client-secret>"
-       }
-     }'
-   ```
-   Replace `<mcp-server-url>` with your [Sumo Logic deployment's MCP server URL](#prerequisites) — the base deployment domain works, a customer-specific subdomain is not required. This flow doesn't use an authorization endpoint, so it's left out of the config above. Instead of specifying `tokenEndpoint` directly, you can point `oauthDiscovery` at your deployment's [OpenID Connect metadata endpoint](/docs/manage/security/oauth#metadata-endpoints); see the AWS `create-oauth2-credential-provider` reference for the exact discovery field name.
-1. Create the gateway target, pointing at the Sumo Logic MCP server and specifying the OAuth2 credential provider:
-   ```bash
-   aws bedrock-agentcore-control create-gateway-target \
-     --gateway-identifier "<your-gateway-id>" \
-     --name "SumoLogicMcpTarget" \
-     --target-configuration '{
-       "mcp": {
-         "mcpServer": {
-           "endpoint": "<mcp-server-url>/mcp"
-         }
-       }
-     }' \
-     --credential-provider-configurations '[{
-       "credentialProviderType": "OAUTH",
-       "credentialProvider": {
-         "oauthCredentialProvider": {
-           "providerArn": "<your-oauth2-credential-provider-arn>",
-           "scopes": [],
-           "grantType": "CLIENT_CREDENTIALS"
-         }
-       }
-     }]'
-   ```
-   :::note
-   The `grantType` field is required. Omitting it fails gateway target creation with an error resembling `Error parsing ClientCredentials response`.
-   :::
-1. Once the target status shows **Ready**, connect your MCP client to the gateway's endpoint instead of connecting directly to Sumo Logic.
 
 ## Available MCP tools
 


### PR DESCRIPTION
## Purpose of this pull request

Customers connecting the Sumo Logic MCP server through an AWS Bedrock AgentCore Gateway (to aggregate multiple MCP servers behind one endpoint) hit an opaque `Error parsing ClientCredentials response` error, because the gateway target's OAuth2 credential provider config needs `grantType: CLIENT_CREDENTIALS` explicitly set — an AWS requirement not obvious from our own OAuth setup docs.

Adds one sentence to the OAuth section of `docs/api/mcp-server.md` noting that the MCP server works behind gateway aggregators like AWS Bedrock AgentCore Gateway, that these should be configured with the Client Credentials flow, and that gateways may need `grantType: CLIENT_CREDENTIALS` set explicitly to avoid the error above.

Source: internal Slack thread (INFOR customer, $3.2M ARR); fix confirmed working by Lokent Banswani; requested by Vijit Singhal.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1788