### PR TITLE
DOCS-1868 - Add plain-tone rules for docs and human-facing comments

### DIFF
--- a/.claude/skills/sumo-style/SKILL.md
+++ b/.claude/skills/sumo-style/SKILL.md
@@ -209,6 +209,7 @@ Fetch the full list at https://www.sumologic.com/help/docs/contributing/word-lis
 These are Sumo Logic- and repo-specific facts that override general assumptions.
 
 - **No em dashes, ever.** Do not use "--" as a substitution for an em dash either. Rewrite the sentence instead.
+- **Concise, human phrasing.** No throat-clearing preambles ("It's worth noting", "In this section we will"), no filler ("simply", "just", "of course"), no sentences that restate what was just said. See the "Concise, human phrasing" section of the live style guide.
 - **Site URL is `sumologic.com/help`**, not `help.sumologic.com`. Always use the former in docs and links.
 - **`:::training` is a custom Sumo Logic admonition** (purple, graduation cap icon). It is not a standard Docusaurus admonition -- do not treat it like one or omit it.
 - **`:::sumo` is also custom.** Standard Docusaurus will not recognize it outside this repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,16 @@ When reviewing any PR or doc, always check existing docs of the same type in the
 
 Some directories have conventions that differ significantly from standard docs. For example, `docs/platform-services/automation-service/app-central/integrations/` intentionally uses `description: ''`, omits `id`, opens with a logo image, and includes a `***Version / Updated***` block — all correct for that directory. When in doubt, read two or three neighboring files before forming an opinion.
 
+## Output tone (docs and messages to people)
+
+This section governs only the prose Claude produces for people to read: published documentation (all of `/docs`), and comments or messages Claude posts through a connector (GitHub PR and issue comments, Jira and Asana comments, Slack messages). Everything else in the repo keeps its existing conventions and is out of scope, for example build and CI config, `.github/` workflows, `AGENTS.md`, `CLAUDE.md`, `.claude/`, source code, and commit messages.
+
+- **No em dashes.** Rewrite with a period, semicolon, colon, commas, or parentheses. A fixed attribution marker appended by tooling is the one exception.
+- **Be concise.** Lead with the point. No throat-clearing preambles, no filler ("simply", "just", "of course", "it's worth noting"), no sentences that restate what was just said.
+- **Plain language.** Short sentences, one idea each. When two phrasings say the same thing, use the shorter one.
+
+For docs, the full editorial rules live in [the style guide](https://www.sumologic.com/help/docs/contributing/style-guide) and are applied by the `sumo-style` skill. This section restates the essentials and extends them to human-facing comments, where that skill does not load.
+
 ## Bulk Changes
 For any change touching 50+ files (e.g. terminology migrations, frontmatter audits, link updates, admonition format changes), follow these rules:
 

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -64,6 +64,16 @@ Helpful blogs on tech writing:
 * **Error messaging**. When explaining a process or procedure, clarity is critical. Edit words that distract or confuse. Put yourself into the reader's shoes and think about what actions you recommend to them when an error message is displayed, rather than merely stating what went wrong. Example: "Could not create the user." vs "This email is already registered in the system. Use a different email, or contact Sumo Logic for assistance."
 * **Humor**. We have a sense of humor! Conveying that we do serious work, but we do not take ourselves too seriously, makes Sumo Logic feel likable.
 
+### Concise, human phrasing
+
+Write the way a knowledgeable colleague would explain something in person. Cut anything that does not carry information. This also keeps our docs from reading like generic AI output.
+
+* **No throat-clearing.** Start with the point. Drop preambles like "It's worth noting that", "It's important to understand", and "In this section, we will".
+* **No filler.** Cut "simply", "just", "of course", "as you can see", "needless to say", and intensifiers like "very", "really", and "quite".
+* **Do not restate.** Skip summary sentences that repeat what the paragraph, list, or procedure just said.
+* **One idea per sentence.** Prefer short sentences over long ones stitched together with "and", "which", or semicolons.
+* **Say it once.** When two sentences make the same point, keep the clearer one and delete the other.
+
 ### Active voice
 
 When writing instructions, use the active voice whenever possible. This example below gives a call to action for the reader or user to effectively get something done. It also reduces word count and keeps instructions clear.
@@ -964,6 +974,14 @@ Colons are used to introduce lists or to separate titles from subtitles. Only in
 ### Commas
 
 We use the Oxford (serial) comma. For example, use "I had eggs, toast, and orange juice", not "[I had eggs, toast and orange juice](https://www.verbicidemagazine.com/wp-content/uploads/2012/01/why-i-still-use-the-oxford-comma.jpg)".
+
+### Dashes
+
+Do not use em dashes (the long dash). They read as generic AI output, and we keep them out of every doc. Rewrite instead: use a period or semicolon to split two independent clauses, a colon to introduce something, or commas or parentheses for a brief aside.
+
+Use the en dash (–) only for numeric and date ranges, with no space on either side: `9–17`, `2023–2024`. See [Numbers](#numbers) and [Dates](#dates).
+
+Use the hyphen (-) for compound modifiers, such as `drop-down menu` or `read-only field`.
 
 ### Exclamation points
 


### PR DESCRIPTION
## Purpose of this pull request

Adds a plain-tone standard so Claude's output reads less like generic AI: no em dashes, no throat-clearing or filler, concise phrasing. It applies to two things: published documentation (all of `/docs`), and comments or messages Claude posts to people through a connector (GitHub, Jira, Asana, Slack). Repo infrastructure (`.github/`, `AGENTS.md`, `.claude/`, source code, commit messages) stays out of scope.

- **`docs/contributing/style-guide.md`**: new **Concise, human phrasing** subsection under Voice and tone, and a **Dashes** subsection under Punctuation that bans the em dash while keeping the en dash for numeric and date ranges.
- **`.claude/skills/sumo-style/SKILL.md`**: mirrors the concision rule in Gotchas (the em dash ban was already there).
- **`AGENTS.md`**: new **Output tone** section, so the rules also govern connector comments, where the `sumo-style` skill does not load.

A follow-up option, not in this PR: a PreToolUse hook could hard-enforce the em dash ban on `Edit` and `Write` to `docs/**` and on comment-posting commands. Verbosity stays a soft rule.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)
