### PR TITLE
Add redirects for broken links found in GA4 404 report

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -5665,5 +5665,13 @@
   "/docs/send-data/installed-collectors/collector-management/mcp-agent": "/docs/api/mcp-server",
   "/docs/send-data/installed-collectors/install-a-collector-on-linux": "/docs/send-data/installed-collectors/linux",
   "/docs/send-data/kubernetes/collecting-application-logs-otel": "/docs/send-data/kubernetes/collecting-logs",
-  "/Send_Data/Sources/HTTP_Source/Upload_Data_to_an_HTTP_Source": "/docs/send-data/hosted-collectors/http-source"
+  "/Send_Data/Sources/HTTP_Source/Upload_Data_to_an_HTTP_Source": "/docs/send-data/hosted-collectors/http-source",
+  "/docs/alerts/monitors/monitor-permissions": "/docs/alerts/monitors/settings#monitor-folder-permissions",
+  "/docs/get-started/library/manage-content-move-copy-delete": "/docs/get-started/library#move-content-in-personal-folders",
+  "/docs/integrations/security-threat-detection/fortigate": "/docs/cse/ingestion/ingestion-sources-for-cloud-siem/fortigate-firewall",
+  "/docs/manage/content-sharing/share-a-dashboard": "/docs/dashboards/share-dashboard-new",
+  "/docs/search/get-started-with-search/build-search/share-search-url": "/docs/search/get-started-with-search/build-search/use-url-to-run-search",
+  "/docs/search/get-started-with-search/search-basics/built-in-metadata-fields": "/docs/search/get-started-with-search/search-basics/built-in-metadata",
+  "/docs/search/get-started-with-search/search-basics/message-time-vs-receipt-time": "/docs/search/get-started-with-search/build-search/use-receipt-time",
+  "/docs/search/get-started-with-search/search-basics/search-time-range": "/docs/search/get-started-with-search/build-search/set-time-range"
 }


### PR DESCRIPTION
## Purpose of this pull request

While investigating whether PR #7010 (the markdown-mirror `useBaseUrl()` fix) actually resolved the `/llm/docs/*` 404s showing up in the GA4 "Pages and Screens" report, I found that fix is working correctly in production (verified against the live mirrored pages) — those specific hits are stale, pre-fix data aging out of the rolling report window.

Separately, the same GA4 report surfaced a set of internal links 404ing against paths that don't correspond to any current doc. This PR adds redirects in `cid-redirects.json` for the ones I could confidently map to their current location/section based on content and title matches:

- `/docs/alerts/monitors/monitor-permissions` → `/docs/alerts/monitors/settings#monitor-folder-permissions`
- `/docs/get-started/library/manage-content-move-copy-delete` → `/docs/get-started/library#move-content-in-personal-folders`
- `/docs/integrations/security-threat-detection/fortigate` → `/docs/cse/ingestion/ingestion-sources-for-cloud-siem/fortigate-firewall`
- `/docs/manage/content-sharing/share-a-dashboard` → `/docs/dashboards/share-dashboard-new`
- `/docs/search/get-started-with-search/build-search/share-search-url` → `/docs/search/get-started-with-search/build-search/use-url-to-run-search`
- `/docs/search/get-started-with-search/search-basics/built-in-metadata-fields` → `/docs/search/get-started-with-search/search-basics/built-in-metadata`
- `/docs/search/get-started-with-search/search-basics/message-time-vs-receipt-time` → `/docs/search/get-started-with-search/build-search/use-receipt-time`
- `/docs/search/get-started-with-search/search-basics/search-time-range` → `/docs/search/get-started-with-search/build-search/set-time-range`

A few other 404s from the same report were intentionally left out: no internal page covers `/docs/security/encryption`, `/docs/cse/schema/full-schema` only has an external (GitHub) equivalent, `/docs/reuse/collection-should-begin-note` is a non-page content snippet, and a large cluster of `threat-forecasting` paths and pre-Docusaurus legacy paths look unrelated to this fix and are being tracked separately.

**Testing:**
* Validated `cid-redirects.json` still parses as valid JSON.
* Confirmed both anchor targets (`#monitor-folder-permissions`, `#move-content-in-personal-folders`) exist as headings on their target pages.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

N/A — quick fix, no Jira ticket

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012Ye1ZWsQniY2hHNJZAdBVV)_