### PR TITLE
DOCS-988 - Remove marketing language from release note templates and style guide

### DIFF
--- a/.claude/commands/release-note-collector.md
+++ b/.claude/commands/release-note-collector.md
@@ -122,7 +122,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 #### Installed Collector Release Structure
 
 ```markdown
-In this release, we've enhanced the security and stability of the Collector with added support for security patches.
+This release includes security and stability fixes.
 
 #### Security fix
 
@@ -136,7 +136,7 @@ In this release, we've enhanced the security and stability of the Collector with
 ```
 
 **Installed Collector Guidelines:**
-* Start with standard intro: "In this release, we've enhanced the security and stability of the Collector with added support for {security patches/bug fixes/features}."
+* Start with a direct intro: "This release includes {security patches/bug fixes/features}."
 * Use H4 (`####`) for section headings: Security fix, Bug fix, Feature
 * List items use bullet points with dashes.
 * Include specific version numbers for dependencies.
@@ -146,7 +146,7 @@ In this release, we've enhanced the security and stability of the Collector with
 
 **Example:**
 ```markdown
-In this release, we've enhanced the security and stability of the Collector with added support for security patches.
+This release includes security and stability fixes.
 
 #### Security fix
 
@@ -161,7 +161,7 @@ In this release, we've enhanced the security and stability of the Collector with
 #### OpenTelemetry Release Structure
 
 ```markdown
-We're excited to {announce/introduce} {feature description}. {What it does and benefits}. [Learn more](/docs/path/to/doc).
+{Feature name} {is now available / now supports X / now includes Y}. {What it does and benefits}. [Learn more](/docs/path/to/doc).
 
 {Optional: Additional paragraphs with more details}
 
@@ -171,7 +171,7 @@ We're excited to {announce/introduce} {feature description}. {What it does and b
 ```
 
 **OpenTelemetry Guidelines:**
-* Start with "We're excited to announce..." or "We're excited to introduce...".
+* Open with a direct statement: "[Feature] is now available." or "[Feature] now supports [X]."
 * Write 2-3 sentences in first paragraph.
 * Focus on user benefits and business value.
 * End first paragraph with "Learn more" link.
@@ -183,14 +183,14 @@ We're excited to {announce/introduce} {feature description}. {What it does and b
 ```markdown
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-We're excited to announce that you can now convert Installed Collector (IC) local file sources to OpenTelemetry (OTel) source templates for a more modern, scalable, and consistent data collection experience. This conversion helps future-proof your setup, making it easier to manage collectors at scale while benefiting from ongoing OTel improvements and support. [Learn more](/docs/send-data/installed-collectors/sources/convert-ic-local-file-source-to-otel-st/).
+You can now convert Installed Collector (IC) local file sources to OpenTelemetry (OTel) source templates for a more modern, scalable, and consistent data collection experience. This conversion makes it easier to manage collectors at scale while benefiting from ongoing OTel improvements and support. [Learn more](/docs/send-data/installed-collectors/sources/convert-ic-local-file-source-to-otel-st/).
 ```
 
 **Example (Infrastructure change):**
 ```markdown
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-We're excited to announce that the OpenTelemetry collector installation files can now be downloaded from a CDN for Chef, Puppet, and Ansible. This change improves download reliability, performance, and availability while maintaining the same installation experience.
+OpenTelemetry collector installation files can now be downloaded from a CDN for Chef, Puppet, and Ansible. This change improves download reliability, performance, and availability while maintaining the same installation experience.
 
 Refer to the following documentation to view the updated URLs in the UI.
 * [Ansible](/docs/send-data/opentelemetry-collector/install-collector/ansible/).

--- a/.claude/commands/release-note-cse.md
+++ b/.claude/commands/release-note-cse.md
@@ -177,7 +177,7 @@ Additional changes are enumerated below.
 
 **Application Release Guidelines:**
 * Use H3 (`###`) for each feature.
-* Start with clear, concise description.
+* Open with a direct statement of what the feature does — not an announcement phrase ("We're excited to announce", "We're happy to introduce"). Example: "Field X now supports Y." or "Feature Z is now available."
 * Include "Learn more" link to relevant docs.
 * Keep it brief (2-3 sentences per feature).
 * Add screenshots using: `<img src={useBaseUrl('img/path')} alt="description" />`

--- a/.claude/commands/release-note-csoar.md
+++ b/.claude/commands/release-note-csoar.md
@@ -253,6 +253,8 @@ Fixed an issue where [description of bug and fix].
 
 ### Step 7: Content formatting guidelines
 
+Open with a direct statement of what the release contains. Do not use excitement or announcement phrases ("We're excited to introduce", "We're happy to announce", "We've added"). State what changed factually.
+
 ## Content Release Formatting
 
 #### Intro Paragraph

--- a/.claude/commands/release-note-developer.md
+++ b/.claude/commands/release-note-developer.md
@@ -156,6 +156,8 @@ hide_table_of_contents: true
 
 ### Step 6: Content formatting guidelines
 
+Open with a direct statement of what changed. Do not use announcement or excitement phrases ("We're excited to announce", "We've released", "We've made improvements to"). State the change factually: "[Feature] is now available." or "[Feature] now supports [X]."
+
 #### API Changes
 
 For API announcements, include:
@@ -172,7 +174,7 @@ image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-cente
 hide_table_of_contents: true
 ---
 
