### PR TITLE
DOCS-1871 - Add missing TI C2C sources

### DIFF
--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -3028,7 +3028,7 @@
   "/cid/1154": "/docs/send-data/hosted-collectors/krutrim-object-storage",
   "/cid/1159": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/openai-source",
   "/cid/1158": "/docs/send-data/opentelemetry-collector/data-source-configurations/windows-active-directory-inventory",
-  "/cid/1161": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source/",
+  "/cid/1161": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source",
   "/release-notes-collector/2026/04/11/hosted/": "/release-notes-collector/2026/05/11/hosted/",
   "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/armis-api-source": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/armis-source",
   "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/confluent-cloud-metrics-source/": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/confluent-metrics-source/",

--- a/cid-redirects.json
+++ b/cid-redirects.json
@@ -3028,6 +3028,7 @@
   "/cid/1154": "/docs/send-data/hosted-collectors/krutrim-object-storage",
   "/cid/1159": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/openai-source",
   "/cid/1158": "/docs/send-data/opentelemetry-collector/data-source-configurations/windows-active-directory-inventory",
+  "/cid/1161": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source/",
   "/release-notes-collector/2026/04/11/hosted/": "/release-notes-collector/2026/05/11/hosted/",
   "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/armis-api-source": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/armis-source",
   "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/confluent-cloud-metrics-source/": "/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/confluent-metrics-source/",

--- a/docs/security/threat-intelligence/about-threat-intelligence.md
+++ b/docs/security/threat-intelligence/about-threat-intelligence.md
@@ -68,16 +68,22 @@ Sumo Logic provides the following out-of-the-box default sources of threat indic
 A Cloud SIEM administrator must first ingest the indicators before they can be used to uncover threats. Indicators can be ingested using one of the following methods:
 * **Add Source**. This flow lets you select from available threat intelligence sources given below, choose a collector, and complete configuration in a streamlined workflow.
    * [CrowdStrike Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-threat-intel-source)
-   * CISA TAXII Client
-   * Dragos TAXII Client
    * [Google Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-threat-intel-source/)
    * [Intel471 Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/intel471-threat-intel-source)
    * [Mandiant Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mandiant-threat-intel-source)
-   * Nozomi TAXII Client
-   * Recorded Future TAXII Client
    * [STIX/TAXII 1 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source)  
-   * [STIX/TAXII 2 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source)
-   * Unit42 TAXII Client
+   * [STIX/TAXII 2 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source)<br/>
+      :::info
+      Sumo Logic provides the following vendor-specific sources, built on the underlying code of the STIX/TAXII 2 Client Source, to simplify setup:
+      * CISA TAXII Client
+      * Dragos TAXII Client
+      * Nozomi TAXII Client
+      * Recorded Future TAXII Client
+      * SOCRadar TAXII Client
+      * Unit42 TAXII Client<br/>
+      
+      [Learn more](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source/#taxii-2-sources)
+      :::
    * [ZeroFox Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/zerofox-intel-source)
 * **Upload**. Manually upload files that add threat intelligence indicators. See [Add indicators in Threat Intelligence](/docs/security/threat-intelligence/threat-intelligence-indicators/#upload). See [Upload formats](/docs/security/threat-intelligence/upload-formats/) for the format to use when uploading indicators using this option or APIs.
 * **The API**. See the following APIs in the [Threat Intel Ingest Management](https://api.sumologic.com/docs/#tag/threatIntelIngest) API resource:

--- a/docs/security/threat-intelligence/about-threat-intelligence.md
+++ b/docs/security/threat-intelligence/about-threat-intelligence.md
@@ -68,11 +68,16 @@ Sumo Logic provides the following out-of-the-box default sources of threat indic
 A Cloud SIEM administrator must first ingest the indicators before they can be used to uncover threats. Indicators can be ingested using one of the following methods:
 * **Add Source**. This flow lets you select from available threat intelligence sources given below, choose a collector, and complete configuration in a streamlined workflow.
    * [CrowdStrike Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/crowdstrike-threat-intel-source)
+   * CISA TAXII Client
+   * Dragos TAXII Client
    * [Google Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/google-threat-intel-source/)
    * [Intel471 Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/intel471-threat-intel-source)
    * [Mandiant Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mandiant-threat-intel-source)
+   * Nozomi TAXII Client
+   * Recorded Future TAXII Client
    * [STIX/TAXII 1 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source)  
    * [STIX/TAXII 2 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source)
+   * Unit42 TAXII Client
    * [ZeroFox Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/zerofox-intel-source)
 * **Upload**. Manually upload files that add threat intelligence indicators. See [Add indicators in Threat Intelligence](/docs/security/threat-intelligence/threat-intelligence-indicators/#upload). See [Upload formats](/docs/security/threat-intelligence/upload-formats/) for the format to use when uploading indicators using this option or APIs.
 * **The API**. See the following APIs in the [Threat Intel Ingest Management](https://api.sumologic.com/docs/#tag/threatIntelIngest) API resource:

--- a/docs/security/threat-intelligence/about-threat-intelligence.md
+++ b/docs/security/threat-intelligence/about-threat-intelligence.md
@@ -79,7 +79,6 @@ A Cloud SIEM administrator must first ingest the indicators before they can be u
       * Dragos TAXII Client
       * Nozomi TAXII Client
       * Recorded Future TAXII Client
-      * SOCRadar TAXII Client
       * Unit42 TAXII Client<br/>
       
       [Learn more](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source/#taxii-2-sources)

--- a/docs/security/threat-intelligence/about-threat-intelligence.md
+++ b/docs/security/threat-intelligence/about-threat-intelligence.md
@@ -72,14 +72,14 @@ A Cloud SIEM administrator must first ingest the indicators before they can be u
    * [Intel471 Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/intel471-threat-intel-source)
    * [Mandiant Threat Intel Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/mandiant-threat-intel-source)
    * [STIX/TAXII 1 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-1-client-source)  
-   * [STIX/TAXII 2 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source)<br/>
+   * [STIX/TAXII 2 Client Source](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source)
       :::info
-      Sumo Logic provides the following vendor-specific sources, built on the underlying code of the STIX/TAXII 2 Client Source, to simplify setup:
+      Sumo Logic provides the following vendor-specific sources, based on the STIX/TAXII 2 Client Source, to simplify setup:
       * CISA TAXII Client
       * Dragos TAXII Client
       * Nozomi TAXII Client
       * Recorded Future TAXII Client
-      * Unit42 TAXII Client<br/>
+      * Unit42 TAXII Client
       
       [Learn more](/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source/#taxii-2-sources)
       :::

--- a/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source.md
+++ b/docs/send-data/hosted-collectors/cloud-to-cloud-integration-framework/stix-taxii-2-client-source.md
@@ -77,7 +77,6 @@ Sumo Logic provides the following sources based on the underlying code of our ST
 * Dragos TAXII Client
 * Nozomi TAXII Client
 * Recorded Future TAXII Client
-* SOCRadar TAXII Client
 * Unit42 TAXII Client
 
 When you set up a source, search for "taxii" and select the tile for the source you want to install:<br/><img src={useBaseUrl('img/security/taxii-sources.png')} alt="TAXII sources" style={{border: '1px solid gray'}} width="800" />


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the missing Threat Intel Cloud-to-Cloud sources (CISA, Dragos, Nozomi, Recorded Future, SOCRadar, and Unit42 TAXII clients) to the About Threat Intelligence source list, nested under the STIX/TAXII 2 Client Source as vendor-specific variants, and adds the corresponding CID redirect.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1871