### PR TITLE
Extract Mobot playbook creation into its own page

### DIFF
--- a/blog-service/2026-08-05-automation-service.md
+++ b/blog-service/2026-08-05-automation-service.md
@@ -10,4 +10,4 @@ hide_table_of_contents: true
 
 We're excited to introduce that you can now build and update playbooks by chatting with Mobot instead of wiring up nodes by hand. Describe the automation you want in plain language, and Mobot checks your org's available integrations, asks clarifying questions, proposes a plan, and configures each step for you. Once you approve, it saves the playbook as a draft.
 
-To make changes, just send a follow-up request and Mobot updates the plan and rebuilds the playbook automatically. Review the finished flow on the canvas, then publish when you're ready. [Learn more](/docs/platform-services/automation-service/playbooks/create-playbooks/#create-edit-and-modify-playbooks-using-mobot).
+To make changes, just send a follow-up request and Mobot updates the plan and rebuilds the playbook automatically. Review the finished flow on the canvas, then publish when you're ready. [Learn more](/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot).

--- a/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot.md
+++ b/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot.md
@@ -40,5 +40,4 @@ Follow the steps below to create a playbook using Mobot:
 ## Related resources
 
 - [Mobot](/docs/search/mobot)
-- [Mobot Example Prompts](/docs/search/mobot/mobot-example-prompts)
 - [Create Playbooks](/docs/platform-services/automation-service/playbooks/create-playbooks)

--- a/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot.md
+++ b/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot.md
@@ -1,0 +1,38 @@
+---
+id: create-playbooks-with-mobot
+title: Create Playbooks with Mobot
+sidebar_label: Create Playbooks with Mobot ✨
+description: Create and manage playbooks in Mobot from plain-language prompts, without manual configuration.
+keywords:
+  - mobot
+  - playbook
+  - dojo ai
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import ConvPlaybookLimits from '../../../reuse/conv-playbook-limits.md';
+
+[Mobot](/docs/search/mobot) enables you to create playbooks using natural language. Mobot is the AI Playbook Assistant built into the Playbooks editor. Instead of manually wiring up nodes, you describe what you want in plain language, and Mobot proposes a plan, asks clarifying questions, and builds the playbook for you.
+
+<ConvPlaybookLimits/>
+
+### Create and manage playbooks using Mobot
+
+#### Prerequisites
+
+Playbooks automate response actions for monitors, Cloud SIEM insights, entities, and Cloud SOAR incidents. Before building a new one, check whether an existing playbook (or one from App Central) already does what you need.
+
+Follow the steps below to create a playbook using Mobot:
+1. [**New UI**](/docs/get-started/sumo-logic-ui). In the main Sumo Logic menu, select **Automation > Playbooks**. You can also click the **Go To...** menu at the top of the screen and select **Playbooks**.  <br/>[**Classic UI**](/docs/get-started/sumo-logic-ui-classic).  In the main Sumo Logic menu, select **Automation**. <br/>Previously-created playbooks display.
+1. Click the **+ Create Playbook** button.
+1. Click the untitled playbook and rename it.<br/><img src={useBaseUrl('img/cse/automations-new-playbook-dialog.png')} style={{border:'1px solid gray'}} alt="New playbook dialog" />
+1. Enter a **Description** of the playbook to help others understand how to use it.
+1. Select the incident **Type**. (For example, for Cloud SIEM automations, select **Cloud SIEM**. For playbooks run from inside another playbook, you can select another incident type to associate with it, for example, **Denial of Service**, **Malware**, **Phishing**, and so on.)
+1. In the chat box, describe the automation you want in plain language. For example, `Create a playbook that creates tickets and sends notifications`.<br/><img src={useBaseUrl('img/cse/prompt-for-mobot.png')} style={{border:'1px solid gray'}} alt="Mobot chatbox" />
+1. Answer Mobot's clarifying questions. Mobot checks your org's available integrations, asks which ones you'd like to use, then walks through each action node one at a time to gather the configuration details it needs.
+1. Review and approve the plan Mobot proposes, including the trigger, steps, and flow between them.
+1. Once every step is confirmed, Mobot saves the playbook as a draft and posts a summary table of what was built (Step / Action / Details).
+1. To make changes, send a follow-up request describing the edit.<br/><img src={useBaseUrl('img/cse/edit-playbook.png')} style={{border:'1px solid gray'}} alt="edit-playbook" width="200"/><br/>Mobot returns an updated plan reflecting the new flow.
+1. Reply `Yes` (or similar) to approve, and Mobot rebuilds and resaves the playbook.
+1. Click any node on the canvas to verify the details Mobot filled in, such as the integration, resource, and field mappings pulled from the trigger payload.<br/><img src={useBaseUrl('img/cse/playbook-flow.png')} style={{border:'1px solid gray'}} alt="playbook-flow"/>
+1. Click **Publish** to make the playbook available for use in automations.

--- a/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot.md
+++ b/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot.md
@@ -36,3 +36,9 @@ Follow the steps below to create a playbook using Mobot:
 1. Reply `Yes` (or similar) to approve, and Mobot rebuilds and resaves the playbook.
 1. Click any node on the canvas to verify the details Mobot filled in, such as the integration, resource, and field mappings pulled from the trigger payload.<br/><img src={useBaseUrl('img/cse/playbook-flow.png')} style={{border:'1px solid gray'}} alt="playbook-flow"/>
 1. Click **Publish** to make the playbook available for use in automations.
+
+## Related resources
+
+- [Mobot](/docs/search/mobot)
+- [Mobot Example Prompts](/docs/search/mobot/mobot-example-prompts)
+- [Create Playbooks](/docs/platform-services/automation-service/playbooks/create-playbooks)