-We're excited to announce new API endpoints for managing Field Extraction Rules (FERs) programmatically. These endpoints enable you to create, update, delete, and list FERs via the REST API, making it easier to automate and scale your field extraction configurations.
+New API endpoints for managing Field Extraction Rules (FERs) are now available. These endpoints enable you to create, update, delete, and list FERs via the REST API, making it easier to automate and scale your field extraction configurations.
 
 #### New endpoints
 
@@ -203,7 +205,7 @@ keywords:
   - python
 ---
 
-We've released version 2.0 of the Sumo Logic Python SDK with support for the latest APIs and improved error handling.
+Sumo Logic Python SDK version 2.0 is now available, with support for the latest APIs and improved error handling.
 
 #### What's new
 
@@ -286,7 +288,7 @@ image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-cente
 hide_table_of_contents: true
 ---
 
-We've made the following improvements to our APIs:
+The following API improvements are now available:
 
 * **Audit logging**: When performing create, update, and delete requests through Sumo Logic APIs, the API accessID is now included within the operator field of your related [Audit Event Index](/docs/manage/security/audit-indexes/audit-event-index) messages.
 * **Search Job API**: Now returns query execution statistics in response headers for better monitoring and debugging.

--- a/.claude/commands/release-note-service.md
+++ b/.claude/commands/release-note-service.md
@@ -197,7 +197,11 @@ This enhancement streamlines your workflow by providing quick access to frequent
 ### Step 6: Content formatting guidelines
 
 **Write for clarity:**
-* Start with a clear statement of what the feature is
+* Open with a direct statement of what the feature is — never an announcement phrase ("We're excited to introduce", "We're happy to announce")
+  * ❌ "We're excited to announce that multi-child-org search results now include an `_orgName` field..."
+  * ✅ "Multi-child-org search results now include an `_orgName` field alongside `_orgId`, so MSSP users can identify which child org a result came from."
+  * ❌ "We are excited to announce the addition of a native Sumo Logic HTTP Source webhook integration for LiteLLM."
+  * ✅ "A native Sumo Logic HTTP Source webhook integration for LiteLLM is now available, enabling you to collect LiteLLM usage and proxy log data."
 * Explain the benefit or business value in 2-3 sentences
 * Use "What's new:" section for bulleted specifics (optional)
 * End with a "Learn more" link to relevant docs
@@ -443,6 +447,8 @@ Would you like me to help refine the content or add additional details?
 ## Tips and best practices
 
 **For all Service releases:**
+* Open with a direct statement of what changed: "[Feature] is now available." or "[Feature] now supports [X]."
+* Do not open with announcement phrases: "We're excited to introduce", "We're happy to announce", and similar
 * Lead with user benefit, not technical implementation
 * Explain "what" and "why", not "how"
 * Keep descriptions concise (2-3 sentences)

--- a/.claude/skills/sumo-style/SKILL.md
+++ b/.claude/skills/sumo-style/SKILL.md
@@ -219,3 +219,4 @@ These are Sumo Logic- and repo-specific facts that override general assumptions.
 - **Numbered list items always use `1.`** (not `1.`, `2.`, `3.`). Docusaurus handles rendering.
 - **Capitalized product terms.** Collector, Source, Hosted Collector, Library. User-created objects (dashboards, folders) are lowercase.
 - **C2C sources and apps have distinct openers.** Do not use the app opener for a source doc or vice versa.
+- **No marketing openers in release notes.** Do not open with "We're excited to introduce/announce", "We're happy to announce", "We're thrilled to share", or similar phrases. Use a direct statement instead: "[Feature] is now available." or "[Feature] now supports [X]." Example — ❌ "We're excited to announce that multi-child-org search results now include an `_orgName` field..." → ✅ "Multi-child-org search results now include an `_orgName` field..."

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -992,6 +992,16 @@ Release notes (our changelog) publish to both the [docs site](/docs/release-note
 
 For lengthy release notes, write a 1-2 paragraph introduction, then add a truncate line (`<!--truncate-->`), followed by the full set of release notes.
 
+**Release note language**
+
+Open with a direct statement of what changed. Do not use excitement or announcement phrases.
+
+| &#9989; **Do** | &#10060; **Don't** |
+|:---------------|:-------------------|
+| "Multi-child-org search results now include an `_orgName` field alongside `_orgId`, so MSSP users can identify which child org a result came from." | "We're excited to announce that multi-child-org search results now include an `_orgName` field..." |
+| "A native Sumo Logic HTTP Source webhook integration for LiteLLM is now available, enabling you to collect LiteLLM usage and proxy log data." | "We are excited to announce the addition of a native Sumo Logic HTTP Source webhook integration for LiteLLM." |
+| "This release includes security and stability fixes." | "We've enhanced the security and stability of the Collector." |
+
 ## Reusing content
 
 When the same passage appears in more than one doc, put it once in the [`/docs/reuse`](https://github.com/SumoLogic/sumologic-documentation/tree/main/docs/reuse) folder and import it where you need it. Add the import at the top of the file, then place the component where the content should appear:


### PR DESCRIPTION
## Purpose of this pull request

Removes marketing/excitement language ("We're excited to introduce", "We are excited to announce") from release note templates and style guidance, replacing it with direct factual statements. Updates the style guide, sumo-style skill, and all five release note Claude command files.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-988