### PR TITLE
DOCS-1822 - Add Feature Management headings for search discoverability

### DIFF
--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -79,6 +79,8 @@ Watch this micro lesson to learn how to connect an MCP-compatible AI client, suc
 
 ## Enable or disable the MCP server
 
+### Feature Management
+
 MCP server access is enabled by default. An administrator can turn it on or off for your entire organization.
 
 1. In the main Sumo Logic menu, select **Administration** > **Feature Management**.

--- a/docs/cse/get-started-with-cloud-siem/soc-analyst-agent.md
+++ b/docs/cse/get-started-with-cloud-siem/soc-analyst-agent.md
@@ -61,6 +61,8 @@ Watch this micro lesson to learn how the SOC Analyst Agent triages and investiga
 
 The SOC Analyst Agent requires a Cloud SIEM subscription and is opt-in. See [How does investigation rate limiting work?](#how-does-investigation-rate-limiting-work) for information about your organization's investigation capacity.
 
+### Feature Management
+
 To disable the SOC Analyst Agent for your entire organization, an administrator can turn it off from the **Feature Management** page (**Administration** > **Feature Management**), available to any user with the Administrator role or the **Manage Organization Settings** permission. The SOC Analyst Agent has its own **SOC Analyst Agent** toggle, independent of the **AI features** toggle that governs Mobot and Parse Assist, and the **MCP Server access** toggle.
 
 Parent and child orgs have the SOC Analyst Agent enabled by default. A parent org administrator can toggle it for the parent org and for its child orgs. Child org administrators cannot toggle it for their own org or for other child orgs.

--- a/docs/get-started/ai-machine-learning.md
+++ b/docs/get-started/ai-machine-learning.md
@@ -145,6 +145,12 @@ AI features are on by default. We offer two methods for opting out:
 
 <MSSPfeatureMgmt/>
 
+### What is the Feature Management page?
+
+**Feature Management** (**Administration** > **Feature Management**) is where administrators enable or disable Mobot, Parse Assist, the SOC Analyst Agent, and MCP server access for your organization. It's available to any user with the Administrator role or the **Manage Organization Settings** permission.
+
+<img src={useBaseUrl('img/search/mobot/feature-management.png')} alt="Feature Management page showing the AI features, MCP Server access, and SOC Analyst Agent toggles" style={{border: '1px solid gray'}} width="800" />
+
 ### What happened to Query Agent, Knowledge Agent, and Summary Agent?
 
 They're still here, but renamed and repositioned as their capabilities have evolved.

--- a/docs/search/mobot/index.md
+++ b/docs/search/mobot/index.md
@@ -622,6 +622,8 @@ Let us know what you think by clicking the thumbs up icon to confirm a useful re
 
 ## Opting out
 
+### Feature Management
+
 An administrator can turn Mobot off for your entire organization from the **Feature Management** page (**Administration** > **Feature Management**). This page is available to all paid customers (not free or trial accounts) to any user with the Administrator role or the **Manage Organization Settings** permission.
 
 Mobot shares a single **AI features** toggle with Parse Assist — turning it off disables both together. The SOC Analyst Agent has its own independent **SOC Analyst Agent** toggle and is not affected by the **AI features** toggle.


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds an H3 **Feature Management** subheading to the Mobot, MCP server, and SOC Analyst Agent docs, and a matching FAQ entry with screenshot to the AI/ML FAQ page.

The phrase "Feature Management" already appeared verbatim on all of these pages, but only in body text. Algolia's docsearch ranks heading matches far above content matches, so searching "Feature Management" on the docs site surfaced unrelated pages (like "Remote Management" and "Reliability Management (SLO)") instead of the actually relevant docs. Adding a literal heading fixes the ranking.

Updated:
- `docs/search/mobot/index.md`
- `docs/api/mcp-server.md`
- `docs/cse/get-started-with-cloud-siem/soc-analyst-agent.md`
- `docs/get-started/ai-machine-learning.md` (new FAQ entry + screenshot, phrased as a question to match the section's existing style)

## Select the type of change
<!-- What types of changes does your code introduce? Select the checkbox after clicking "Create pull request" button. -->

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)