### PR TITLE
SUMO-293148 - Fix missing -o flag in OTel collector curl download commands

### DIFF
--- a/docs/send-data/opentelemetry-collector/install-collector/linux.md
+++ b/docs/send-data/opentelemetry-collector/install-collector/linux.md
@@ -68,7 +68,7 @@ You can run the script in two ways:
    ```
 * By first downloading the script, inspecting its contents for security, and then running it:
    ```bash
-   sudo curl -sL https://download-otel.sumologic.com/latest/download/install.sh
+   sudo curl -sLo install-otelcol-sumo.sh https://download-otel.sumologic.com/latest/download/install.sh
    sudo -E bash ./install-otelcol-sumo.sh
    ```
 

--- a/docs/send-data/opentelemetry-collector/install-collector/macos.md
+++ b/docs/send-data/opentelemetry-collector/install-collector/macos.md
@@ -68,7 +68,7 @@ You can run the script in two ways:
    ```
 * Or by first downloading the script, inspecting its contents for security, and then running it:
    ```bash
-   sudo curl -sL https://download-otel.sumologic.com/latest/download/install.sh
+   sudo curl -sLo install-otelcol-sumo.sh https://download-otel.sumologic.com/latest/download/install.sh
    sudo -E bash ./install-otelcol-sumo.sh -d
    ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request restores the missing `-o install-otelcol-sumo.sh` flag in the curl commands for the "download first, then inspect" OTel collector installation method on Linux and macOS. The flag was accidentally dropped in PR #5812 during the CDN URL migration from GitHub to `download-otel.sumologic.com`. Without `-o`, curl dumps the install script contents to stdout instead of saving it to a file, which breaks the installation workflow.

Reported in [Slack (#sumo-collectors)](https://sumologic.slack.com/archives/C02DUQT0A/p1788387302890999).

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

SUMO-293148