### PR TITLE
DOCS-1880 - Qualify Sumo Logic SDK references in AWSO Terraform docs and developer release notes

### DIFF
--- a/.claude/commands/jira.md
+++ b/.claude/commands/jira.md
@@ -73,6 +73,7 @@ Use these keywords and file path patterns to suggest the most relevant Technical
 **Keywords in content/descriptions:**
 
 - **Alerts**: monitor, alert, scheduled search, webhook, notification
+<!-- awaiting SME guidance --> 
 - **APIs**: API, endpoint, REST, SDK, authentication, token
 - **APM**: trace, span, RUM, real user monitoring, application performance
 - **Apps/Integrations**: app, integration, connector, third-party

--- a/.claude/commands/release-note-developer.md
+++ b/.claude/commands/release-note-developer.md
@@ -190,35 +190,7 @@ For SDK releases:
 * Version number
 * What's new or changed
 * Installation instructions
-* Link to SDK docs or GitHub
-
-**Example:**
-```markdown
----
-title: March 23, 2026 - Python SDK Version 2.0
-image: https://assets-www.sumologic.com/company-logos/_800x418_crop_center-center_82_none/SumoLogic_Preview_600x600.jpg?mtime=1617040082
-hide_table_of_contents: true
-keywords:
-  - sdk
-  - python
----
-
-We've released version 2.0 of the Sumo Logic Python SDK with support for the latest APIs and improved error handling.
-
-#### What's new
-
-* Support for Field Extraction Rules API
-* Async client support for better performance
-* Improved error messages and debugging
-
-#### Installation
-
-```python
-pip install sumologic-sdk==2.0.0
-```
-
-Learn more in the [Python SDK documentation](/docs/api/python-client).
-```
+* Link to the SDK's own GitHub releases or changelog
 
 #### Deprecations
 

--- a/.claude/commands/release-note-developer.md
+++ b/.claude/commands/release-note-developer.md
@@ -2,6 +2,8 @@
 
 Automates the creation of Developer release notes for APIs, SDKs, integrations, and platform changes relevant to developers.
 
+<!-- awaiting SME guidance --> 
+
 ## What this command does
 
 When you invoke `release-note-developer`, Claude will guide you through:

--- a/docs/api/about-apis/terraform-with-sumo-logic.md
+++ b/docs/api/about-apis/terraform-with-sumo-logic.md
@@ -143,7 +143,7 @@ You can use Terraform data sources to retrieve Sumo Logic data from your Terrafo
 To use Terraform with Sumo Logic, you need the following:
 * A Sumo Logic [account](/docs/get-started/sign-up/)
 * A Sumo Logic [access key](/docs/manage/security/access-keys/)