--- a/docs/platform-services/automation-service/playbooks/create-playbooks.md
+++ b/docs/platform-services/automation-service/playbooks/create-playbooks.md
@@ -44,26 +44,6 @@ The following procedure provides a brief introduction to how to create a playboo
 
 See [Add nodes to a playbook](/docs/platform-services/automation-service/playbooks/create-playbooks/#add-nodes-to-a-playbook) for next steps.
 
-### Create, edit, and modify playbooks using Mobot
-
-Mobot is the AI Playbook Assistant built into the Playbooks editor. Instead of manually wiring up nodes, you describe what you want in plain language, and Mobot proposes a plan, asks clarifying questions, and builds the playbook for you.
-
-<ConvPlaybookLimits/>
-
-#### Prerequisites
-
-Playbooks automate response actions for monitors, Cloud SIEM insights, entities, and Cloud SOAR incidents. Before building a new one, check whether an existing playbook (or one from App Central) already does what you need.
-
-Follow steps 1–5 above to open the Playbooks page, create, name, and describe your playbook. Then:
-1. In the chat box, describe the automation you want in plain language. For example, `Create a playbook that creates tickets and sends notifications`.<br/><img src={useBaseUrl('img/cse/prompt-for-mobot.png')} style={{border:'1px solid gray'}} alt="Mobot chatbox" />
-1. Answer Mobot's clarifying questions. Mobot checks your org's available integrations, asks which ones you'd like to use, then walks through each action node one at a time to gather the configuration details it needs.
-1. Review and approve the plan Mobot proposes, including the trigger, steps, and flow between them.
-1. Once every step is confirmed, Mobot saves the playbook as a draft and posts a summary table of what was built (Step / Action / Details).
-1. To make changes, send a follow-up request describing the edit.<br/><img src={useBaseUrl('img/cse/edit-playbook.png')} style={{border:'1px solid gray'}} alt="edit-playbook" width="200"/><br/>Mobot returns an updated plan reflecting the new flow.
-1. Reply `Yes` (or similar) to approve, and Mobot rebuilds and resaves the playbook.
-1. Click any node on the canvas to verify the details Mobot filled in, such as the integration, resource, and field mappings pulled from the trigger payload.<br/><img src={useBaseUrl('img/cse/playbook-flow.png')} style={{border:'1px solid gray'}} alt="playbook-flow"/>
-1. Click **Publish** to make the playbook available for use in automations.
-
 ## Add nodes to a playbook
 
 You can add nodes to a playbook when you either create a new playbook, or edit an existing playbook. To add a node to a playbook, hover your mouse over an existing node, such as the **Start** node, and click on the **+** button that appears on the node. A *node* is a step in a playbook. Nodes run in the order they are placed in a playbook. When all nodes run without error, the playbook is considered to have executed successfully.

--- a/docs/platform-services/automation-service/playbooks/index.md
+++ b/docs/platform-services/automation-service/playbooks/index.md
@@ -33,6 +33,12 @@ You can use Terraform to manage playbooks with the [`sumologic_csoar_playbook`](
 </div>
 <div className="box smallbox card">
   <div className="container">
+  <a href={useBaseUrl('docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot/')}><img src={useBaseUrl('img/icons/security/siem-challenges.png')} alt="SIEM Challenges icon" width="40"/><h4>Create Playbooks with Mobot</h4></a>
+  <p>Create and manage playbooks in Mobot from plain-language prompts, without manual configuration.</p>
+  </div>
+</div>
+<div className="box smallbox card">
+  <div className="container">
   <a href={useBaseUrl('docs/platform-services/automation-service/playbooks/playbook-payloads/')}><img src={useBaseUrl('img/icons/security/siem-challenges.png')} alt="SIEM Challenges icon" width="40"/><h4>Playbook Payloads</h4></a>
   <p> Learn about the data payloads of the different playbook types.</p>
   </div>

--- a/docs/search/mobot/index.md
+++ b/docs/search/mobot/index.md
@@ -336,7 +336,7 @@ Known limitations:
 
 Create and edit Automation Service [playbooks](/docs/platform-services/automation-service/playbooks) through natural language, using the Mobot chat box built into the Playbooks editor, instead of building node by node on the visual canvas. Describe the automation you want, and Mobot proposes a plan, asks clarifying questions, and builds the playbook for you. The visual canvas is unchanged and remains fully available for manual edits.
 
-For the full walkthrough, see [Create, edit, and modify playbooks using Mobot](/docs/platform-services/automation-service/playbooks/create-playbooks/#create-edit-and-modify-playbooks-using-mobot).
+For the full walkthrough, see [Create Playbooks with Mobot](/docs/platform-services/automation-service/playbooks/create-playbooks-with-mobot).
 
 <ConvPlaybookLimits/>
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -3355,6 +3355,7 @@ integrations: [
               link: {type: 'doc', id: 'platform-services/automation-service/playbooks/index'},
               items: [
                 'platform-services/automation-service/playbooks/create-playbooks',
+                'platform-services/automation-service/playbooks/create-playbooks-with-mobot',
                 'platform-services/automation-service/playbooks/playbook-payloads',
                 'platform-services/automation-service/playbooks/arrays-in-playbooks',
                 'platform-services/automation-service/playbooks/troubleshoot-playbooks',


### PR DESCRIPTION
## Purpose of this pull request

This pull request extracts the "Create, edit, and modify playbooks using Mobot" section out of `create-playbooks.md` into a standalone `create-playbooks-with-mobot.md` page, matching the pattern already used for `create-monitor-with-mobot.md` and `create-panel-with-mobot.md`. Adds an index tile, sidebar entry (with the sparkle emoji convention), and fixes two stale cross-references left pointing at the old inline anchor.

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

N/A