### PR TITLE
DOCS-1870 - Remove 15-day retention options from Metrics Transformation Rules

### DIFF
--- a/blog-service/2026-09-08-manage.md
+++ b/blog-service/2026-09-08-manage.md
@@ -1,0 +1,18 @@
+---
+title: 15-Day Retention Options Removed From Metrics Transformation Rules (Manage)
+image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-center_82_none/SumoLogic_Preview_600x600.jpg?mtime=1617040082
+keywords:
+  - metrics transformation rules
+  - retention
+  - metrics
+hide_table_of_contents: true
+---
+
+The 15-day retention and 15-day aggregate retention options have been removed from Metrics Transformation Rules. Retention for matching metrics is now **Do Not Store** or **400 days**, and aggregate retention for aggregated metrics is now **400 days**.
+
+**What's new:**
+* The **Retention** field for a metrics transformation rule now offers **Do Not Store** or **400 days**
+* The **Aggregate Retention** field for aggregated metrics is now always **400 days**
+* Existing rules configured with 15-day retention or 15-day aggregate retention are no longer supported
+
+[Learn more](/docs/metrics/metrics-transformation-rules/).

--- a/blog-service/2026-09-08-manage.md
+++ b/blog-service/2026-09-08-manage.md
@@ -1,5 +1,5 @@
 ---
-title: 15-Day Retention Options Removed From Metrics Transformation Rules (Manage)
+title: Updated Retention Options for Metrics Transformation Rules (Manage)
 image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-center_82_none/SumoLogic_Preview_600x600.jpg?mtime=1617040082
 keywords:
   - metrics transformation rules
@@ -8,11 +8,6 @@ keywords:
 hide_table_of_contents: true
 ---
 
-The 15-day retention and 15-day aggregate retention options have been removed from Metrics Transformation Rules. Retention for matching metrics is now **Do Not Store** or **400 days**, and aggregate retention for aggregated metrics is now **400 days**.
-
-**What's new:**
-* The **Retention** field for a metrics transformation rule now offers **Do Not Store** or **400 days**
-* The **Aggregate Retention** field for aggregated metrics is now always **400 days**
-* Existing rules configured with 15-day retention or 15-day aggregate retention are no longer supported
+We're excited to announce updated retention options for Metrics Transformation Rules. Retention for matching metrics is now **Do Not Store** or **400 days**, and aggregate retention for aggregated metrics is now standardized to **400 days**.
 
 [Learn more](/docs/metrics/metrics-transformation-rules/).

--- a/docs/metrics/metrics-transformation-rules.md
+++ b/docs/metrics/metrics-transformation-rules.md
@@ -11,16 +11,15 @@ Metrics transformation rules allow you control how long raw metrics are retained
 
 Metrics transformation rules are useful when:
 
-* You want to store highly ephemeral, high cardinality data for only 15 days, and to aggregate the metrics into business-level KPIs for long term storage and trending.
-* You want to store metrics from development and test environments for only 15 days, because after that you have no interest in them. 
+* You want to aggregate highly ephemeral, high cardinality data into business-level KPIs for long term storage and trending, and discard the raw metrics once they're aggregated.
 * You want to pre-aggregate raw metrics to improve query performance, and not retain raw metrics at all.
 
 ## Key facts
 
 * A metrics transformation rule applies to metrics that match a selector that you define for the rule. You can check what metrics will be affected by entering the selector in a metric query tab.  
-* You can reduce the amount of time that Sumo Logic will retain metrics that match the rule selector. By default, Sumo Logic saves your metrics for 400 days. In a transformation rule, you can set the retention period for metrics that match the selector to 15 days.   
+* By default, Sumo Logic saves your metrics for 400 days. If you aggregate the metrics that match the rule selector, you can also choose to discard the raw metrics entirely by setting their retention to **Do Not Store**.
 * Optionally, you aggregate the metrics that match the selector by one or more dimensions. If you choose to aggregate the metrics:
-   * You can specify a retention time of either 15 or 400 days for aggregated metrics.
+   * Aggregated metrics are retained for 400 days.
    * You can reduce the retention time for the raw (non-aggregated) metrics to zero. In this case, Sumo Logic will aggregate the metrics, and discard the raw metrics.
    * You can transform one or more dimensions of the aggregated metrics using mustache templates. For instance, you can transform the metric dimension to include a suffix that indicates that the metric is aggregated. This makes it easier to distinguish between raw and aggregated metrics.
 
@@ -41,13 +40,10 @@ Metrics transformation rules are useful when:
 1. **Selector.** The selector that matches the metrics to which you
     want to apply the transformation rule. (The scope of a metric query.)
 1. **Retention**. The period of time you want to retain the metrics that match the selector. Available options are:
