### PR TITLE
DOCS-1789 - Consolidate Mobot monitor-creation docs, fix sidebar label

### DIFF
--- a/docs/alerts/monitors/create-monitor-with-mobot.md
+++ b/docs/alerts/monitors/create-monitor-with-mobot.md
@@ -1,7 +1,6 @@
 ---
 id: create-monitor-with-mobot
-title: Create Monitors with Mobot
-sidebar_label: Create a Monitor with Mobot
+title: Create a Monitor with Mobot
 description: Use Mobot to create and update logs monitors from plain-language prompts, without filling out the monitor form manually.
 keywords:
   - mobot

--- a/docs/alerts/monitors/create-monitor-with-mobot.md
+++ b/docs/alerts/monitors/create-monitor-with-mobot.md
@@ -1,7 +1,7 @@
 ---
 id: create-monitor-with-mobot
 title: Create Monitors with Mobot
-sidebar_label: Create Monitors with Mobot
+sidebar_label: Create a Monitor with Mobot
 description: Use Mobot to create and update logs monitors from plain-language prompts, without filling out the monitor form manually.
 keywords:
   - mobot

--- a/docs/alerts/monitors/create-monitor.md
+++ b/docs/alerts/monitors/create-monitor.md
@@ -480,3 +480,7 @@ Optionally, you can add [**Tags**](/docs/alerts/monitors/settings#tags) to organ
 ### Using Terraform
 
 You can configure Sumo Logic monitors using [Terraform modules](https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor).
+
+### Using Mobot
+
+You can also create and update logs monitors from plain-language prompts using [Mobot](/docs/alerts/monitors/create-monitor-with-mobot).

--- a/docs/search/mobot/index.md
+++ b/docs/search/mobot/index.md
@@ -300,30 +300,9 @@ Beyond analyzing logs, Mobot can create, edit, and summarize Sumo Logic content 
 
 ### Conversational Monitors
 
-Create log-based [monitors](/docs/alerts/monitors) by describing your alerting goal in plain language, instead of writing queries, calculating thresholds, and configuring notifications by hand.
+Create and update log-based [monitors](/docs/alerts/monitors) from plain-language prompts, instead of writing queries and configuring thresholds by hand. Mobot supports static, anomaly, and outlier detection for logs monitors only — not metrics or SLO monitors — and keeps a human in the loop: no monitor goes live until you confirm it.
 
-You can start from any of the following:
-
-- **A query**. Paste a log search query, and Mobot recommends threshold bounds, alert severities, and a name.
-- **An intent**. Describe what you want to watch (for example, `Watch my checkout latency`), and Mobot builds the underlying query and selects the monitor structure for you.
-- **Full parameters**. List every parameter explicitly, and Mobot validates the configuration for deployment.
-
-Mobot uses your historical data to recommend defaults, and you can change any of them inline before you confirm (for example, `Change the threshold to 10%`):
-
-- **Detection method**. Static, anomaly, or outlier detection, based on how much your data varies.
-- **Time window and trigger**. A rolling time window with a trigger condition.
-- **Alert routing**. Webhook connections such as Slack or PagerDuty, or email notifications.
-- **Metadata**. A title, labels, folder location, and description.
-
-No monitor goes live until you confirm it. Reply `Yes` or `Proceed` to deploy.
-
-Known limitations:
-
-- You create monitors from the Mobot interface. Creating them from within the Monitors page is not supported.
-- Only log-based monitors are supported. Metric- and SLO-based monitors are not.
-- You can update a monitor within the same conversation where you created it. You cannot use Mobot to update monitors from other conversations or to disable or delete a monitor. Manage those from the **Monitors** tab.
-
-For the full walkthrough, including example prompts and FAQ, see [Create Monitors with Mobot](/docs/alerts/monitors/create-monitor-with-mobot).
+For the full walkthrough, including example prompts, known limitations, and FAQ, see [Create a Monitor with Mobot](/docs/alerts/monitors/create-monitor-with-mobot).
 
 <!-- Uncomment once Conversational Dashboards GAs
 ### Conversational Dashboards


### PR DESCRIPTION
## Purpose of this pull request

`create-monitor-with-mobot.md` was published as a standalone page with no cross-reference from `create-monitor.md`, unlike every other alternate monitor-creation method (Terraform, dashboard/log-search entry points), which are cross-linked from the main doc rather than left to stand alone. It also has a `sidebar_label` plural mismatch with its sibling doc, and `mobot/index.md`'s "Conversational Monitors" section duplicates most of its content instead of teasing it.

This PR:
- Adds a "Using Mobot" entry under `create-monitor.md`'s Other configurations, mirroring the existing "Using Terraform" pattern.
- Renames `create-monitor-with-mobot.md`'s `sidebar_label` from "Create Monitors with Mobot" to **"Create a Monitor with Mobot"**, matching the singular phrasing of its sibling "Create a New Monitor."
- Trims `mobot/index.md`'s Conversational Monitors section to a short teaser, removing bullet lists (starting inputs, adjustable defaults, known limitations) that duplicated the dedicated doc — cutting the two-places-to-update problem down to one.

Not touched: `create-monitor-with-mobot.md`'s own content, which is well-organized and just needed better cross-linking, not restructuring.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1789