### PR TITLE
DOCS-1793 - Fix useBaseUrl() not evaluated in llm markdown mirror

### DIFF
--- a/src/plugins/markdown-mirror.js
+++ b/src/plugins/markdown-mirror.js
@@ -26,6 +26,32 @@ function walkDocs(dir, base = dir, files = []) {
   return files;
 }
 
+// Mirrors of a subset of Docusaurus's real addBaseUrl() behavior (see
+// @docusaurus/core/lib/client/exports/useBaseUrl.js): URLs with a protocol
+// (http:, https:, mailto:, //, etc.) or a local anchor (#...) pass through
+// unchanged; everything else gets baseUrl prepended, without doubling it up
+// if it's already there.
+function hasProtocolOrAnchor(url) {
+  return url.startsWith('#') || /^(?:[A-Za-z][A-Za-z\d+.-]*:|\/\/)/.test(url);
+}
+
+function addBaseUrl(url, baseUrl) {
+  if (!url || hasProtocolOrAnchor(url) || url.startsWith(baseUrl)) return url;
+  return baseUrl + url.replace(/^\//, '');
+}
+
+// The raw .md/.mdx source is copied verbatim into the mirror, so JSX like
+// <img src={useBaseUrl('img/x.png')} /> never gets evaluated — it's left in
+// as literal, unresolved text, which downstream crawlers then mangle into
+// broken hrefs. Resolve every useBaseUrl(...) call to its static path before
+// writing the mirrored file.
+function resolveUseBaseUrl(content, baseUrl) {
+  return content.replace(
+    /\{?\s*useBaseUrl\(\s*(['"])(.*?)\1\s*\)\s*\}?/g,
+    (_match, _quote, url) => addBaseUrl(url, baseUrl)
+  );
+}
+
 // Extract the slug field from frontmatter if present.
 function parseFrontmatterSlug(content) {
   if (!content.startsWith('---')) return null;
@@ -95,7 +121,8 @@ module.exports = function markdownMirrorPlugin(context) {
 
         const source = fs.readFileSync(src, 'utf8');
         const { canonical, slug, hasExistingSlug } = deriveCanonical(rel, source, siteUrl, baseUrl);
-        const mirrored = injectCanonicalFields(source, canonical, slug, hasExistingSlug);
+        const resolved = resolveUseBaseUrl(source, baseUrl);
+        const mirrored = injectCanonicalFields(resolved, canonical, slug, hasExistingSlug);
         fs.writeFileSync(dest, mirrored);
 
         index.push(`/llm/docs/${rel.replace(/\\/g, '/')}`);


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes the markdown-mirror plugin, which copies raw `.md`/`.mdx` source verbatim into `/llm/docs/*` for AI crawlers. Because it never evaluates JSX, `useBaseUrl(...)` calls inside image `src` and link `href` attributes were left as literal unresolved text (e.g. `{useBaseUrl('img/apm/traces/display-settings-setup.png')}`). Downstream crawlers mangled these into broken hrefs, which are showing up as real 404s in the GA "Pages and Screens" report.

The plugin now resolves every `useBaseUrl(...)` call to its static path before writing each mirrored file, matching Docusaurus's actual `addBaseUrl()` behavior (absolute URLs and anchors pass through untouched; everything else gets `baseUrl` prepended without doubling it up if already present).

**Testing:**
* Unit-tested the resolver against 6 cases: leading-slash paths, no-leading-slash paths, absolute `https://` URLs, and extra whitespace inside the call.
* Ran a full `yarn build` — confirmed zero remaining `useBaseUrl(` strings across all 2261 mirrored files, and the exact three broken patterns from the ticket now resolve correctly.
* Served the build with `yarn serve` and curled a live mirrored page to confirm the fix holds end-to-end, not just in the build output.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1793