### PR TITLE
DOCS-1542 - Restores homepage and nav to pre-Pantheon state

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -549,6 +549,25 @@ module.exports = {
             type: 'search',
             position: 'left',
           },
+          {
+            type: 'html',
+            position: 'right',
+            value: 'google_translate',
+            className: 'navbar-translate-item',
+          },
+          {
+            label: 'Log In',
+            to: 'https://service.sumologic.com/',
+            position: 'right',
+            className: 'header-login',
+          },
+          {
+            label: 'Try for Free',
+            to: 'https://www.sumologic.com/sign-up',
+            position: 'right',
+            className: 'header-trial',
+            alt: 'Sign up for a Sumo Logic free trial',
+          },
         ],
       },
       footer: {

--- a/src/css/sumo.scss
+++ b/src/css/sumo.scss
@@ -95,6 +95,15 @@
   font-size: .85rem;
 }
 
+// Bold left-side nav labels (Guides, API, Release Notes, Support)
+// Descendant selector (not a direct-child one) because the swizzled
+// DropdownNavbarItem wraps its .navbar__item.navbar__link one level
+// deeper inside a .dropdown div — .navbar__link never appears on
+// submenu items (those get .dropdown__link instead), so this stays scoped.
+.navbar__items:not(.navbar__items--right) .navbar__link {
+  font-weight: 700;
+}
+
 @media (min-width: 1440px) {
   .container {
       max-width: 97%;

--- a/src/css/sumo.scss
+++ b/src/css/sumo.scss
@@ -231,6 +231,17 @@ html[data-theme='light'] {
   min-width: 100px;
 }
 
+@media (min-width: 997px) {
+  .navbar .DocSearch-Button {
+    max-width: 100%;
+    width: 340px;
+  }
+
+  .navbar .DocSearch-Button-Placeholder {
+    min-width: 0;
+  }
+}
+
 html[data-theme='dark'] .DocSearch-Button-Placeholder {
   color: #bdc1c6 !important;
 }
@@ -368,23 +379,206 @@ html[data-theme='dark'] .DocSearch-Search-Icon {
 
 
 
-//Free Trial nav button
-.header-trial:hover {
-  opacity: 0.85;
+// Navbar account and trial buttons
+.navbar__items--right {
+  gap: 0.5rem;
 }
 
-.header-trial::before {
-  content: 'Start free trial';
-  border: .5px solid #0466FF;
-  color: #FFF;
-  border-radius: 3px;
-  padding: 5px 15px;
-  font-size: 13px;
-  font-weight: 600;
+.navbar-translate-item {
+  align-items: center;
+  display: flex;
+  padding: 0;
+}
+
+.navbar__items--right > .navbar__item:not(.header-login):not(.header-trial):not(.navbar-translate-item) {
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.navbar-translate {
+  position: relative;
+}
+
+.navbar-translate__button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  color: var(--ifm-navbar-link-color);
+  cursor: pointer;
   display: inline-flex;
-  background: linear-gradient(35deg,#0466FF 0%,#0800FF 100%);
-  margin-left: -10px;
-  margin-right: -10px;
+  height: 40px;
+  justify-content: center;
+  padding: 0;
+  width: 40px;
+
+  svg {
+    fill: none;
+    height: 24px;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.4;
+    width: 24px;
+  }
+
+  &:hover {
+    background-color: rgba(4, 102, 255, 0.08);
+    color: #0466ff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #06bcee;
+    outline-offset: 2px;
+  }
+}
+
+.navbar-translate__menu {
+  background: var(--ifm-dropdown-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  box-shadow: var(--ifm-global-shadow-lw);
+  padding: 0.75rem;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  z-index: var(--ifm-z-index-dropdown);
+
+  &[hidden] {
+    display: none !important;
+  }
+
+  .goog-te-gadget,
+  .goog-te-combo {
+    font-family: "Lab Grotesque", sans-serif;
+  }
+
+  .goog-te-combo {
+    margin: 0;
+    min-width: 10rem;
+  }
+
+  .goog-te-gadget {
+    color: var(--ifm-font-color-secondary);
+    line-height: 1.4;
+  }
+
+  .goog-logo-link {
+    color: var(--ifm-link-color) !important;
+  }
+}
+
+.header-login,
+.header-trial {
+  align-items: center;
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: "Lab Grotesque", sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  height: 34px;
+  justify-content: center;
+  line-height: 1;
+  min-height: 34px;
+  padding: 0 13px;
+  transition: none;
+}
+
+.header-login {
+  --ifm-navbar-link-color: #1d2b45;
+  --ifm-navbar-link-hover-color: #1d2b45;
+  background-color: #eef0f2;
+  border: 1px solid #e2e5e8;
+  border-radius: 10px;
+  color: #1d2b45;
+}
+
+.navbar .header-login,
+.navbar .header-login *,
+.navbar .header-login:hover,
+.navbar .header-login:hover *,
+.navbar .header-login:focus,
+.navbar .header-login:focus *,
+.navbar .header-login:active,
+.navbar .header-login:active *,
+.navbar .header-login:visited,
+.navbar .header-login:visited * {
+  color: #1d2b45 !important;
+}
+
+.header-login:hover {
+  background-color: #e4e7ea;
+  border-color: #d9dde1;
+  color: #1d2b45;
+  text-decoration: none;
+}
+
+.header-trial {
+  --ifm-navbar-link-color: #fff;
+  --ifm-navbar-link-hover-color: #fff;
+  background: #0466ff;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  color: #fff !important;
+  letter-spacing: 0.01em;
+  margin-left: 0;
+  min-width: 100px;
+  white-space: nowrap;
+}
+
+.navbar .header-trial,
+.navbar .header-trial *,
+.navbar .header-trial:hover,
+.navbar .header-trial:hover *,
+.navbar .header-trial:focus,
+.navbar .header-trial:active,
+.navbar .header-trial:visited {
+  color: #fff !important;
+}
+
+[data-theme='light'] .navbar .header-trial,
+[data-theme='light'] .navbar .header-trial * {
+  color: #fff !important;
+}
+
+.header-trial:hover {
+  background: #0055d6;
+  border-color: transparent;
+  color: #fff !important;
+  text-decoration: none;
+}
+
+.header-trial:active {
+  background: #0045be;
+  border-color: transparent;
+}
+
+.header-login:focus-visible,
+.header-trial:focus-visible {
+  outline: 2px solid #06bcee;
+  outline-offset: 2px;
+}
+
+[data-theme='dark'] .header-login {
+  --ifm-navbar-link-color: #d5d9e0;
+  --ifm-navbar-link-hover-color: #d5d9e0;
+  background-color: #1a253b;
+  border-color: #2b3952;
+  color: #d5d9e0;
+}
+
+[data-theme='dark'] .navbar .header-login,
+[data-theme='dark'] .navbar .header-login * {
+  color: #d5d9e0 !important;
+}
+
+[data-theme='dark'] .header-login:hover {
+  background-color: #24324a;
+  border-color: #34445f;
+  color: #d5d9e0;
 }
 
 div[class*="announcementBar_"] {
@@ -408,23 +602,11 @@ div[class*="announcementBar_"] a {
     content: none !important;
 }
 
-[data-theme='dark'] .header-trial::before {
-  background: transparent;
-  border: .5px solid #0466FF;
-  color: #FFF;
-  border-radius: 3px;
-  padding: 5px 15px;
-  font-size: 13px;
-  font-weight: 600;
-  display: inline-flex;
-  margin-left: -10px;
-  margin-right: -10px;
-  background: linear-gradient(35deg, #0466FF 0%, #0800FF 30%, #000099 100%);
+.header-login::after {
+  content: none !important;
+  display: none !important;
 }
 
-[data-theme='light'] .header-trial::before {
-  border: .5px solid #0466FF;
-}
 .markdown {
   h1 {
     font-size: 2rem !important;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,6 @@ import SumoLogicDocsLogo from '../../static/img/reuse/sumo-logic-docs.svg';
 import { Feature } from '../components/Feature';
 import { features } from '../helper/features';
 import ErrorBoundary from '../components/ErrorBoundary';
-import GoogleTranslateNavbarItem from '../theme/NavbarItem/GoogleTranslateNavbarItem';
 
 export const Home = () => {
   const [tab, setTab] = useState('0');
@@ -62,7 +61,6 @@ export const Home = () => {
             }}
             width='100%'
           />
-        <GoogleTranslateNavbarItem/>
         </Typography>
 
         {/* Hero */}
@@ -129,11 +127,6 @@ export const Home = () => {
                     Get started quickly with log analytics, AI-powered troubleshooting, observability, and security.
                   </Typography>
                   {[
-                    {
-                      children: 'Start a free trial',
-                      description: 'Sign up for a Sumo Logic free trial',
-                      href: 'https://www.sumologic.com/sign-up/',
-                    },
                     {
                       children: '1. Set up collector and source',
                       description: 'Set up a Sumo Logic collector and source',

--- a/src/theme/NavbarItem/GoogleTranslateNavbarItem.tsx
+++ b/src/theme/NavbarItem/GoogleTranslateNavbarItem.tsx
@@ -1,6 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const GoogleTranslateNavbarItem = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (!window.googleTranslateElementInit) {
       window.googleTranslateElementInit = function () {
@@ -17,7 +20,51 @@ const GoogleTranslateNavbarItem = () => {
     }
   }, []);
 
-  return <div id="google_translate_element"></div>;
+  useEffect(() => {
+    const closeMenu = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', closeMenu);
+    document.addEventListener('keydown', closeOnEscape);
+
+    return () => {
+      document.removeEventListener('mousedown', closeMenu);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, []);
+
+  return (
+    <div className="navbar-translate" ref={containerRef}>
+      <button
+        aria-expanded={isOpen}
+        aria-label="Translate this page"
+        className="navbar-translate__button"
+        onClick={() => setIsOpen((open) => !open)}
+        type="button"
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" />
+          <path d="M3 12h18M12 3c2.4 2.5 3.7 5.5 3.7 9S14.4 18.5 12 21M12 3C9.6 5.5 8.3 8.5 8.3 12s1.3 6.5 3.7 9" />
+        </svg>
+      </button>
+      <div
+        aria-hidden={!isOpen}
+        className={`navbar-translate__menu${isOpen ? ' navbar-translate__menu--open' : ''}`}
+        hidden={!isOpen}
+      >
+        <div id="google_translate_element"></div>
+      </div>
+    </div>
+  );
 };
 
 export default GoogleTranslateNavbarItem;


### PR DESCRIPTION
## Purpose of this pull request

This pull request restores the JS-dependent nav elements that were pulled during the Algolia outage mitigation, per [DOCS-1542](https://sumologic.atlassian.net/browse/DOCS-1542):

- Re-adds primary/secondary CTA buttons ("Log In", "Try for Free") to the top-right nav
- Restores the language selector, rebuilt as an icon button with a dropdown menu (moved from the homepage hero into the navbar)
- Restores the enlarged search input on desktop
- Bolds the left-side nav labels (Guides, API, Release Notes, Support)
- Removes the now-duplicate Google Translate widget and "Start a free trial" CTA from the homepage hero, since both are superseded by the new nav items

**Out of scope for this PR:** remaining items on DOCS-1542, including homepage hero audience-based intent logic, hero image/product screenshot, and announcement banner verification.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1542
