### PR TITLE
Update August release note with AWSO module and Terraform provider details

### DIFF
--- a/blog-service/2026-08-31-apps.md
+++ b/blog-service/2026-08-31-apps.md
@@ -9,7 +9,9 @@ hide_table_of_contents: true
 
 ### New release
 
-We're excited to announce the release of the Sumo Logic app for **Druva - Platform Events**. This app helps you monitor Druva via a webhook-based integration. [Learn more](/docs/integrations/webhooks/druva-platform-events/).
+We're excited to announce the release of the following Sumo Logic apps: 
+- **Druva - Platform Events**. This app helps you monitor Druva via a webhook-based integration. [Learn more](/docs/integrations/webhooks/druva-platform-events/).
+- **[AWS Observability Terraform Module for AWSO 3.0.0](https://registry.terraform.io/modules/SumoLogic/aws-observability/sumologic/latest)**. This Terraform module deploys the [Sumo Logic AWS Observability Solution](/docs/observability/aws/), a full-stack observability solution for AWS environments. It configures AWS collection infrastructure and installs Sumo Logic apps, monitors, dashboards, and field extraction rules for supported AWS services.
 
 ### Automation service integrations
 
@@ -23,14 +25,12 @@ The following Automation Service Integrations are now generally available:
 ### Enhancements
 
 - **Akamai SIEM API v1.2.26**. Added parser path support. For more information, see [Akamai SIEM API Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/akamai-siem-api-source/).
-- **Cato Networks v1.0.23**. Performance improvements for Cato Networks data collection. For more information, see [Cato Networks Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/cato-networks-source/).
-- **Claude Compliance C2C v2.0.2**. Reliability improvements for Claude Compliance data collection. For more information, see [Claude Compliance Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/claude-compliance-source/) and [Claude Compliance App](/docs/integrations/saas-cloud/claude-compliance/).
 - **Google Cloud SQL**. Added support for PostgreSQL instances. For more information, see [Google Cloud SQL](/docs/integrations/google/cloud-sql/).
-- **Miro**. Aligned the app with the latest Miro Cloud-to-Cloud source, added new out-of-the-box monitors, and included additional fixes. The Miro source also completed a smooth transition to a new API version, removing its dependency on the deprecated Audit Log API v2. For more information, see [Miro App](/docs/integrations/saas-cloud/miro/) and [Miro Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/miro-source/).
-- **SumoLogic Terraform Provider [v3.3.0](https://github.com/SumoLogic/terraform-provider-sumologic/releases/tag/v3.3.0)**. Released with two new resources: [`sumologic_async_aws_lambda_invocation`](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/async_aws_lambda_invocation) and [`sumologic_s3_logging_lambda_enable`](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/s3_logging_lambda_enable).
-- **Universal Connector v1.0.34**. Reliability improvements for Universal Connector data collection. For more information, see [Universal Connector Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/universal-connector-source/).
+- **Miro**. Aligned the Miro app with the latest Miro Cloud-to-Cloud source, added new out-of-the-box monitors, and included additional fixes. The Miro source also completed a smooth transition to a new API version **Audit Log v2 API**. For more information, see [Miro App](/docs/integrations/saas-cloud/miro/) and [Miro Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/miro-source/).
+- **SumoLogic Terraform Provider [v3.3.0](https://github.com/SumoLogic/terraform-provider-sumologic/releases/tag/v3.3.0)**. Released with the following resources:
+  - [`sumologic_async_aws_lambda_invocation`](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/async_aws_lambda_invocation). This resource asynchronously invokes an AWS Lambda function with support for AWS named profiles, enabling multi-account deployments.
+  - [`sumologic_s3_logging_lambda_enable`](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/s3_logging_lambda_enable). Renamed from `sumologic_lambda_invoke_action` and enhanced with `region` and `aws_profile` arguments to support explicit AWS region configuration and named AWS credential profiles, enabling multi-account deployments. If you use `sumologic_lambda_invoke_action` in an existing configuration, update it to `sumologic_s3_logging_lambda_enable`.
 
 ### Bug fixes
 
-- **Google Workspace** and **Azure Audit**. Bug fixes were released for these apps.
-- **SentinelOne Mgmt API v1.2.17**. Fixed a data duplication issue. For more information, see [SentinelOne Mgmt API Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/sentinelone-mgmt-api-source/).
+- **[Google Workspace](/docs/integrations/google/workspace/install-app-dashboards/)** and **[Azure Audit](/docs/integrations/microsoft-azure/audit/)**. Bug fixes were released for these apps.


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the AWS Observability Terraform module 3.0.0 as a new release in the August apps/integrations note, expands the SumoLogic Terraform Provider v3.3.0 resource descriptions, and clarifies that `sumologic_s3_logging_lambda_enable` was renamed from `sumologic_lambda_invoke_action` so existing Terraform users know to update their configs.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

N/A