-    * **Do Not Store**. This option does not not appear until and unless you specify one or more aggregation dimensions in the **Aggregate on** section below. (This is to ensure that your raw metrics are not deleted if they haven’t been aggregated.)
+    * **Do Not Store**. This option does not appear until and unless you specify one or more aggregation dimensions in the **Aggregate on** section below. (This is to ensure that your raw metrics are not deleted if they haven’t been aggregated.)
     * **400 days**
-    * **15 days**
 1. **Aggregate On**. (Optional) If you would like to aggregate the raw metrics by one or more dimensions, click **+Add** and enter the dimension name. Upon ingestion, Sumo Logic will [quantize](/docs/metrics/introduction/metric-quantization/) the aggregated metrics to one minute and one hour resolutions for all rollup types: avg, min, max, sum, and count.  You can aggregate raw metrics on a maximum of 10 dimensions
-1. **Aggregate Retention**. (Required if you entered an aggregation dimension). The retention period for the aggregated metrics. Available options are:
-    * **400 Days**
-    * **15 Days**
+1. **Aggregate Retention**. (Required if you entered an aggregation dimension). The retention period for the aggregated metrics is **400 days**.
 1. **Transformations**. (Optional) If you want to add a new dimension, or transform a dimension of the aggregated metrics, click **+Add**:
     * **Dimension to replace or add**. Enter the dimension you want to transform, for example:   `metric`
     * **Value**. Enter a new name for the dimension, or use a mustache template to form the new dimension name, for example: `{{metric}}_agg_by_service`. If the metric dimension for an aggregated metric was `container_memory_usage_byte`, the mustache template above would transform the metric dimension to: `container_memory_usage_byte_agg_by_svc`
@@ -74,17 +70,19 @@ Metrics transformation rules are useful when:
 
 ## Metrics transformation rule examples
 
-### Change metrics retention to 15 days
+### Discard metrics from development and test environments
 
-Assume that the metrics you collect from your dev environment are only
-of interest for a week after collection. You tag metrics from the dev
+Assume that the metrics you collect from your dev environment are of
+no interest once they've been aggregated. You tag metrics from the dev
 environment with a dimension whose key is “environment” and value is
 “dev”. When you configure your rule:
 
 1. Selector. Enter: `environment=dev`
-1. Retention. Select ` days` from the pull-down list.
+1. Aggregate On. Add the dimensions you want to aggregate by, for example, `environment`.
+1. Retention. Select **Do Not Store**.
+1. Aggregate Retention. **400 days** (the only available option).
 
-All metrics that match the selector `environment=dev` will be stored for 15 days, and then removed. They will not be aggregated, as aggregation is optional. In this case, we are simply using the transformation rule to control how long we want to retain the metrics. By default, Sumo Logic stores metrics for 400 days. A rule like this lets you reduce the metric retention period to 15 days.  
+All metrics that match the selector `environment=dev` are aggregated and the raw metrics are discarded, so you keep the aggregated trend data without paying to store 400 days of raw dev-environment metrics you have no interest in.
 
 ### Aggregate high cardinality and ephemeral data for long term trending
 
@@ -101,7 +99,7 @@ Here’s what the rule does:
     metric=container_fs_bytes service=foo container=1234 pod=abcd
     metric=container_fs_bytes service=foo container=4321 pod=dcba
     ```
-1. The matching metrics shown above will be retained for 15 days, then discarded.
+1. The matching metrics shown above are set to **Do Not Store**, so the raw metrics are discarded once they're aggregated.
 1. Matching metrics will be aggregating by the `metric` and `service` dimensions. The aggregated metrics are quantized to one minute and one hour resolutions for all rollup types: avg, min, max, sum, and count.
 1. The aggregated metrics shown above will be retained for 400 days, then discarded. Only the dimensions upon which the raw metrics were aggregated are preserved in the aggregated metrics. The `container` and `pod` dimensions are not included in the aggregated metrics.
 1. The aggregated metrics will have the value of the metric dimension modified to have a suffix of `_agg`, like this:  


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the 15-day retention and 15-day aggregate retention options from Metrics Transformation Rules, since they're no longer available in the product. The available options are now:

- **Retention**: Do Not Store, 400 days
- **Aggregate Retention**: 400 days

Updated the intro use-case bullets, the "Key facts" section, the **Retention** and **Aggregate Retention** steps, and both walkthrough examples in `docs/metrics/metrics-transformation-rules.md` to match. The first example, previously "Change metrics retention to 15 days," is renamed to "Discard metrics from development and test environments" and now demonstrates the **Do Not Store** option instead.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1870