-* [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) 
+* [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 
 ## Using Sumo Logic's AWS Terraform template
 
@@ -162,6 +162,9 @@ Perform the following steps to use the template:
      1. [Install Python](https://www.python.org/downloads/) (version 3.11 or later).
      1. [Install the latest version of the "jq" JSON parser](https://github.com/jqlang/jq/wiki/Installation), necessary to run the `.sh` batch files in the template.
      1. [Install the Sumo Logic Python SDK](https://pypi.org/project/sumologic-sdk/).
+
+<!-- awaiting SME guidance --> 
+
      1. [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 1. Next, navigate to the `sumologic-solution-templates` folder where you cloned the repository, and go to the `aws-observability-terraform` subdirectory. Set this directory to be the Terraform working directory by executing the following command: `terraform init`
 1. Using the solution template starts with [the main.auto.tfvars file](https://github.com/SumoLogic/sumologic-solution-templates/blob/master/aws-observability-terraform/main.auto.tfvars) which contains variable settings for your Sumo Logic organization, access ID and key, and other configuration information that will be referenced by the other template files. Open this file and fill in each field with the requested information.<br/><img src={useBaseUrl('img/api/tfvars-file.png')} alt="tfvars file" style={{border: '1px solid gray'}} width="800" /><br/>Check the [Sumo Logic API endpoints](/docs/api/about-apis/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security) if you need help finding the proper deployment value to use.
@@ -181,7 +184,7 @@ Perform the following steps to use the template:
      module "<ALIAS>" {
      source = "./source-module"
      providers = { aws = aws.<ALIAS> }
-     
+
      aws_account_alias = <var.aws_account_alias OR "account alias">
      sumologic_organization_id = var.sumologic_organization_id
      access_id    = var.sumologic_access_id
@@ -201,7 +204,7 @@ Perform the following steps to use the template:
 
 ## Understanding the Terraform format
 
-Terraform scripts are text files, typically with a `.tf` extension, that use names and values in a hierarchal format, defined by curly braces `{ }`. Terraform scripts can be edited with any text editor, and although they are intended to be run automatically by a computer system, the script elements are generally human-readable and not difficult to parse and understand. 
+Terraform scripts are text files, typically with a `.tf` extension, that use names and values in a hierarchal format, defined by curly braces `{ }`. Terraform scripts can be edited with any text editor, and although they are intended to be run automatically by a computer system, the script elements are generally human-readable and not difficult to parse and understand.
 
 Let's look at some examples:
 * [Terraform providers](#terraform-providers)
@@ -325,7 +328,7 @@ data "httpclient_request" "enable_audit_policy" {
  provider = http-client
  username = "${var.sumologic_access_id}"
  password = "${var.sumologic_access_key}"
- url = "${var.sumologic_deployment}v1/policies/audit" 
+ url = "${var.sumologic_deployment}v1/policies/audit"
  request_method = "PUT"
  request_headers = {
  Content-Type: "application/json",
@@ -339,7 +342,7 @@ data "httpclient_request" "enable_searchaudit_policy" {
  provider = http-client
  username = "${var.sumologic_access_id}"
  password = "${var.sumologic_access_key}"
- url = "${var.sumologic_deployment}v1/policies/searchAudit" 
+ url = "${var.sumologic_deployment}v1/policies/searchAudit"
  request_method = "PUT"
  request_headers = {
  Content-Type: "application/json",
@@ -356,7 +359,7 @@ After running Terraform, there is another file type you should be aware of. A *s
 
 The state file is used by Terraform to track the current infrastructure state in order to properly process updates or deletes. The state file should be kept safe and secure (since it may contain sensitive data such as access keys and secrets) and is not meant to be edited directly, even though it is a simple human-readable JSON text file. An example state file might look like the screenshot below:
 
-<img src={useBaseUrl('img/api/terraform-state-file.png')} alt="Terraform state file" style={{border: '1px solid gray'}} width="600" /> 
+<img src={useBaseUrl('img/api/terraform-state-file.png')} alt="Terraform state file" style={{border: '1px solid gray'}} width="600" />
 
 ## Additional resources
 

--- a/docs/observability/aws/deploy-use-aws-observability/deploy-with-terraform.md
+++ b/docs/observability/aws/deploy-use-aws-observability/deploy-with-terraform.md
@@ -82,6 +82,9 @@ Before you run the Terraform script, perform the following actions on a server m
     ```bash
     jq --version
     ```
+
+<!-- awaiting SME guidance -->
+    
 1. Install Sumo Logic Python SDK using the following command. Click [here](https://pypi.org/project/sumologic-sdk/) to learn more.
     ```bash
     pip install sumologic-sdk
@@ -697,7 +700,7 @@ collect_cloudwatch_metrics = "Kinesis Firehose Metrics Source"
 
 Provide details for the Sumo Logic CloudWatch Metrics source. If not provided, then defaults will be used.
 
-* `limit_to_namespaces`. Enter a comma-delimited list of the namespaces which will be used for both AWS CloudWatch Metrics Source. You can provide both AWS and custom namespaces. 
+* `limit_to_namespaces`. Enter a comma-delimited list of the namespaces which will be used for both AWS CloudWatch Metrics Source. You can provide both AWS and custom namespaces.
 
 Supported namespaces are based on the type of CloudWatch Metrics Source you have selected above. See [AWS Kinesis Firehose for Metrics Source](/docs/send-data/hosted-collectors/amazon-aws/aws-kinesis-firehose-metrics-source) and [Amazon CloudWatch Source for Metrics](/docs/send-data/hosted-collectors/amazon-aws/amazon-cloudwatch-source-metrics) for details on which namespaces they support.
 
@@ -724,7 +727,7 @@ Supported namespaces are based on the type of CloudWatch Metrics Source you have
    "AWS/NetworkELB",
    "AWS/SQS",
    "AWS/SNS"
- ], 
+ ],
  "tag_filters": [],
  "source_category": "aws/observability/cloudwatch/metrics",
  "source_name": "CloudWatch Metrics (Region)"
@@ -748,7 +751,7 @@ cloudwatch_metrics_source_details = {
    "AWS/DynamoDB",
    "AWS/Lambda",
    "CWAgent"
-  ], 
+  ],
  "tag_filters": [{
       "type":"TagFilters",
       "namespace" : "AWS/DynamoDB",
@@ -1293,7 +1296,7 @@ auto_enable_logs_subscription="New"
 ### auto_enable_logs_subscription_options
 
 * `filter`. Enter regex for matching logGroups for AWS Lambda only. The regex will check the name. See [Configuring parameters](/docs/send-data/collect-from-other-data-sources/autosubscribe-arn-destination/#configuringparameters).
-* `tags_filter`. Enter comma separated key value pairs for filtering logGroups using tags. Ex KeyName1=string,KeyName2=string. This is optional leave it blank if tag based filtering is not needed. See [Configuring parameters](/docs/send-data/collect-from-other-data-sources/autosubscribe-arn-destination/#configuringparameters). 
+* `tags_filter`. Enter comma separated key value pairs for filtering logGroups using tags. Ex KeyName1=string,KeyName2=string. This is optional leave it blank if tag based filtering is not needed. See [Configuring parameters](/docs/send-data/collect-from-other-data-sources/autosubscribe-arn-destination/#configuringparameters).
 
 **Default value:**
 
@@ -1569,13 +1572,13 @@ Refer to step 4 in this [section](/docs/observability/aws/deploy-use-aws-observa
 Error: waiting for S3 Bucket Policy (bucket-name) delete: found resource
 ```
 #### Solution
-Run `terraform destroy` again. 
+Run `terraform destroy` again.
 
 ### Field with the given id can't be deleted because it is in use
 #### Error Message
 `"errors":[{"code":"field:cant_be_deleted","message":"Field with the given id can't be deleted because it is in use","meta":{"reason":"Field is used in the Field Extraction Rule"}}]`
 #### Solution
-Run `terraform destroy` again. 
+Run `terraform destroy` again.
 
 
 ### Hierarchy named 'AWS Observability' already exists
@@ -1613,7 +1616,7 @@ Invalid IAM role OR AccessDenied
 ```
 #### Solution
 
-- Refer to [Edit, deactivate/activate, rotate, or delete access keys](/docs/manage/security/access-keys/#edit-deactivateactivate-rotate-or-delete-access-keys) for access keys activation. 
+- Refer to [Edit, deactivate/activate, rotate, or delete access keys](/docs/manage/security/access-keys/#edit-deactivateactivate-rotate-or-delete-access-keys) for access keys activation.
 - Refer to [Prerequisites](/docs/observability/aws/deploy-use-aws-observability/before-you-deploy/#prerequisites) for permissions related issues.
 
 

--- a/docs/send-data/collect-from-other-data-sources/sumo-logic-open-source-projects.md
+++ b/docs/send-data/collect-from-other-data-sources/sumo-logic-open-source-projects.md
@@ -87,4 +87,4 @@ The following open-source solutions are collected in Sumo Logic’s GitHub repos
 | [sumologic-python-sdk](https://github.com/SumoLogic/sumologic-python-sdk)| This solution is a Community-supported Python interface to the Sumo Logic REST API.|
 | [Sumotoolbox](https://github.com/voltaire321/sumologictoolbox)| This is a GUI utility for accessing the various Sumo Logic APIs (currently the search, content, and collector APIs.) The idea is to make it easier to perform common API tasks such as copying sources and generating CSV files from searches.|
 
- 
+<!-- awaiting SME guidance - add more info link to SDK line? --> 


### PR DESCRIPTION
## Purpose of this pull request

Cleans up references to the community [`sumologic-python-sdk`](https://github.com/SumoLogic/sumologic-python-sdk) (PyPI `sumologic-sdk`), which Sumo Logic's README says it doesn't officially support. There's an open question about whether the v2 API framework security update broke session cookie auth in the SDK — that's unconfirmed (nothing in the SDK's own issues or changelog backs it up) and is one of the things we're checking with sumoappdev, not a settled fact. Two places:

- **AWSO Terraform docs** tell customers to `pip install sumologic-sdk` as a setup prerequisite (`docs/api/about-apis/terraform-with-sumo-logic.md`, `docs/observability/aws/deploy-use-aws-observability/deploy-with-terraform.md`), so onboarding fails.
- **The developer release-note template** (`.claude/commands/release-note-developer.md`) has a `#### SDK Updates` section and SDK line items throughout — an AI-scaffolding artifact from the `.claude/` command build (DOCS-1475, #6488). No SDK release note has ever been published in `blog-developer/`.

Still pending SME/PM input (tracked on DOCS-1880): whether the AWSO Terraform workflow still needs `sumologic-sdk`, and whether SDK updates belong in our developer release notes at all.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [x] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1880
