### PR TITLE
Update automations page

### DIFF
--- a/blog-cse/2026-08-12-application.md
+++ b/blog-cse/2026-08-12-application.md
@@ -12,7 +12,3 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 We're happy to announce a redesigned Automations tab on Insights, featuring a new table view that replaces the previous card view, along with a new side panel for a more streamlined experience.
 
 The Insights Automations tab displays all associated playbook runs, including the trigger, start time, and current status. Select a playbook to view detailed execution information. [Learn more](/docs/cse/automation/automations-in-cloud-siem#view-results-of-an-automation).
-
-:::note
-This is in the rollout phase and will be available in all regions shortly.
-:::


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the "rollout phase" note from the Cloud SIEM Automations tab redesign announcement, since the feature is now fully available in all regions.


## Select the type of change

- [x] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

N/A