### PR TITLE
DOCS-1792 - Update Data Masking documentation for Limitations and Transpose fix

### DIFF
--- a/docs/manage/data-masking.md
+++ b/docs/manage/data-masking.md
@@ -66,15 +66,17 @@ You can create a data masking rule of your own from scratch by following the ins
 
 ## What are the limitations of data masking?
 
+:::note
+Data masking rule is applied as the **last step** of query processing. This means that any string manipulations earlier in a query execute before masking runs, which may expose sensitive values within the query pipeline.
+:::
+
 | Area | Behavior |
 |:--|:--|
 | **Scheduled Search (Save to Lookup/Index)** | Results are masked or unmasked depending on the `View Unmasked Data` role capability of the user who created the scheduled search. |
-| **Field names** | Masking applies to field values only, not field names. For example, when using the `transpose` operator, values that become field names are not masked. |
 | **Timestamp** | The following timestamp fields are not eligible for data masking: `_messageTime`, `_receiptTime`, and `_searchableTime`. |
 | **Metadata fields** | The following system metadata fields are not eligible for data masking: `_size`, `_collectorid`, `_orgid`, and `_sourceid`. |
 | **Lookup UI page** | Results displayed on the Lookup UI page are always shown unmasked. |
 | **Cloud SIEM (CSE) pages** | Data masking is not applied to any Cloud SIEM pages. |
-| **Internal system queries** | Data masking is not applied to queries running under internal caller modules or system user contexts. |
 | **Query assist suggestions** | Masking is not applied to query-assist suggestions, regardless of the user's role or data access level. |
 
 ## How to edit a data masking rule?


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the public Data Masking documentation per [DOCS-1792](https://sumologic.atlassian.net/browse/DOCS-1792):

- Adds a note to the Limitations section explaining that data masking is applied as the last step of query processing, so string manipulations earlier in a query may expose sensitive values (mirrors the existing note under "How does data masking work?").
- Removes the "Field names" / Transpose limitation row now that the underlying issue is fixed.
- Removes the "Internal system queries" row, which shouldn't be documented publicly.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1792