### PR TITLE
DOCS-1883 - Fix inaccurate deploy build-time estimate

### DIFF
--- a/.claude/commands/review-deploy.md
+++ b/.claude/commands/review-deploy.md
@@ -24,7 +24,7 @@ For staging larger UX/UI or site-wide feature work, use `/stage-deploy` instead 
 - **URL**: `https://docs-review-sumo-logic.pantheonsite.io/help/`
 - **HTTP basic auth protected**: Contact the docs team for credentials.
 - **Single shared slot**: Only one PR can be in review at a time. Deploying overwrites the previous deployment.
-- **Build time**: 5–10 minutes after the push triggers the workflow.
+- **Build time**: 20–30 minutes after the push triggers the workflow.
 
 ## Workflow
 

--- a/.claude/commands/stage-deploy.md
+++ b/.claude/commands/stage-deploy.md
@@ -24,7 +24,7 @@ For quick, temporary article-level review, use `/review-deploy` instead — it t
 - **URL**: `https://helpdocs-sumo-logic.pantheonsite.io/help/`
 - **HTTP basic auth protected**: Contact the docs team for credentials.
 - **Single shared slot**: Only one PR can be staged at a time. Deploying overwrites the previous deployment.
-- **Build time**: 5–10 minutes after the push triggers the workflow.
+- **Build time**: 20–30 minutes after the push triggers the workflow.
 
 ## Workflow
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the build-time estimate in `/stage-deploy` and `/review-deploy` from 5-10 minutes to 20-30 minutes, matching actual GitHub Actions run history for both workflows.

## Select the type of change

- [ ] Minor Changes - Typos, formatting, slight revisions
- [ ] Update Content - Revisions, updating sections
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - .clabot, version updates, maintenance, dependencies, new packages for the site (Docusaurus, Gatsby, React, etc.)

## Ticket (if applicable)

https://sumologic.atlassian.net/browse/DOCS-1883

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Cbo11Jvu4ApW7cFV5usDZ